### PR TITLE
fix(holded-mcp): list_documents default range (24m) — fix soporte blindspot

### DIFF
--- a/apps/holded-mcp/package.json
+++ b/apps/holded-mcp/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/index.js",
     "dev": "tsx watch src/index.ts",
     "lint": "eslint src/**/*.ts",
-    "test": "node --import tsx --test test/tools.test.ts test/auth-and-metadata.test.ts test/oauth.test.ts test/holded-client.test.ts test/create-invoice-draft.test.ts test/branding.test.ts test/redirects.test.ts test/controlled-errors.test.ts",
+    "test": "node --import tsx --test test/tools.test.ts test/auth-and-metadata.test.ts test/oauth.test.ts test/holded-client.test.ts test/create-invoice-draft.test.ts test/branding.test.ts test/redirects.test.ts test/controlled-errors.test.ts test/list-documents-default-range.test.ts",
     "validate-branding": "node scripts/validate-branding.mjs"
   },
   "dependencies": {

--- a/apps/holded-mcp/src/tools/invoicing.ts
+++ b/apps/holded-mcp/src/tools/invoicing.ts
@@ -31,7 +31,11 @@ export function registerInvoicingTools(
 ) {
   server.tool(
     'list_documents',
-    'Returns Holded documents (invoices, sales receipts, credit notes, sales orders, proformas, waybills, estimates, purchases, purchase orders, purchase refunds) filtered by type, date range and contact. Read-only. Paginated. Each document is enriched with *Formatted fields in Europe/Madrid timezone so the model does not need to parse Unix timestamps.',
+    'Returns Holded documents (invoices, sales receipts, credit notes, sales orders, proformas, waybills, estimates, purchases, purchase orders, purchase refunds) filtered by type, date range and contact. Read-only. Paginated. Each document is enriched with *Formatted fields in Europe/Madrid timezone so the model does not need to parse Unix timestamps. ' +
+      '\n\n' +
+      'IMPORTANT — Holded\'s native default returns ONLY current-year documents (approved status), so documents from previous years are invisible without an explicit date range. ' +
+      'To prevent this audit blind-spot the connector automatically applies a default window of "previous calendar year January 1 → today" (~24 months) when neither starttmp nor endtmp is provided, surfaced in `rangeApplied.defaultsAppliedByConnector`. ' +
+      'To audit OLDER history (e.g. 2024 or earlier) pass explicit `starttmp`/`endtmp` covering that period. To audit a SPECIFIC fiscal year, pass starttmp = Jan 1 of that year, endtmp = Dec 31 of that year.',
     {
       docType: z
         .enum(DOC_TYPES)
@@ -40,10 +44,10 @@ export function registerInvoicingTools(
         ),
       page: z.string().optional().describe('Results page number (default 1).'),
       starttmp: dateInputOptional.describe(
-        'Start date (ISO 8601 or Unix seconds). Optional — omit or null for no lower bound.'
+        'Start date (ISO 8601 or Unix seconds). Optional — if omitted AND endtmp is also omitted, defaults to Jan 1 of the previous calendar year (e.g. 2025-01-01 when called in 2026) to cover ~24 months. Pass an explicit value to audit older periods.'
       ),
       endtmp: dateInputOptional.describe(
-        'End date (ISO 8601 or Unix seconds). Optional — omit or null for no upper bound.'
+        'End date (ISO 8601 or Unix seconds). Optional — if omitted, no upper bound is sent to Holded (which then uses "today" as the implicit upper bound).'
       ),
       contactId: z.string().optional().describe('Optional Holded contact ID filter.'),
       limit: z.coerce
@@ -62,7 +66,26 @@ export function registerInvoicingTools(
       for (const [k, v] of Object.entries(rest)) {
         if (v !== undefined) params[k] = String(v);
       }
-      if (starttmp !== undefined) params.starttmp = toUnixSecondsString(starttmp);
+
+      // Holded API default behaviour: cuando NO se pasa rango de fechas, el
+      // endpoint /documents devuelve solo el ejercicio en curso y solo
+      // documentos aprobados. La auditoría de soporte (2026-05-16) confirmó
+      // que esto causa "30 facturas visibles" en una cuenta que en realidad
+      // tiene 168 del año anterior. Para evitar el blind spot aplicamos un
+      // default de "1 de enero del año anterior → hoy" (~24 meses), que cubre
+      // ejercicio en curso + ejercicio cerrado anterior — el caso de uso más
+      // común para análisis fiscal/contable.
+      const defaultsApplied = {
+        starttmp: starttmp === undefined && endtmp === undefined,
+        endtmp: false,
+      };
+
+      if (starttmp !== undefined) {
+        params.starttmp = toUnixSecondsString(starttmp);
+      } else if (defaultsApplied.starttmp) {
+        const previousYear = new Date().getUTCFullYear() - 1;
+        params.starttmp = String(Math.floor(Date.UTC(previousYear, 0, 1) / 1000));
+      }
       if (endtmp !== undefined) params.endtmp = toUnixSecondsString(endtmp);
 
       const raw = await getClient().listDocuments(docType, params);
@@ -79,9 +102,18 @@ export function registerInvoicingTools(
         count: documents.length,
         totalReceived: all.length,
         truncated,
+        rangeApplied: {
+          starttmp: params.starttmp ?? null,
+          endtmp: params.endtmp ?? null,
+          defaultsAppliedByConnector: defaultsApplied,
+        },
         timezoneNote:
           'Dates with *Formatted suffix are YYYY-MM-DD in Europe/Madrid (peninsular Spain). Raw Unix timestamps are kept for reference.',
       };
+      if (defaultsApplied.starttmp) {
+        payload.note =
+          'Holded\'s native default would return only current-year documents. The connector applied a default range of "previous calendar year Jan 1 → today" (~24 months) so older fiscal-year documents are visible. To audit older periods (e.g. 2024 or earlier), pass explicit starttmp/endtmp.';
+      }
       if (truncated) {
         payload.hint = `Showing first ${limit} of ${all.length} documents received from Holded. Use page=2 (or higher) for the next batch, or narrow with starttmp/endtmp/contactId.`;
       }

--- a/apps/holded-mcp/test/list-documents-default-range.test.ts
+++ b/apps/holded-mcp/test/list-documents-default-range.test.ts
@@ -1,0 +1,126 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { installTestEnv, startTestServer, withHoldedFetchRecorder } from './helpers.ts';
+
+installTestEnv();
+
+/**
+ * Soporte audit (2026-05-16): el default de la API de Holded para /documents
+ * sólo devuelve documentos del ejercicio en curso y aprobados. Una cuenta con
+ * 168 facturas de 2025 mostraba sólo 30 de 2026 sin filtro explícito.
+ *
+ * Fix: el connector aplica un default de "1 de enero del año anterior → hoy"
+ * cuando ni starttmp ni endtmp se proporcionan, exponiendo el rango aplicado
+ * en `rangeApplied.defaultsAppliedByConnector` para que el modelo lo razone.
+ */
+
+async function callListDocuments(args: Record<string, unknown>) {
+  const runtime = await startTestServer();
+  const recorder = withHoldedFetchRecorder({ responseBody: [] });
+
+  try {
+    const { createTokenPair } = await import('../src/auth.ts');
+    const tokenPair = await createTokenPair({
+      holdedApiKey: 'holded-api-key-test',
+      clientId: 'test-client',
+      scope: 'holded:read holded:write',
+    });
+
+    const transport = new StreamableHTTPClientTransport(new URL(`${runtime.baseUrl}/mcp`), {
+      requestInit: { headers: { Authorization: `Bearer ${tokenPair.accessToken}` } },
+    });
+
+    const client = new Client({ name: 'holded-mcp-test', version: '1.0.0' });
+    await client.connect(transport);
+
+    const response = await client.callTool({ name: 'list_documents', arguments: args });
+
+    await transport.close();
+
+    const getCalls = recorder.calls.filter(
+      (c) => c.method === 'GET' && c.url.includes('/documents/invoice')
+    );
+    assert.ok(getCalls.length >= 1, 'expected at least one GET to /documents/invoice');
+    const callUrl = new URL(getCalls[0].url);
+
+    const content = (response as { content?: Array<{ type: string; text: string }> }).content ?? [];
+    const text = content.find((c) => c.type === 'text')?.text ?? '{}';
+    const payload = JSON.parse(text) as Record<string, unknown>;
+
+    return { callUrl, payload };
+  } finally {
+    recorder.restore();
+    await runtime.close();
+  }
+}
+
+test('list_documents applies default range "previous year Jan 1 → today" when no date filter is given', async () => {
+  const { callUrl, payload } = await callListDocuments({ docType: 'invoice' });
+
+  const sentStarttmp = callUrl.searchParams.get('starttmp');
+  const sentEndtmp = callUrl.searchParams.get('endtmp');
+
+  // starttmp default = Jan 1 previous year
+  const previousYear = new Date().getUTCFullYear() - 1;
+  const expectedStart = Math.floor(Date.UTC(previousYear, 0, 1) / 1000);
+  assert.equal(
+    sentStarttmp,
+    String(expectedStart),
+    'connector should default starttmp to Jan 1 of the previous calendar year'
+  );
+
+  // endtmp not sent — Holded interprets as "today"
+  assert.equal(sentEndtmp, null, 'endtmp should be omitted when caller did not provide it');
+
+  const rangeApplied = payload.rangeApplied as Record<string, unknown>;
+  assert.equal((rangeApplied.defaultsAppliedByConnector as Record<string, boolean>).starttmp, true);
+  assert.match(payload.note as string, /previous calendar year Jan 1/i);
+});
+
+test('list_documents honors explicit starttmp without applying default', async () => {
+  const { callUrl, payload } = await callListDocuments({
+    docType: 'invoice',
+    starttmp: '2024-01-01T00:00:00Z',
+  });
+
+  // Jan 1 2024 UTC = 1704067200
+  assert.equal(callUrl.searchParams.get('starttmp'), '1704067200');
+
+  const rangeApplied = payload.rangeApplied as Record<string, unknown>;
+  assert.equal((rangeApplied.defaultsAppliedByConnector as Record<string, boolean>).starttmp, false);
+  // No note about defaults when user provided the range
+  assert.equal(payload.note, undefined);
+});
+
+test('list_documents honors explicit endtmp without applying default starttmp', async () => {
+  const { callUrl, payload } = await callListDocuments({
+    docType: 'invoice',
+    endtmp: '2025-12-31T23:59:59Z',
+  });
+
+  // When only endtmp is given, the connector should NOT auto-apply a starttmp
+  // (the caller has signaled they know what range they want — the start is open).
+  assert.equal(callUrl.searchParams.get('starttmp'), null);
+  assert.equal(callUrl.searchParams.get('endtmp'), '1767225599');
+
+  const rangeApplied = payload.rangeApplied as Record<string, unknown>;
+  assert.equal((rangeApplied.defaultsAppliedByConnector as Record<string, boolean>).starttmp, false);
+});
+
+test('list_documents response includes rangeApplied with the timestamps actually sent', async () => {
+  const { payload } = await callListDocuments({
+    docType: 'invoice',
+    starttmp: '2025-01-01T00:00:00Z',
+    endtmp: '2025-12-31T23:59:59Z',
+  });
+
+  const rangeApplied = payload.rangeApplied as Record<string, unknown>;
+  assert.equal(rangeApplied.starttmp, '1735689600'); // 2025-01-01
+  assert.equal(rangeApplied.endtmp, '1767225599');   // 2025-12-31 end of day
+  assert.deepEqual(rangeApplied.defaultsAppliedByConnector, {
+    starttmp: false,
+    endtmp: false,
+  });
+});


### PR DESCRIPTION
## Summary

Soporte audit (2026-05-16, cuenta demo "Nova Gestión") encontró que `list_documents` sin filtros de fecha **solo devolvía 30 facturas de 2026** cuando la cuenta tenía **168 facturas más en 2025** (F250001–F250168) invisibles. El default nativo de la API de Holded `/documents` filtra al ejercicio en curso + solo aprobados — sin rango explícito, los documentos de ejercicios anteriores quedan ocultos.

Esto es un blindspot de auditoría: el modelo no podía detectar duplicados de numeración ni hacer trabajos contables de cierre porque "lo que no aparece" sí existía. La workaround manual de soporte ("siempre pasar rango de fechas") no funciona si el LLM no sabe que tiene que hacerlo.

## Fix

Cuando ni `starttmp` ni `endtmp` se pasan, el connector aplica automáticamente un default de **"1 de enero del año anterior → hoy"** (~24 meses), cubriendo ejercicio en curso + ejercicio cerrado anterior — el caso más común para análisis fiscal/contable.

| Args                                  | starttmp enviado a Holded         | default? |
|---------------------------------------|-----------------------------------|----------|
| `{docType: invoice}`                  | Jan 1 (currentYear-1)             | sí       |
| `{docType, starttmp: 2024-01-01}`     | 2024-01-01                        | no       |
| `{docType, endtmp: 2025-12-31}`       | (omitido)                         | no       |
| `{docType, starttmp, endtmp}`         | starttmp                          | no       |

La respuesta ahora incluye `rangeApplied.{starttmp, endtmp, defaultsAppliedByConnector}` + un `note` cuando el default se aplicó, para que el modelo razone sobre el rango y sepa cuándo expandirlo (p.ej. para auditar 2024 o antes).

Descripción del tool actualizada con el caveat explícito de Holded y la guía de cómo overridearlo para periodos más antiguos o específicos.

## Test plan

- [x] `pnpm --filter holded-mcp-server test` → 40/41 pass. El 1 fail es el test pre-existente de OAuth consent XSS (no relacionado, mismo count antes y después).
- [x] 4 tests nuevos en `test/list-documents-default-range.test.ts` cubren:
  - Default aplicado cuando no hay filtros → `starttmp = previousYear.Jan 1`
  - `starttmp` explícito → no aplica default
  - Solo `endtmp` → no aplica default starttmp (el caller señaló rango deliberadamente)
  - `rangeApplied` metadata refleja exactamente los timestamps enviados
- [x] `tsc --noEmit` pasa.

## Verificación post-deploy

Con un access token Claude, llamar:
```
list_documents { docType: "invoice" }
```
Debe ver el `rangeApplied.defaultsAppliedByConnector.starttmp = true` + un `count` que incluya facturas del año anterior (no solo del año en curso).

🤖 Generated with [Claude Code](https://claude.com/claude-code)