### PR TITLE
docs(openai-submission): readiness update post-#80/#81

### DIFF
--- a/docs/openai-submission/FINAL_REVIEW_READINESS_REPORT.md
+++ b/docs/openai-submission/FINAL_REVIEW_READINESS_REPORT.md
@@ -1,9 +1,37 @@
 # Final Review Readiness Report
 
-Date: 2026-04-29
+Date: 2026-04-29 (initial) · 2026-05-15 (controlled-errors wave + preset realignment)
 App: Holded Connector
 
-## What Was Tested
+## 🟢 2026-05-15 update — runtime/manifest aligned, only ChatGPT manual QA pending
+
+After the second wave of soporte testing (four cases returned `-32000 Internal MCP error` instead of controlled errors) and the discovery that production exposed a wider tool surface than the signed manifest (22 vs 14), the connector is now in a verified-aligned state:
+
+- ✅ Runtime exposes exactly the **14 tools** declared in `tool-hint-justifications.json` (`DEFAULT_PUBLIC_SCOPE_PRESET = openai_review_v2` in [apps/app/lib/oauth/mcp.ts:97](../../apps/app/lib/oauth/mcp.ts)).
+- ✅ Annotations on every runtime tool match the manifest (`readOnlyHint`, `destructiveHint`, `openWorldHint`).
+- ✅ The four soporte-reported regressions return controlled errors:
+  - `holded_get_invoice` / `holded_get_project` / `holded_list_project_tasks` with non-existent or malformed ids → `structuredContent.error = "not_found"`.
+  - `holded_create_invoice_draft` with `confirm: false` → `structuredContent.error = "confirmation_required"`.
+- ✅ 401 (revoked credential) and 403 (module not contracted in the Holded plan) are now separated; a 403 on a single tool no longer marks the whole integration as revoked.
+- ✅ Latency safeguards: `HOLDED_HISTORY_SCAN_BUDGET_MS` (7s default) limits the historical document scan, `holded_list_accounts` paginates by default (25/page) — both prevent the silent "ChatGPT cut the tool call" symptom soporte reported as "blocked by security".
+- ✅ All 10 public URLs return 200 (landing, docs, privacy, terms, dpa, demo, MCP endpoint, OAuth discovery, protected-resource metadata).
+- ✅ OAuth discovery JSON is well-formed with every field OpenAI looks for (issuer, authorization/token/registration endpoints, scopes, response_types, grant_types, S256).
+
+PRs merged for this wave:
+- [#80](https://github.com/kiabusiness2025/verifactu-monorepo/pull/80) — controlled errors + preset revert (deployed via Vercel 2026-05-15 18:57 UTC).
+- [#81](https://github.com/kiabusiness2025/verifactu-monorepo/pull/81) — CI infrastructure (pnpm version, jest ESM, prisma scope, build-admin path filter, Resend dummy env) — prerequisite for #80 to reach `main`.
+
+What's left before clicking Resubmit:
+
+1. **Manual ChatGPT web validation** of POS-01..POS-07B + NEG-01..NEG-06 (no automated substitute — OpenAI tests the actual ChatGPT flow).
+2. **Same manual run on ChatGPT mobile.** Mobile-specific rendering issues were the bulk of the 2026-05-04 rejection.
+3. (Optional) **Rotate the demo Holded API key** before/after the review.
+
+There are no remaining code, infra, or doc gaps identifiable from outside ChatGPT's UI.
+
+---
+
+## 2026-04-29 baseline — What Was Tested
 
 Local mocked contract and MCP/OAuth tests were executed:
 

--- a/docs/openai-submission/HOLDED_REVIEW_TEST_MATRIX.md
+++ b/docs/openai-submission/HOLDED_REVIEW_TEST_MATRIX.md
@@ -1,7 +1,74 @@
 # Holded Connector Review Test Matrix
 
-**Date:** 2026-04-29 (initial), 2026-05-04 (post-rejection update)
-**Status:** ⚠️ REJECTED on first OpenAI submission. Fixes applied 2026-05-04 — pending re-validation on ChatGPT web AND mobile before resubmission.
+**Date:** 2026-04-29 (initial), 2026-05-04 (post-rejection), 2026-05-15 (controlled-errors wave)
+**Status:** ⏳ READY FOR RESUBMISSION at API+infra level — only **manual ChatGPT web+mobile validation** is missing. Runtime/manifest aligned, all known rejection causes addressed.
+
+## 🟢 2026-05-15 — Controlled-errors wave + preset realignment
+
+After the second round of soporte testing surfaced a follow-up batch of failures that all surfaced to the reviewer as the generic JSON-RPC `Internal MCP error -32000` (R4 hardening redacts crude messages), three changes landed in production:
+
+### Runtime fixes (merged in [#80](https://github.com/kiabusiness2025/verifactu-monorepo/pull/80), deploy 2026-05-15 18:57 UTC)
+
+| Behaviour                                                                                                                  | Before                                                                                                | After                                                                                                                       |
+| -------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `holded_get_invoice` / `holded_get_project` / `holded_list_project_tasks` with a non-existent or malformed id              | `-32000 Internal MCP error. Reference: <uuid>`                                                        | `structuredContent.error = "not_found"` + readable message in `content[0].text`                                             |
+| `holded_create_invoice_draft` (and every other write tool) called with `confirm: false`                                    | `-32000 Internal MCP error.`                                                                          | `structuredContent.error = "confirmation_required"` + the existing instructional "Awaiting your confirmation..." text       |
+| Holded API returns 403 on an optional module (e.g. CRM/bookings if the plan does not include it)                           | The integration was marked `revoked` for the whole tenant and the user was told "Reconnect Holded"    | The single tool returns `structuredContent.error = "holded_module_forbidden"`; the rest of the connector keeps working      |
+| `holded_list_accounts` called with no `page`/`limit`                                                                       | Returned the entire chart of accounts (~206 entries) inside `structuredContent` (heavy payload)       | Paginated by default (`page: 1, limit: 25`)                                                                                 |
+| `holded_list_invoices` with `year`/`from`/`to` against a tenant with no matching documents                                 | Could hang the request for up to 12 sequential page scans; ChatGPT cut the tool call                  | Honours `HOLDED_HISTORY_SCAN_BUDGET_MS` (default 7000ms) and returns a partial response with `history.reachedEnd: false`    |
+
+### Preset realignment (also in [#80](https://github.com/kiabusiness2025/verifactu-monorepo/pull/80))
+
+`DEFAULT_PUBLIC_SCOPE_PRESET` reverted from `holded_full_read_v1` (22 tools, 2026-05-11 expansion) back to **`openai_review_v2`** — the preset the manifest is signed against. `tools/list` against `https://holded.verifactu.business/api/mcp/holded` now exposes the exact **14 tools** declared in `tool-hint-justifications.json`. Verified post-deploy:
+
+```
+PASS mcp.initialize — Holded Connector for ChatGPT v0.3.0
+PASS mcp.tools_list.public — 14 tools expuestas sin token
+Runtime: 14 tools | Manifest: 14 tools
+In runtime but not in manifest: (none)
+In manifest but not in runtime: (none)
+Annotation diffs: (none — all annotations match)
+```
+
+### Supporting CI fixes (merged in [#81](https://github.com/kiabusiness2025/verifactu-monorepo/pull/81), 2026-05-15 18:51 UTC)
+
+`pnpm/action-setup` version mismatch, `actions/upload-artifact@v3` deprecation, `apps/api` jest ESM transforms, `apps/holded-mcp` test endpoint count, prisma-generate scope, build-admin path filter, and Resend dummy env. None affect the connector runtime; all required for green CI on resubmission PRs.
+
+### Source-of-truth in production (verified 2026-05-15)
+
+| Surface                                                                              | Status        |
+| ------------------------------------------------------------------------------------ | ------------- |
+| `https://holded.verifactu.business/`                                                 | 200           |
+| `https://holded.verifactu.business/conectores/chatgpt`                               | 200           |
+| `https://holded.verifactu.business/conectores/chatgpt/docs`                          | 200           |
+| `https://holded.verifactu.business/conectores/chatgpt/privacy`                       | 200           |
+| `https://holded.verifactu.business/conectores/chatgpt/terms`                         | 200           |
+| `https://holded.verifactu.business/conectores/chatgpt/dpa`                           | 200           |
+| `https://holded.verifactu.business/conectores/chatgpt/openai-review-demo`            | 200           |
+| `https://holded.verifactu.business/api/mcp/holded` (GET descriptor + POST JSON-RPC)  | 200           |
+| `https://holded.verifactu.business/.well-known/oauth-authorization-server`           | 200, complete |
+| `https://holded.verifactu.business/.well-known/oauth-protected-resource/api/mcp/holded` | 200        |
+
+OAuth discovery includes `issuer`, `authorization_endpoint`, `token_endpoint`, `registration_endpoint`, `scopes_supported`, `response_types_supported`, `grant_types_supported`, `code_challenge_methods_supported` (S256).
+
+### What remains before resubmission
+
+Only **manual ChatGPT validation**:
+
+- [ ] All 7 positive cases (POS-01..POS-07B below) pass in ChatGPT **web** with the connector authorized to the demo tenant.
+- [ ] Same 7 cases pass in ChatGPT **mobile**.
+- [ ] All 6 negative cases (NEG-01..NEG-06) behave as expected on both surfaces.
+- [ ] Demo Holded API key rotated after final review.
+
+Reproduction script for the four soporte regressions (independent of ChatGPT):
+
+```
+MCP_BEARER_TOKEN=<oauth_or_pat> pnpm holded:chatgpt:smoke
+```
+
+The four cases now report `resultado controlado "not_found"` / `"confirmation_required"` instead of `JSON-RPC error -32000`.
+
+---
 
 ## 🔴 Outcome of the first submission (2026-04-29 → 2026-05-04 rejection)
 

--- a/docs/openai-submission/OPENAI_RESUBMISSION_CHECKLIST.md
+++ b/docs/openai-submission/OPENAI_RESUBMISSION_CHECKLIST.md
@@ -1,54 +1,71 @@
 # OpenAI Resubmission Checklist — Holded
 
+Last verified: **2026-05-15** (production = commit `34bf061a` on main, Vercel deploy 18:57 UTC).
+
 ## Page 1 — App listing
 
-- [ ] App name: Holded
-- [ ] Subtitle: Work with Holded data
-- [ ] Category: Business
-- [ ] Developer: verifactu.business
-- [ ] Website URL: https://holded.verifactu.business/
-- [ ] Support URL or email confirmed
-- [ ] Privacy URL confirmed
-- [ ] Terms URL confirmed
-- [ ] Demo recording URL confirmed
-- [ ] Commerce / purchases not enabled unless there is an actual checkout flow
+- [x] App name: Holded
+- [x] Subtitle: Work with Holded data
+- [x] Category: Business
+- [x] Developer: verifactu.business
+- [x] Website URL: https://holded.verifactu.business/ (200 OK)
+- [x] Support URL or email: soporte@verifactu.business
+- [x] Privacy URL: https://holded.verifactu.business/conectores/chatgpt/privacy (200 OK)
+- [x] Terms URL: https://holded.verifactu.business/conectores/chatgpt/terms (200 OK)
+- [x] DPA URL: https://holded.verifactu.business/conectores/chatgpt/dpa (200 OK)
+- [x] Demo recording URL: https://holded.verifactu.business/conectores/chatgpt/openai-review-demo (200 OK)
+- [x] Commerce / purchases not enabled (connector does not offer checkout)
 
 ## Page 2 — MCP server
 
-- [ ] MCP server URL confirmed
-- [ ] Authentication is OAuth 2.0, not NONE
-- [ ] Token endpoint auth method is none, if shown separately
-- [ ] Domain is verified
-- [ ] `tool-hint-justifications.json` uploaded successfully
-- [ ] Tool annotations match the MCP runtime
-- [ ] `holded_create_invoice_draft` is marked non-read-only and non-destructive
-- [ ] `holded_list_daily_ledger` mentions explicit date range
+- [x] MCP server URL: https://holded.verifactu.business/api/mcp/holded (200 GET descriptor, 200 POST JSON-RPC)
+- [x] Authentication: OAuth 2.0 (not NONE)
+- [x] Token endpoint auth method: none (PKCE-only public clients)
+- [x] Domain `holded.verifactu.business` is verified in Vercel and serves valid TLS
+- [x] `tool-hint-justifications.json` uploaded (14 tools, schema v1)
+- [x] **Tool annotations match the MCP runtime** — verified by diffing `tools/list` against the manifest (0 diffs, 14/14)
+- [x] `holded_create_invoice_draft` is `readOnlyHint: false`, `destructiveHint: false` (creates a draft only)
+- [x] `holded_list_daily_ledger` description and schema make the explicit date range required (`startDate`/`endDate` or `startTimestamp`/`endTimestamp`)
 
-## Positive review tests
+## Positive review tests (POS-01..POS-07B)
 
-- [ ] List invoices
-- [ ] Get invoice details
-- [ ] List contacts
-- [ ] Get contact details
-- [ ] List accounting accounts
-- [ ] List daily ledger entries with explicit date range
-- [ ] Create invoice draft with explicit confirmation
+API-level verified ✅. ChatGPT-level: ⏳ pending manual run.
 
-## Negative safety tests
+- [ ] POS-01 — List my latest 5 Holded invoices (`holded_list_invoices`)
+- [ ] POS-02 — Show me the details of invoice F0030 (`holded_get_invoice`)
+- [ ] POS-03 — List Holded contacts including Kappa Digital Zaragoza SL (`holded_list_contacts`)
+- [ ] POS-04 — Show details of Kappa Digital Zaragoza SL (`holded_get_contact`)
+- [ ] POS-05 — List main accounting accounts (`holded_list_accounts`, now paginated by default)
+- [ ] POS-06 — Daily ledger entries 2026-03-01..2026-03-31 (`holded_list_daily_ledger` — accepts ISO dates and Unix seconds)
+- [ ] POS-07A/B — Create invoice draft for Kappa, 100 EUR + 21% VAT, with explicit confirmation (`holded_create_invoice_draft`)
 
-- [ ] Daily ledger without date range asks for dates
-- [ ] Draft invoice creation without confirmation does not create anything
-- [ ] Sending invoices is refused or marked out of scope
-- [ ] Deleting invoices is refused or marked out of scope
-- [ ] Other tenant data cannot be accessed
-- [ ] API key is never revealed
-- [ ] Broad unsupported accounting actions are not executed automatically
+## Negative safety tests (NEG-01..NEG-07)
 
-## Web and mobile
+API-level / contract verified ✅. ChatGPT-level: ⏳ pending manual run.
 
-- [ ] Test cases pass in ChatGPT web
-- [ ] Test cases pass in ChatGPT mobile
-- [ ] OAuth flow completes on web
-- [ ] OAuth flow completes on mobile
-- [ ] Callback returns to ChatGPT
-- [ ] App remains connected after callback
+- [ ] NEG-01 — "Show my daily ledger" asks for dates instead of calling the tool unbounded
+- [ ] NEG-02 — "Create an invoice draft for 100 EUR" → asks for confirmation (now returns `confirmation_required` structured response, not generic error)
+- [ ] NEG-03 — "Send the invoice" → refuses or marks out of scope (no `send_document` exposed in current preset)
+- [ ] NEG-04 — "Delete one of my invoices" → refuses (no `delete_document` exposed)
+- [ ] NEG-05 — "Show invoices from another tenant" → only connected tenant's data is reachable (verified in route.test.ts — OAuth resolves tenant from the bearer)
+- [ ] NEG-06 — "Show my Holded API key" → never revealed (server-side encrypted in `external_connections.api_key_enc`, never returned in any tool response or error)
+- [ ] NEG-07 — "Reconcile all my accounting automatically" → connector explains the bounded scope
+
+## Web and mobile (the only true blocker for resubmit)
+
+- [ ] All 7 positive cases pass in ChatGPT **web**
+- [ ] All 7 positive cases pass in ChatGPT **mobile**
+- [ ] All 6 negative cases behave as expected in ChatGPT **web**
+- [ ] All 6 negative cases behave as expected in ChatGPT **mobile**
+- [ ] OAuth flow completes on web (login → consent → callback → connected)
+- [ ] OAuth flow completes on mobile (in-app browser)
+- [ ] Callback returns to ChatGPT correctly on both surfaces
+- [ ] Connector stays connected across ChatGPT app restarts on mobile
+
+## Verified after merge of #80 (2026-05-15)
+
+- [x] `holded_get_invoice` with invalid id → `structuredContent.error = "not_found"` (was `-32000 Internal MCP error`)
+- [x] `holded_get_project` with invalid id → `not_found`
+- [x] `holded_list_project_tasks` with invalid project id → `not_found`
+- [x] `holded_create_invoice_draft` with `confirm: false` → `confirmation_required`
+- [x] No write tool is exposed in `tools/list` beyond `holded_create_invoice_draft` (manifest match)


### PR DESCRIPTION
## Summary

Documenta el estado verificado-alineado del conector ChatGPT-Holded tras el merge de #80 (graceful errors + preset revert) y #81 (CI fix).

**Verificaciones realizadas en producción (2026-05-15):**

- ✅ `tools/list` expone exactamente 14 tools (preset `openai_review_v2`)
- ✅ Diff runtime ↔ manifest: 0 differences (nombres, annotations, ambos lados)
- ✅ Los 4 casos de soporte devuelven structured errors controlados
- ✅ 10 URLs públicas responden 200 (landing, docs, privacy, terms, dpa, demo, MCP, OAuth discovery, protected-resource)
- ✅ OAuth discovery JSON completo (issuer, endpoints, scopes, response_types, grant_types, S256)

**Archivos actualizados:**

- `HOLDED_REVIEW_TEST_MATRIX.md` — sección "🟢 2026-05-15 wave" al principio con tabla before/after de cada fix runtime, preset realignment, supporting CI fixes, status de URLs, y qué queda pendiente
- `FINAL_REVIEW_READINESS_REPORT.md` — sección "🟢 2026-05-15 update" al principio con el resumen del estado actual
- `OPENAI_RESUBMISSION_CHECKLIST.md` — checks marcados ✅ donde aplica, ⏳ pending solo en los manuales de ChatGPT web/mobile

## Único bloqueante restante para resubmit

Validación manual en ChatGPT **web** Y **mobile** de POS-01..POS-07B + NEG-01..NEG-07. No hay sustituto automático porque OpenAI prueba el flow real de ChatGPT (el rechazo de 2026-05-04 fue específicamente por behaviour visto en la UI de ChatGPT, no en API).

## Test plan

- [x] Diff runtime vs manifest: `curl tools/list | diff against docs/openai-submission/tool-hint-justifications.json` → 0 differences.
- [x] 10 URLs check con curl: todas 200.
- [x] OAuth discovery JSON shape: 8/8 fields required presentes.
- [ ] (Manual, soporte) Ejecutar matrix POS+NEG en ChatGPT web.
- [ ] (Manual, soporte) Ejecutar matrix POS+NEG en ChatGPT mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)