### PR TITLE
feat(holded-connectors): status monitoring fase 1 (cron + landing badge)

### DIFF
--- a/apps/app/app/api/cron/connector-health/route.test.ts
+++ b/apps/app/app/api/cron/connector-health/route.test.ts
@@ -1,0 +1,166 @@
+/** @jest-environment node */
+
+jest.mock('@/lib/connectorHealth/checks', () => ({
+  runAllConnectorHealthChecks: jest.fn(),
+}));
+
+jest.mock('@/lib/prisma', () => ({
+  __esModule: true,
+  default: {
+    connectorHealthCheck: {
+      createMany: jest.fn(),
+      create: jest.fn(),
+    },
+  },
+}));
+
+import { NextRequest } from 'next/server';
+import { POST } from './route';
+import { runAllConnectorHealthChecks } from '@/lib/connectorHealth/checks';
+import prisma from '@/lib/prisma';
+
+const runMock = runAllConnectorHealthChecks as jest.MockedFunction<
+  typeof runAllConnectorHealthChecks
+>;
+const createManyMock = prisma.connectorHealthCheck.createMany as jest.MockedFunction<
+  typeof prisma.connectorHealthCheck.createMany
+>;
+const createMock = prisma.connectorHealthCheck.create as jest.MockedFunction<
+  typeof prisma.connectorHealthCheck.create
+>;
+
+function buildRequest(headers: Record<string, string> = {}) {
+  return new NextRequest('http://localhost/api/cron/connector-health', {
+    method: 'POST',
+    headers,
+  });
+}
+
+const sampleResults = [
+  {
+    connector: 'chatgpt' as const,
+    checkType: 'landing',
+    target: 'https://holded.verifactu.business/conectores/chatgpt',
+    status: 'ok' as const,
+    latencyMs: 120,
+    httpStatus: 200,
+    errorCode: null,
+    errorMessage: null,
+    metadata: null,
+  },
+  {
+    connector: 'chatgpt' as const,
+    checkType: 'tools_list',
+    target: 'https://holded.verifactu.business/api/mcp/holded',
+    status: 'fail' as const,
+    latencyMs: 230,
+    httpStatus: 200,
+    errorCode: 'tool_count_mismatch' as const,
+    errorMessage: 'expected 14 tools, got 13',
+    metadata: { toolCount: 13, expected: 14 },
+  },
+];
+
+describe('POST /api/cron/connector-health', () => {
+  const envBackup = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...envBackup };
+    delete process.env.CRON_SECRET;
+    Object.assign(process.env, { NODE_ENV: 'test' });
+    runMock.mockResolvedValue(sampleResults);
+    createManyMock.mockResolvedValue({ count: sampleResults.length });
+  });
+
+  afterAll(() => {
+    process.env = envBackup;
+  });
+
+  it('rechaza cuando CRON_SECRET está seteado y no hay token', async () => {
+    process.env.CRON_SECRET = 'super-secret';
+
+    const response = await POST(buildRequest());
+    expect(response.status).toBe(401);
+    expect(runMock).not.toHaveBeenCalled();
+  });
+
+  it('acepta cuando CRON_SECRET coincide con Bearer header', async () => {
+    process.env.CRON_SECRET = 'super-secret';
+
+    const response = await POST(buildRequest({ authorization: 'Bearer super-secret' }));
+    expect(response.status).toBe(200);
+    expect(runMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('acepta cuando CRON_SECRET coincide con x-cron-secret header', async () => {
+    process.env.CRON_SECRET = 'super-secret';
+
+    const response = await POST(buildRequest({ 'x-cron-secret': 'super-secret' }));
+    expect(response.status).toBe(200);
+  });
+
+  it('en non-production sin CRON_SECRET, acepta sin auth (modo testing)', async () => {
+    const response = await POST(buildRequest());
+    expect(response.status).toBe(200);
+    expect(runMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('persiste resultados via createMany y devuelve summary con conteos', async () => {
+    const response = await POST(buildRequest());
+    const body = await response.json();
+
+    expect(createManyMock).toHaveBeenCalledTimes(1);
+    expect(createManyMock).toHaveBeenCalledWith({
+      data: expect.arrayContaining([
+        expect.objectContaining({
+          connector: 'chatgpt',
+          checkType: 'landing',
+          status: 'ok',
+          latencyMs: 120,
+        }),
+        expect.objectContaining({
+          connector: 'chatgpt',
+          checkType: 'tools_list',
+          status: 'fail',
+          errorCode: 'tool_count_mismatch',
+        }),
+      ]),
+    });
+
+    expect(body).toMatchObject({
+      ok: false, // hay un fail → ok=false
+      summary: { total: 2, ok: 1, degraded: 0, fail: 1 },
+      failedChecks: [
+        {
+          connector: 'chatgpt',
+          checkType: 'tools_list',
+          errorCode: 'tool_count_mismatch',
+        },
+      ],
+    });
+  });
+
+  it('fallback a createMany falla → inserts individuales', async () => {
+    createManyMock.mockRejectedValueOnce(new Error('Prisma Accelerate createMany not supported'));
+    createMock.mockResolvedValue({} as never);
+
+    const response = await POST(buildRequest());
+
+    expect(response.status).toBe(200);
+    expect(createMock).toHaveBeenCalledTimes(sampleResults.length);
+  });
+
+  it('ok=true cuando todos los checks pasan', async () => {
+    runMock.mockResolvedValueOnce([
+      {
+        ...sampleResults[0],
+        checkType: 'landing',
+      },
+    ]);
+    const response = await POST(buildRequest());
+    const body = await response.json();
+    expect(body.ok).toBe(true);
+    expect(body.failedChecks).toEqual([]);
+  });
+});

--- a/apps/app/app/api/cron/connector-health/route.ts
+++ b/apps/app/app/api/cron/connector-health/route.ts
@@ -1,0 +1,131 @@
+/**
+ * POST /api/cron/connector-health
+ *
+ * Vercel Cron handler: corre todos los checks de superficie pública de los
+ * conectores ChatGPT-Holded y Claude-Holded, persiste resultados en
+ * `connector_health_checks` y devuelve un summary.
+ *
+ * Auth: Bearer CRON_SECRET (mismo patrón que /api/cron). En non-production sin
+ * CRON_SECRET definido permite ejecutar sin auth para testing local.
+ *
+ * Schedule (configurado en apps/app/vercel.json): cada 5 minutos.
+ */
+
+import { runAllConnectorHealthChecks } from '@/lib/connectorHealth/checks';
+import prisma from '@/lib/prisma';
+import type { Prisma } from '@prisma/client';
+import { NextRequest, NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+function resolveCronSecret(request: NextRequest) {
+  const authHeader = request.headers.get('authorization') || '';
+  const bearer = authHeader.startsWith('Bearer ') ? authHeader.slice(7).trim() : '';
+  const direct = request.headers.get('x-cron-secret')?.trim() || '';
+  return bearer || direct;
+}
+
+function isCronAuthorized(request: NextRequest) {
+  const requiredSecret = process.env.CRON_SECRET?.trim() || '';
+  if (!requiredSecret) {
+    return process.env.NODE_ENV !== 'production';
+  }
+  const received = resolveCronSecret(request);
+  return Boolean(received) && received === requiredSecret;
+}
+
+export async function POST(request: NextRequest) {
+  if (!isCronAuthorized(request)) {
+    return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const startedAt = Date.now();
+  try {
+    const results = await runAllConnectorHealthChecks();
+
+    // Persistir TODOS los checks en una sola transacción (cae si la DB tira,
+    // pero no degradamos el cron por persistencia parcial). Si createMany no
+    // está disponible (Accelerate), fallback a inserts individuales.
+    try {
+      await prisma.connectorHealthCheck.createMany({
+        data: results.map((r) => ({
+          connector: r.connector,
+          checkType: r.checkType,
+          target: r.target,
+          status: r.status,
+          latencyMs: r.latencyMs,
+          httpStatus: r.httpStatus ?? null,
+          errorCode: r.errorCode ?? null,
+          errorMessage: r.errorMessage ?? null,
+          metadata: (r.metadata ?? undefined) as Prisma.InputJsonValue | undefined,
+        })),
+      });
+    } catch (err) {
+      console.warn('[cron/connector-health] createMany failed, falling back to individual inserts', {
+        message: err instanceof Error ? err.message : String(err),
+      });
+      for (const r of results) {
+        try {
+          await prisma.connectorHealthCheck.create({
+            data: {
+              connector: r.connector,
+              checkType: r.checkType,
+              target: r.target,
+              status: r.status,
+              latencyMs: r.latencyMs,
+              httpStatus: r.httpStatus ?? null,
+              errorCode: r.errorCode ?? null,
+              errorMessage: r.errorMessage ?? null,
+              metadata: (r.metadata ?? undefined) as Prisma.InputJsonValue | undefined,
+            },
+          });
+        } catch (writeErr) {
+          console.error('[cron/connector-health] failed to persist single check', {
+            connector: r.connector,
+            checkType: r.checkType,
+            message: writeErr instanceof Error ? writeErr.message : String(writeErr),
+          });
+        }
+      }
+    }
+
+    const okCount = results.filter((r) => r.status === 'ok').length;
+    const degradedCount = results.filter((r) => r.status === 'degraded').length;
+    const failCount = results.filter((r) => r.status === 'fail').length;
+
+    return NextResponse.json({
+      ok: failCount === 0,
+      executedAt: new Date().toISOString(),
+      durationMs: Date.now() - startedAt,
+      summary: {
+        total: results.length,
+        ok: okCount,
+        degraded: degradedCount,
+        fail: failCount,
+      },
+      failedChecks: results
+        .filter((r) => r.status === 'fail')
+        .map((r) => ({
+          connector: r.connector,
+          checkType: r.checkType,
+          errorCode: r.errorCode,
+          errorMessage: r.errorMessage,
+        })),
+    });
+  } catch (err) {
+    console.error('[cron/connector-health] unhandled failure', {
+      message: err instanceof Error ? err.message : String(err),
+      stack: err instanceof Error ? err.stack : undefined,
+    });
+    return NextResponse.json(
+      {
+        ok: false,
+        error: 'Internal error',
+        durationMs: Date.now() - startedAt,
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/app/app/api/public/status/[connector]/route.test.ts
+++ b/apps/app/app/api/public/status/[connector]/route.test.ts
@@ -1,0 +1,217 @@
+/** @jest-environment node */
+
+jest.mock('@/lib/prisma', () => ({
+  __esModule: true,
+  default: {
+    connectorHealthCheck: {
+      findMany: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('@/lib/connectorHealth/checks', () => ({
+  getCheckDefinitions: jest.fn(() => [
+    { connector: 'chatgpt', checkType: 'landing', target: 'https://holded.verifactu.business/conectores/chatgpt' },
+    { connector: 'chatgpt', checkType: 'tools_list', target: 'https://holded.verifactu.business/api/mcp/holded' },
+    { connector: 'claude', checkType: 'landing', target: 'https://claude.verifactu.business/' },
+  ]),
+}));
+
+import { NextRequest } from 'next/server';
+import { GET } from './route';
+import prisma from '@/lib/prisma';
+
+const findManyMock = prisma.connectorHealthCheck.findMany as jest.MockedFunction<
+  typeof prisma.connectorHealthCheck.findMany
+>;
+
+function buildRequest() {
+  return new NextRequest('http://localhost/api/public/status/chatgpt');
+}
+
+function buildContext(connector: string) {
+  return { params: Promise.resolve({ connector }) };
+}
+
+describe('GET /api/public/status/[connector]', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('rechaza connectors desconocidos con 404', async () => {
+    const response = await GET(buildRequest(), buildContext('unknown'));
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.error).toBe('unknown_connector');
+  });
+
+  it('agrega checks por checkType y devuelve overall=operational si todos ok', async () => {
+    const now = new Date();
+    findManyMock.mockResolvedValue([
+      {
+        checkType: 'landing',
+        status: 'ok',
+        latencyMs: 100,
+        httpStatus: 200,
+        errorCode: null,
+        errorMessage: null,
+        checkedAt: now,
+        target: 'https://holded.verifactu.business/conectores/chatgpt',
+      },
+      {
+        checkType: 'tools_list',
+        status: 'ok',
+        latencyMs: 200,
+        httpStatus: 200,
+        errorCode: null,
+        errorMessage: null,
+        checkedAt: now,
+        target: 'https://holded.verifactu.business/api/mcp/holded',
+      },
+    ] as never);
+
+    const response = await GET(buildRequest(), buildContext('chatgpt'));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.connector).toBe('chatgpt');
+    expect(body.overall).toBe('operational');
+    expect(body.checks).toHaveLength(2);
+    expect(body.checks[0].status).toBe('ok');
+    expect(body.checksOk).toBe(2);
+    expect(body.checksFail).toBe(0);
+  });
+
+  it('overall=down si cualquier check tiene status fail', async () => {
+    findManyMock.mockResolvedValue([
+      {
+        checkType: 'tools_list',
+        status: 'fail',
+        latencyMs: 200,
+        httpStatus: 200,
+        errorCode: 'tool_count_mismatch',
+        errorMessage: 'expected 14 tools, got 13',
+        checkedAt: new Date(),
+        target: 'https://holded.verifactu.business/api/mcp/holded',
+      },
+      {
+        checkType: 'landing',
+        status: 'ok',
+        latencyMs: 100,
+        httpStatus: 200,
+        errorCode: null,
+        errorMessage: null,
+        checkedAt: new Date(),
+        target: 'https://holded.verifactu.business/conectores/chatgpt',
+      },
+    ] as never);
+
+    const response = await GET(buildRequest(), buildContext('chatgpt'));
+    const body = await response.json();
+
+    expect(body.overall).toBe('down');
+    expect(body.checksFail).toBe(1);
+    const failedCheck = body.checks.find((c: { checkType: string }) => c.checkType === 'tools_list');
+    expect(failedCheck.lastErrorCode).toBe('tool_count_mismatch');
+    expect(failedCheck.lastErrorMessage).toContain('expected 14 tools');
+  });
+
+  it('overall=degraded si al menos un check tiene status degraded y ninguno fail', async () => {
+    findManyMock.mockResolvedValue([
+      {
+        checkType: 'landing',
+        status: 'degraded',
+        latencyMs: 3500,
+        httpStatus: 200,
+        errorCode: null,
+        errorMessage: null,
+        checkedAt: new Date(),
+        target: '',
+      },
+      {
+        checkType: 'tools_list',
+        status: 'ok',
+        latencyMs: 200,
+        httpStatus: 200,
+        errorCode: null,
+        errorMessage: null,
+        checkedAt: new Date(),
+        target: '',
+      },
+    ] as never);
+
+    const response = await GET(buildRequest(), buildContext('chatgpt'));
+    const body = await response.json();
+    expect(body.overall).toBe('degraded');
+  });
+
+  it('overall=unknown si no hay ningún check en DB', async () => {
+    findManyMock.mockResolvedValue([] as never);
+
+    const response = await GET(buildRequest(), buildContext('chatgpt'));
+    const body = await response.json();
+    expect(body.overall).toBe('unknown');
+    expect(body.checks).toHaveLength(2); // las definiciones esperadas se incluyen igual
+    expect(body.checks.every((c: { status: string }) => c.status === 'unknown')).toBe(true);
+  });
+
+  it('calcula uptime24h por check considerando ok+degraded como "OK"', async () => {
+    const recent = new Date();
+    findManyMock.mockResolvedValue([
+      {
+        checkType: 'landing',
+        status: 'ok',
+        latencyMs: 100,
+        httpStatus: 200,
+        errorCode: null,
+        errorMessage: null,
+        checkedAt: recent,
+        target: '',
+      },
+      {
+        checkType: 'landing',
+        status: 'degraded',
+        latencyMs: 3500,
+        httpStatus: 200,
+        errorCode: null,
+        errorMessage: null,
+        checkedAt: recent,
+        target: '',
+      },
+      {
+        checkType: 'landing',
+        status: 'fail',
+        latencyMs: 0,
+        httpStatus: null,
+        errorCode: 'timeout',
+        errorMessage: 'aborted',
+        checkedAt: recent,
+        target: '',
+      },
+    ] as never);
+
+    const response = await GET(buildRequest(), buildContext('chatgpt'));
+    const body = await response.json();
+    const landing = body.checks.find((c: { checkType: string }) => c.checkType === 'landing');
+    // 2 OK (ok + degraded), 1 fail → 66.7%
+    expect(landing.uptime24hPct).toBeCloseTo(66.7, 1);
+    expect(landing.sampleCount24h).toBe(3);
+  });
+
+  it('expone CORS y Cache-Control para edge caching', async () => {
+    findManyMock.mockResolvedValue([] as never);
+    const response = await GET(buildRequest(), buildContext('chatgpt'));
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    expect(response.headers.get('Cache-Control')).toMatch(/s-maxage=60/);
+  });
+
+  it('devuelve overall=unknown con status=200 si la DB falla (no rompe la landing)', async () => {
+    findManyMock.mockRejectedValueOnce(new Error('connection refused'));
+
+    const response = await GET(buildRequest(), buildContext('chatgpt'));
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.overall).toBe('unknown');
+    expect(body.error).toBe('status_unavailable');
+  });
+});

--- a/apps/app/app/api/public/status/[connector]/route.ts
+++ b/apps/app/app/api/public/status/[connector]/route.ts
@@ -1,0 +1,178 @@
+/**
+ * GET /api/public/status/{connector}
+ *
+ * Endpoint público (sin auth) que devuelve el estado actual del conector
+ * para que las landings de holded.verifactu.business lo embeban.
+ *
+ * Devuelve, por cada `checkType` definido en lib/connectorHealth/checks.ts:
+ *   - status: ok | degraded | fail (último resultado)
+ *   - latencyMs: latencia del último check
+ *   - lastCheckedAt: timestamp del último check
+ *   - uptime24h: % de checks `ok` en las últimas 24h
+ *   - lastFailedAt: fecha del último fail en 30 días (o null)
+ *
+ * Además computa un `overall` agregado para el widget compacto.
+ *
+ * Cache: 60s edge + 300s SWR para que aguante picos de tráfico en las landings
+ * sin saturar la DB. La granularidad real del estado es de 5 min (cron) — más
+ * fino que eso no aporta.
+ */
+
+import prisma from '@/lib/prisma';
+import { getCheckDefinitions, type ConnectorId } from '@/lib/connectorHealth/checks';
+import { NextRequest, NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const ALLOWED_CONNECTORS: ReadonlyArray<ConnectorId> = ['chatgpt', 'claude'];
+
+function applyCors<T extends { headers: Headers }>(response: T) {
+  response.headers.set('Access-Control-Allow-Origin', '*');
+  response.headers.set('Access-Control-Allow-Methods', 'GET, OPTIONS');
+  response.headers.set('Access-Control-Allow-Headers', 'Content-Type');
+  response.headers.set('Cache-Control', 'public, s-maxage=60, stale-while-revalidate=300');
+  return response;
+}
+
+export async function OPTIONS() {
+  return applyCors(new NextResponse(null, { status: 204 }));
+}
+
+export async function GET(_req: NextRequest, ctx: { params: Promise<{ connector: string }> }) {
+  const { connector: connectorParam } = await ctx.params;
+  const connector = connectorParam as ConnectorId;
+  if (!ALLOWED_CONNECTORS.includes(connector)) {
+    return applyCors(
+      NextResponse.json(
+        { error: 'unknown_connector', allowed: ALLOWED_CONNECTORS },
+        { status: 404 }
+      )
+    );
+  }
+
+  const expectedChecks = getCheckDefinitions().filter((c) => c.connector === connector);
+  const since24h = new Date(Date.now() - 24 * 60 * 60 * 1000);
+  const since30d = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+
+  try {
+    // Una sola query trae los últimos 30 días de este conector; agregamos en
+    // memoria para evitar N+1 queries (uno por checkType).
+    const rows = await prisma.connectorHealthCheck.findMany({
+      where: { connector, checkedAt: { gte: since30d } },
+      orderBy: { checkedAt: 'desc' },
+      select: {
+        checkType: true,
+        status: true,
+        latencyMs: true,
+        httpStatus: true,
+        errorCode: true,
+        errorMessage: true,
+        checkedAt: true,
+        target: true,
+      },
+    });
+
+    const byCheckType = new Map<string, typeof rows>();
+    for (const row of rows) {
+      const list = byCheckType.get(row.checkType);
+      if (list) list.push(row);
+      else byCheckType.set(row.checkType, [row]);
+    }
+
+    const checks = expectedChecks.map((def) => {
+      const history = byCheckType.get(def.checkType) ?? [];
+      const latest = history[0];
+      const last24h = history.filter((r) => r.checkedAt >= since24h);
+      const okCount24h = last24h.filter((r) => r.status === 'ok' || r.status === 'degraded').length;
+      const uptime24h =
+        last24h.length === 0 ? null : Math.round((okCount24h / last24h.length) * 1000) / 10;
+      const lastFailedAt = history.find((r) => r.status === 'fail')?.checkedAt ?? null;
+      const latestLatencyP95 = (() => {
+        // Aproximación: ordenar latencias del último día y coger el p95.
+        const samples = last24h.map((r) => r.latencyMs).sort((a, b) => a - b);
+        if (samples.length === 0) return null;
+        const idx = Math.min(samples.length - 1, Math.floor(samples.length * 0.95));
+        return samples[idx];
+      })();
+
+      return {
+        checkType: def.checkType,
+        target: def.target,
+        status: latest?.status ?? 'unknown',
+        latencyMs: latest?.latencyMs ?? null,
+        httpStatus: latest?.httpStatus ?? null,
+        lastCheckedAt: latest?.checkedAt.toISOString() ?? null,
+        lastErrorCode: latest?.status === 'fail' ? latest.errorCode : null,
+        lastErrorMessage: latest?.status === 'fail' ? latest.errorMessage : null,
+        uptime24hPct: uptime24h,
+        latencyP95Ms24h: latestLatencyP95,
+        lastFailedAt: lastFailedAt ? lastFailedAt.toISOString() : null,
+        sampleCount24h: last24h.length,
+      };
+    });
+
+    // Overall: cae al peor estado de cualquier check (fail > degraded > ok).
+    const overall: 'operational' | 'degraded' | 'down' | 'unknown' = (() => {
+      if (checks.every((c) => c.status === 'unknown')) return 'unknown';
+      if (checks.some((c) => c.status === 'fail')) return 'down';
+      if (checks.some((c) => c.status === 'degraded')) return 'degraded';
+      return 'operational';
+    })();
+
+    const lastCheckedAt = checks.reduce<string | null>((acc, c) => {
+      if (!c.lastCheckedAt) return acc;
+      if (!acc) return c.lastCheckedAt;
+      return c.lastCheckedAt > acc ? c.lastCheckedAt : acc;
+    }, null);
+
+    const okCount = checks.filter((c) => c.status === 'ok').length;
+    const overallUptime24hPct = (() => {
+      const sampled = checks.filter((c) => c.uptime24hPct !== null);
+      if (sampled.length === 0) return null;
+      const sum = sampled.reduce((acc, c) => acc + (c.uptime24hPct ?? 0), 0);
+      return Math.round((sum / sampled.length) * 10) / 10;
+    })();
+
+    return applyCors(
+      NextResponse.json({
+        connector,
+        overall,
+        lastCheckedAt,
+        checksTotal: checks.length,
+        checksOk: okCount,
+        checksDegraded: checks.filter((c) => c.status === 'degraded').length,
+        checksFail: checks.filter((c) => c.status === 'fail').length,
+        checksUnknown: checks.filter((c) => c.status === 'unknown').length,
+        overallUptime24hPct,
+        checks,
+      })
+    );
+  } catch (err) {
+    console.error('[public/status] DB read failed', {
+      connector,
+      message: err instanceof Error ? err.message : String(err),
+    });
+    // Degradar a respuesta neutra para no romper el render de la landing.
+    return applyCors(
+      NextResponse.json(
+        {
+          connector,
+          overall: 'unknown',
+          lastCheckedAt: null,
+          error: 'status_unavailable',
+          checks: expectedChecks.map((def) => ({
+            checkType: def.checkType,
+            target: def.target,
+            status: 'unknown',
+            latencyMs: null,
+            lastCheckedAt: null,
+            uptime24hPct: null,
+            sampleCount24h: 0,
+          })),
+        },
+        { status: 200 }
+      )
+    );
+  }
+}

--- a/apps/app/lib/connectorHealth/checks.ts
+++ b/apps/app/lib/connectorHealth/checks.ts
@@ -1,0 +1,344 @@
+/**
+ * Conector health checks: definición + ejecución.
+ *
+ * Cada check es una probe HTTP a un endpoint público del conector (sin token).
+ * Diseñado para Vercel Cron — corre los ~16 checks en paralelo, persiste
+ * resultados en `connector_health_checks`, y alimenta el endpoint público
+ * /api/public/status/{connector} que la landing renderiza.
+ */
+
+export type ConnectorId = 'chatgpt' | 'claude';
+export type CheckStatus = 'ok' | 'degraded' | 'fail';
+export type CheckErrorCode =
+  | 'timeout'
+  | 'network'
+  | 'non_2xx'
+  | 'invalid_json'
+  | 'missing_field'
+  | 'tool_count_mismatch'
+  | 'rpc_error'
+  | 'unexpected_status';
+
+export interface HealthCheckResult {
+  connector: ConnectorId;
+  checkType: string;
+  target: string;
+  status: CheckStatus;
+  latencyMs: number;
+  httpStatus: number | null;
+  errorCode: CheckErrorCode | null;
+  errorMessage: string | null;
+  metadata: Record<string, unknown> | null;
+}
+
+type ProbeMode =
+  | { kind: 'get'; expectStatus?: number }
+  | { kind: 'json_get'; expectStatus?: number; validate: (body: unknown) => string | null }
+  | {
+      kind: 'json_rpc_post';
+      body: Record<string, unknown>;
+      expectStatus?: number;
+      validate: (body: unknown) => { error: CheckErrorCode | null; message: string | null; metadata?: Record<string, unknown> | null };
+    };
+
+interface CheckDefinition {
+  connector: ConnectorId;
+  checkType: string;
+  target: string;
+  probe: ProbeMode;
+  /** Latencia por encima de la cual el check pasa a `degraded` aunque sea 2xx. */
+  degradedAboveMs?: number;
+  /** Timeout absoluto del fetch. */
+  timeoutMs?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 8000;
+const DEFAULT_DEGRADED_ABOVE_MS = 3000;
+
+const HOLDED_PUBLIC_URL =
+  process.env.HEALTH_HOLDED_PUBLIC_URL?.trim() || 'https://holded.verifactu.business';
+const CHATGPT_MCP_URL =
+  process.env.HEALTH_CHATGPT_MCP_URL?.trim() || `${HOLDED_PUBLIC_URL}/api/mcp/holded`;
+const CLAUDE_PUBLIC_URL =
+  process.env.HEALTH_CLAUDE_PUBLIC_URL?.trim() || 'https://claude.verifactu.business';
+const CLAUDE_MCP_URL =
+  process.env.HEALTH_CLAUDE_MCP_URL?.trim() || `${CLAUDE_PUBLIC_URL}/mcp`;
+
+const CHATGPT_EXPECTED_TOOL_COUNT = Number(
+  process.env.HEALTH_CHATGPT_EXPECTED_TOOL_COUNT || '14'
+);
+
+function expectOauthDiscovery(body: unknown): string | null {
+  if (!body || typeof body !== 'object') return 'response is not an object';
+  const o = body as Record<string, unknown>;
+  const required = ['issuer', 'authorization_endpoint', 'token_endpoint', 'registration_endpoint'];
+  for (const field of required) {
+    if (typeof o[field] !== 'string' || !o[field]) return `missing field: ${field}`;
+  }
+  return null;
+}
+
+function expectProtectedResource(body: unknown): string | null {
+  if (!body || typeof body !== 'object') return 'response is not an object';
+  const o = body as Record<string, unknown>;
+  if (typeof o.resource !== 'string' || !o.resource) return 'missing field: resource';
+  return null;
+}
+
+function expectClaudeHealth(body: unknown): string | null {
+  if (!body || typeof body !== 'object') return 'response is not an object';
+  const o = body as Record<string, unknown>;
+  if (o.status !== 'ok') return `status is not "ok" (got ${JSON.stringify(o.status)})`;
+  return null;
+}
+
+function checks(): CheckDefinition[] {
+  return [
+    // ─── ChatGPT MCP ──────────────────────────────────────────────────────────
+    { connector: 'chatgpt', checkType: 'landing', target: `${HOLDED_PUBLIC_URL}/conectores/chatgpt`, probe: { kind: 'get' } },
+    { connector: 'chatgpt', checkType: 'docs', target: `${HOLDED_PUBLIC_URL}/conectores/chatgpt/docs`, probe: { kind: 'get' } },
+    { connector: 'chatgpt', checkType: 'privacy', target: `${HOLDED_PUBLIC_URL}/conectores/chatgpt/privacy`, probe: { kind: 'get' } },
+    { connector: 'chatgpt', checkType: 'terms', target: `${HOLDED_PUBLIC_URL}/conectores/chatgpt/terms`, probe: { kind: 'get' } },
+    { connector: 'chatgpt', checkType: 'dpa', target: `${HOLDED_PUBLIC_URL}/conectores/chatgpt/dpa`, probe: { kind: 'get' } },
+    {
+      connector: 'chatgpt',
+      checkType: 'oauth_discovery',
+      target: `${HOLDED_PUBLIC_URL}/.well-known/oauth-authorization-server`,
+      probe: { kind: 'json_get', validate: expectOauthDiscovery },
+    },
+    {
+      connector: 'chatgpt',
+      checkType: 'protected_resource',
+      target: `${HOLDED_PUBLIC_URL}/.well-known/oauth-protected-resource/api/mcp/holded`,
+      probe: { kind: 'json_get', validate: expectProtectedResource },
+    },
+    {
+      connector: 'chatgpt',
+      checkType: 'mcp_initialize',
+      target: CHATGPT_MCP_URL,
+      probe: {
+        kind: 'json_rpc_post',
+        body: { jsonrpc: '2.0', id: 1, method: 'initialize' },
+        validate: (body) => {
+          const o = body as { result?: { serverInfo?: { name?: string } } };
+          const name = o?.result?.serverInfo?.name;
+          if (typeof name !== 'string' || !name)
+            return { error: 'missing_field', message: 'result.serverInfo.name missing', metadata: null };
+          return { error: null, message: null, metadata: { serverName: name } };
+        },
+      },
+    },
+    {
+      connector: 'chatgpt',
+      checkType: 'tools_list',
+      target: CHATGPT_MCP_URL,
+      probe: {
+        kind: 'json_rpc_post',
+        body: { jsonrpc: '2.0', id: 2, method: 'tools/list' },
+        validate: (body) => {
+          const o = body as { result?: { tools?: unknown[] } };
+          const tools = o?.result?.tools;
+          if (!Array.isArray(tools))
+            return { error: 'missing_field', message: 'result.tools is not an array', metadata: null };
+          if (tools.length !== CHATGPT_EXPECTED_TOOL_COUNT)
+            return {
+              error: 'tool_count_mismatch',
+              message: `expected ${CHATGPT_EXPECTED_TOOL_COUNT} tools, got ${tools.length}`,
+              metadata: { toolCount: tools.length, expected: CHATGPT_EXPECTED_TOOL_COUNT },
+            };
+          return { error: null, message: null, metadata: { toolCount: tools.length } };
+        },
+      },
+    },
+
+    // ─── Claude MCP ────────────────────────────────────────────────────────────
+    { connector: 'claude', checkType: 'landing', target: `${CLAUDE_PUBLIC_URL}/`, probe: { kind: 'get' } },
+    {
+      connector: 'claude',
+      checkType: 'health',
+      target: `${CLAUDE_PUBLIC_URL}/health`,
+      probe: { kind: 'json_get', validate: expectClaudeHealth },
+    },
+    { connector: 'claude', checkType: 'docs', target: `${HOLDED_PUBLIC_URL}/conectores/claude/docs`, probe: { kind: 'get' } },
+    { connector: 'claude', checkType: 'privacy', target: `${HOLDED_PUBLIC_URL}/conectores/claude/privacy`, probe: { kind: 'get' } },
+    { connector: 'claude', checkType: 'terms', target: `${HOLDED_PUBLIC_URL}/conectores/claude/terms`, probe: { kind: 'get' } },
+    { connector: 'claude', checkType: 'dpa', target: `${HOLDED_PUBLIC_URL}/conectores/claude/dpa`, probe: { kind: 'get' } },
+    {
+      connector: 'claude',
+      checkType: 'oauth_discovery',
+      target: `${CLAUDE_PUBLIC_URL}/.well-known/oauth-authorization-server`,
+      probe: { kind: 'json_get', validate: expectOauthDiscovery },
+    },
+    {
+      connector: 'claude',
+      checkType: 'protected_resource',
+      target: `${CLAUDE_PUBLIC_URL}/.well-known/oauth-protected-resource`,
+      probe: { kind: 'json_get', validate: expectProtectedResource },
+    },
+    {
+      connector: 'claude',
+      checkType: 'mcp_requires_auth',
+      target: CLAUDE_MCP_URL,
+      probe: {
+        kind: 'json_rpc_post',
+        body: { jsonrpc: '2.0', id: 1, method: 'tools/list' },
+        expectStatus: 401, // Claude MCP requires Bearer for any method
+        validate: () => ({ error: null, message: null, metadata: null }),
+      },
+    },
+  ];
+}
+
+async function runProbe(def: CheckDefinition): Promise<HealthCheckResult> {
+  const timeoutMs = def.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const degradedAboveMs = def.degradedAboveMs ?? DEFAULT_DEGRADED_ABOVE_MS;
+  const startedAt = Date.now();
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+
+  const base = {
+    connector: def.connector,
+    checkType: def.checkType,
+    target: def.target,
+  } as const;
+
+  try {
+    let response: Response;
+    if (def.probe.kind === 'get' || def.probe.kind === 'json_get') {
+      response = await fetch(def.target, {
+        method: 'GET',
+        headers: { Accept: 'application/json,text/html;q=0.9,*/*;q=0.1' },
+        redirect: 'follow',
+        signal: ctrl.signal,
+        cache: 'no-store',
+      });
+    } else {
+      response = await fetch(def.target, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify(def.probe.body),
+        redirect: 'manual',
+        signal: ctrl.signal,
+        cache: 'no-store',
+      });
+    }
+
+    const latencyMs = Date.now() - startedAt;
+    const expectStatus =
+      def.probe.kind === 'json_rpc_post' ? def.probe.expectStatus ?? 200 : def.probe.expectStatus ?? 200;
+
+    if (response.status !== expectStatus) {
+      return {
+        ...base,
+        status: 'fail',
+        latencyMs,
+        httpStatus: response.status,
+        errorCode: 'non_2xx',
+        errorMessage: `expected HTTP ${expectStatus}, got ${response.status}`,
+        metadata: null,
+      };
+    }
+
+    if (def.probe.kind === 'get') {
+      return {
+        ...base,
+        status: latencyMs > degradedAboveMs ? 'degraded' : 'ok',
+        latencyMs,
+        httpStatus: response.status,
+        errorCode: null,
+        errorMessage: null,
+        metadata: latencyMs > degradedAboveMs ? { reason: 'slow_response', thresholdMs: degradedAboveMs } : null,
+      };
+    }
+
+    const text = await response.text();
+    let body: unknown;
+    try {
+      body = text ? JSON.parse(text) : null;
+    } catch {
+      return {
+        ...base,
+        status: 'fail',
+        latencyMs,
+        httpStatus: response.status,
+        errorCode: 'invalid_json',
+        errorMessage: `response body is not valid JSON (first 80 chars: ${text.slice(0, 80)})`,
+        metadata: null,
+      };
+    }
+
+    if (def.probe.kind === 'json_get') {
+      const issue = def.probe.validate(body);
+      if (issue) {
+        return {
+          ...base,
+          status: 'fail',
+          latencyMs,
+          httpStatus: response.status,
+          errorCode: 'missing_field',
+          errorMessage: issue,
+          metadata: null,
+        };
+      }
+      return {
+        ...base,
+        status: latencyMs > degradedAboveMs ? 'degraded' : 'ok',
+        latencyMs,
+        httpStatus: response.status,
+        errorCode: null,
+        errorMessage: null,
+        metadata: latencyMs > degradedAboveMs ? { reason: 'slow_response', thresholdMs: degradedAboveMs } : null,
+      };
+    }
+
+    // json_rpc_post
+    const validation = def.probe.validate(body);
+    if (validation.error) {
+      return {
+        ...base,
+        status: 'fail',
+        latencyMs,
+        httpStatus: response.status,
+        errorCode: validation.error,
+        errorMessage: validation.message,
+        metadata: validation.metadata ?? null,
+      };
+    }
+    return {
+      ...base,
+      status: latencyMs > degradedAboveMs ? 'degraded' : 'ok',
+      latencyMs,
+      httpStatus: response.status,
+      errorCode: null,
+      errorMessage: null,
+      metadata: validation.metadata ?? null,
+    };
+  } catch (err) {
+    const latencyMs = Date.now() - startedAt;
+    const isAbort = err instanceof Error && err.name === 'AbortError';
+    return {
+      ...base,
+      status: 'fail',
+      latencyMs,
+      httpStatus: null,
+      errorCode: isAbort ? 'timeout' : 'network',
+      errorMessage: err instanceof Error ? err.message : String(err),
+      metadata: null,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function runAllConnectorHealthChecks(): Promise<HealthCheckResult[]> {
+  const defs = checks();
+  return Promise.all(defs.map((def) => runProbe(def)));
+}
+
+export function getCheckDefinitions(): ReadonlyArray<{
+  connector: ConnectorId;
+  checkType: string;
+  target: string;
+}> {
+  return checks().map(({ connector, checkType, target }) => ({ connector, checkType, target }));
+}

--- a/apps/app/vercel.json
+++ b/apps/app/vercel.json
@@ -2,5 +2,11 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "installCommand": "node scripts/vercel-install.mjs",
   "buildCommand": "pnpm run build",
-  "framework": "nextjs"
+  "framework": "nextjs",
+  "crons": [
+    {
+      "path": "/api/cron/connector-health",
+      "schedule": "*/5 * * * *"
+    }
+  ]
 }

--- a/apps/holded/app/components/ConnectorStatusBadge.tsx
+++ b/apps/holded/app/components/ConnectorStatusBadge.tsx
@@ -1,0 +1,273 @@
+/**
+ * Widget público de estado del conector — Fase 1 / Opción B.
+ *
+ * Server Component: hace fetch del endpoint público
+ * /api/public/status/{connector} de apps/app y renderiza:
+ *
+ *   1. Badge compacto (semáforo + texto + "última comprobación hace X" + 24h uptime)
+ *   2. <details>/<summary> colapsable con la tabla por check
+ *
+ * Diseño defensivo: si el fetch falla, renderiza un badge neutro ("Estado
+ * desconocido") en vez de romper el render de la landing.
+ *
+ * Cache: `next.revalidate = 60` empata con el edge cache del endpoint público
+ * (s-maxage=60, SWR=300). La granularidad real del estado es 5 min (cron).
+ */
+
+import { Activity, AlertTriangle, CheckCircle2, ChevronDown, HelpCircle, XCircle } from 'lucide-react';
+
+const APP_BASE_URL =
+  process.env.NEXT_PUBLIC_VERIFACTU_APP_URL?.trim() || 'https://app.verifactu.business';
+
+type CheckStatus = 'ok' | 'degraded' | 'fail' | 'unknown';
+
+type Check = {
+  checkType: string;
+  target: string;
+  status: CheckStatus;
+  latencyMs: number | null;
+  httpStatus: number | null;
+  lastCheckedAt: string | null;
+  lastErrorCode: string | null;
+  lastErrorMessage: string | null;
+  uptime24hPct: number | null;
+  latencyP95Ms24h: number | null;
+  lastFailedAt: string | null;
+  sampleCount24h: number;
+};
+
+type StatusResponse = {
+  connector: 'chatgpt' | 'claude';
+  overall: 'operational' | 'degraded' | 'down' | 'unknown';
+  lastCheckedAt: string | null;
+  checksTotal?: number;
+  checksOk?: number;
+  checksDegraded?: number;
+  checksFail?: number;
+  overallUptime24hPct: number | null;
+  checks: Check[];
+  error?: string;
+};
+
+const CHECK_TYPE_LABEL_ES: Record<string, string> = {
+  landing: 'Página de aterrizaje',
+  docs: 'Documentación',
+  privacy: 'Política de privacidad',
+  terms: 'Términos del servicio',
+  dpa: 'Acuerdo de tratamiento (DPA)',
+  health: 'Health endpoint',
+  oauth_discovery: 'OAuth discovery',
+  protected_resource: 'Protected resource metadata',
+  mcp_initialize: 'MCP initialize',
+  tools_list: 'MCP tools/list',
+  mcp_requires_auth: 'MCP rechaza sin Bearer',
+};
+
+const CONNECTOR_LABEL: Record<'chatgpt' | 'claude', string> = {
+  chatgpt: 'ChatGPT',
+  claude: 'Claude',
+};
+
+function formatRelative(iso: string | null): string {
+  if (!iso) return 'sin datos todavía';
+  const diffMs = Date.now() - new Date(iso).getTime();
+  if (diffMs < 0) return 'ahora mismo';
+  const minutes = Math.floor(diffMs / 60_000);
+  if (minutes < 1) return 'hace menos de 1 min';
+  if (minutes < 60) return `hace ${minutes} min`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `hace ${hours} h`;
+  const days = Math.floor(hours / 24);
+  return `hace ${days} d`;
+}
+
+function formatLatency(ms: number | null): string {
+  if (ms === null || ms === undefined) return '—';
+  if (ms < 1000) return `${ms} ms`;
+  return `${(ms / 1000).toFixed(1)} s`;
+}
+
+function formatUptime(pct: number | null): string {
+  if (pct === null || pct === undefined) return '—';
+  return `${pct.toFixed(1)}%`;
+}
+
+const OVERALL_STYLES = {
+  operational: {
+    label: 'Conector operativo',
+    pill: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+    dot: 'bg-emerald-500',
+    icon: CheckCircle2,
+    iconClass: 'text-emerald-600',
+  },
+  degraded: {
+    label: 'Conector con latencia elevada',
+    pill: 'border-amber-200 bg-amber-50 text-amber-700',
+    dot: 'bg-amber-500',
+    icon: AlertTriangle,
+    iconClass: 'text-amber-600',
+  },
+  down: {
+    label: 'Conector con incidencias',
+    pill: 'border-rose-200 bg-rose-50 text-rose-700',
+    dot: 'bg-rose-500',
+    icon: XCircle,
+    iconClass: 'text-rose-600',
+  },
+  unknown: {
+    label: 'Estado desconocido',
+    pill: 'border-slate-200 bg-slate-50 text-slate-600',
+    dot: 'bg-slate-400',
+    icon: HelpCircle,
+    iconClass: 'text-slate-500',
+  },
+} as const;
+
+const CHECK_DOT: Record<CheckStatus, string> = {
+  ok: 'bg-emerald-500',
+  degraded: 'bg-amber-500',
+  fail: 'bg-rose-500',
+  unknown: 'bg-slate-300',
+};
+
+async function fetchStatus(connector: 'chatgpt' | 'claude'): Promise<StatusResponse | null> {
+  try {
+    const res = await fetch(`${APP_BASE_URL}/api/public/status/${connector}`, {
+      next: { revalidate: 60 },
+      headers: { Accept: 'application/json' },
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as StatusResponse;
+  } catch {
+    return null;
+  }
+}
+
+export async function ConnectorStatusBadge({
+  connector,
+}: {
+  connector: 'chatgpt' | 'claude';
+}) {
+  const status = await fetchStatus(connector);
+  const overall = (status?.overall ?? 'unknown') as keyof typeof OVERALL_STYLES;
+  const styles = OVERALL_STYLES[overall];
+  const Icon = styles.icon;
+  const connectorLabel = CONNECTOR_LABEL[connector];
+
+  const lastCheckedLabel = formatRelative(status?.lastCheckedAt ?? null);
+  const uptime = status?.overallUptime24hPct;
+
+  return (
+    <section
+      aria-label={`Estado del conector ${connectorLabel}`}
+      className="mx-auto max-w-5xl px-4 sm:px-6"
+    >
+      <div className={`flex flex-col gap-3 rounded-2xl border p-4 ${styles.pill}`}>
+        {/* ── Resumen compacto ── */}
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-3">
+            <span className={`inline-flex h-2.5 w-2.5 shrink-0 rounded-full ${styles.dot}`} aria-hidden />
+            <Icon className={`h-5 w-5 shrink-0 ${styles.iconClass}`} aria-hidden />
+            <div>
+              <p className="text-sm font-semibold leading-snug">
+                {styles.label} — {connectorLabel} ↔ Holded
+              </p>
+              <p className="mt-0.5 text-xs leading-snug opacity-80">
+                Última comprobación {lastCheckedLabel}
+                {uptime !== null && uptime !== undefined ? ` · ${formatUptime(uptime)} de uptime en 24 h` : ''}
+              </p>
+            </div>
+          </div>
+
+          {status && status.checksTotal !== undefined && (
+            <div className="flex flex-wrap items-center gap-2 text-xs">
+              <span className="inline-flex items-center gap-1 rounded-full bg-white/60 px-2 py-0.5 font-medium">
+                <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" aria-hidden />
+                {status.checksOk ?? 0} OK
+              </span>
+              {(status.checksDegraded ?? 0) > 0 && (
+                <span className="inline-flex items-center gap-1 rounded-full bg-white/60 px-2 py-0.5 font-medium">
+                  <span className="h-1.5 w-1.5 rounded-full bg-amber-500" aria-hidden />
+                  {status.checksDegraded} degradados
+                </span>
+              )}
+              {(status.checksFail ?? 0) > 0 && (
+                <span className="inline-flex items-center gap-1 rounded-full bg-white/60 px-2 py-0.5 font-medium">
+                  <span className="h-1.5 w-1.5 rounded-full bg-rose-500" aria-hidden />
+                  {status.checksFail} con fallo
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* ── Detalle colapsable ── */}
+        {status?.checks && status.checks.length > 0 && (
+          <details className="group rounded-xl bg-white/60">
+            <summary className="flex cursor-pointer list-none items-center justify-between gap-2 rounded-xl px-3 py-2 text-xs font-medium opacity-80 hover:bg-white/80 hover:opacity-100">
+              <span className="inline-flex items-center gap-1.5">
+                <Activity className="h-3.5 w-3.5" aria-hidden />
+                Ver detalle por check
+              </span>
+              <ChevronDown
+                className="h-4 w-4 transition-transform group-open:rotate-180"
+                aria-hidden
+              />
+            </summary>
+            <div className="overflow-x-auto px-3 pb-3">
+              <table className="w-full min-w-[520px] text-left text-xs">
+                <thead className="text-[10px] uppercase tracking-wider opacity-70">
+                  <tr>
+                    <th className="px-2 py-1.5 font-semibold">Surface check</th>
+                    <th className="px-2 py-1.5 font-semibold">Estado</th>
+                    <th className="px-2 py-1.5 font-semibold text-right">Latencia</th>
+                    <th className="px-2 py-1.5 font-semibold text-right">Uptime 24 h</th>
+                    <th className="px-2 py-1.5 font-semibold text-right whitespace-nowrap">Última caída</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-white/40">
+                  {status.checks.map((check) => (
+                    <tr key={check.checkType}>
+                      <td className="px-2 py-1.5">
+                        <span className="font-medium">
+                          {CHECK_TYPE_LABEL_ES[check.checkType] ?? check.checkType}
+                        </span>
+                      </td>
+                      <td className="px-2 py-1.5">
+                        <span className="inline-flex items-center gap-1.5">
+                          <span
+                            className={`inline-flex h-2 w-2 rounded-full ${CHECK_DOT[check.status]}`}
+                            aria-hidden
+                          />
+                          <span className="capitalize">{check.status}</span>
+                          {check.status === 'fail' && check.lastErrorCode && (
+                            <span className="rounded bg-rose-100 px-1.5 py-0.5 text-[10px] font-medium text-rose-700">
+                              {check.lastErrorCode}
+                            </span>
+                          )}
+                        </span>
+                      </td>
+                      <td className="px-2 py-1.5 text-right tabular-nums">
+                        {formatLatency(check.latencyMs)}
+                      </td>
+                      <td className="px-2 py-1.5 text-right tabular-nums">
+                        {formatUptime(check.uptime24hPct)}
+                      </td>
+                      <td className="px-2 py-1.5 text-right tabular-nums whitespace-nowrap opacity-70">
+                        {check.lastFailedAt ? formatRelative(check.lastFailedAt) : '—'}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              <p className="mt-2 text-[10px] leading-relaxed opacity-60">
+                Checks ejecutados cada 5 minutos contra superficie pública (sin token). Uptime
+                calculado sobre las últimas 24 h. Cache del endpoint público 60 s.
+              </p>
+            </div>
+          </details>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/holded/app/conectores/chatgpt/docs/page.tsx
+++ b/apps/holded/app/conectores/chatgpt/docs/page.tsx
@@ -28,6 +28,7 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 
 import { ConnectorPageHero, ConnectorPageShell } from '@/app/components/ConnectorPageShell';
+import { ConnectorStatusBadge } from '@/app/components/ConnectorStatusBadge';
 
 export const metadata: Metadata = {
   title: 'Documentación | Conector Holded para ChatGPT — Verifactu Business',
@@ -193,6 +194,9 @@ const SECURITY_HIGHLIGHTS: ReadonlyArray<readonly [string, string]> = [
 export default function ChatGPTDocsPage() {
   return (
     <ConnectorPageShell provider="chatgpt" kind="docs">
+      <div className="pb-6">
+        <ConnectorStatusBadge connector="chatgpt" />
+      </div>
       <ConnectorPageHero
         provider="chatgpt"
         badgeIcon={<MessageSquare className="h-4 w-4" />}

--- a/apps/holded/app/conectores/chatgpt/page.tsx
+++ b/apps/holded/app/conectores/chatgpt/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { ConnectorLandingClient } from '@/app/components/ConnectorLandingClient';
+import { ConnectorStatusBadge } from '@/app/components/ConnectorStatusBadge';
 import { ConnectorMobileBanner } from '@/app/components/ConnectorMobileBanner';
 import { getFaqJsonLd } from '@/app/components/ConnectorFAQData';
 
@@ -168,6 +169,9 @@ export default function ChatGPTConnectorPage() {
       {/* F4.3: banner mobile-only que invita a usar /auth/holded-direct
           (sobrevive al iOS in-app browser de ChatGPT mobile). */}
       <ConnectorMobileBanner provider="chatgpt" />
+      <div className="pt-6">
+        <ConnectorStatusBadge connector="chatgpt" />
+      </div>
       <ConnectorLandingClient connector="chatgpt" />
     </>
   );

--- a/apps/holded/app/conectores/claude/docs/page.tsx
+++ b/apps/holded/app/conectores/claude/docs/page.tsx
@@ -17,6 +17,7 @@ import {
 } from 'lucide-react';
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { ConnectorStatusBadge } from '@/app/components/ConnectorStatusBadge';
 
 export const metadata: Metadata = {
   title: 'Documentación | Conector Holded para Claude — Verifactu Business',
@@ -229,6 +230,9 @@ const realUsageExamples = [
 export default function ClaudeDocsPage() {
   return (
     <main className="page-enter min-h-screen bg-[linear-gradient(180deg,#ffffff_0%,#fffbf0_45%,#ffffff_100%)] text-slate-900">
+      <div className="pt-8">
+        <ConnectorStatusBadge connector="claude" />
+      </div>
       <section className="mx-auto max-w-5xl px-4 py-16">
         {/* ── Header ── */}
         <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">

--- a/apps/holded/app/conectores/claude/page.tsx
+++ b/apps/holded/app/conectores/claude/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { ConnectorLandingClient } from '@/app/components/ConnectorLandingClient';
+import { ConnectorStatusBadge } from '@/app/components/ConnectorStatusBadge';
 import { ConnectorMobileBanner } from '@/app/components/ConnectorMobileBanner';
 import { getFaqJsonLd } from '@/app/components/ConnectorFAQData';
 
@@ -169,6 +170,9 @@ export default function ClaudeConnectorPage() {
       {/* F4.3: banner mobile-only que invita a usar /auth/holded-direct
           (sobrevive al iOS in-app browser de Claude mobile). */}
       <ConnectorMobileBanner provider="claude" />
+      <div className="pt-6">
+        <ConnectorStatusBadge connector="claude" />
+      </div>
       <ConnectorLandingClient connector="claude" />
     </>
   );

--- a/packages/db/prisma/migrations/20260516120000_add_connector_health_check/migration.sql
+++ b/packages/db/prisma/migrations/20260516120000_add_connector_health_check/migration.sql
@@ -1,0 +1,22 @@
+-- CreateTable
+CREATE TABLE "connector_health_checks" (
+    "id" TEXT NOT NULL,
+    "connector" VARCHAR(32) NOT NULL,
+    "check_type" VARCHAR(64) NOT NULL,
+    "target" TEXT NOT NULL,
+    "status" VARCHAR(16) NOT NULL,
+    "latency_ms" INTEGER NOT NULL,
+    "http_status" INTEGER,
+    "error_code" VARCHAR(64),
+    "error_message" TEXT,
+    "metadata" JSONB,
+    "checked_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "connector_health_checks_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "connector_health_checks_connector_check_type_checked_at_idx" ON "connector_health_checks"("connector", "check_type", "checked_at" DESC);
+
+-- CreateIndex
+CREATE INDEX "connector_health_checks_checked_at_idx" ON "connector_health_checks"("checked_at" DESC);

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -2259,3 +2259,34 @@ model HoldedMcpPatAuditLog {
   @@index([patId])
   @@map("holded_mcp_pat_audit_logs")
 }
+
+/// Health check periódico de los conectores MCP (ChatGPT, Claude) ejecutado
+/// por Vercel Cron contra superficie pública (sin token). Alimenta el widget
+/// de estado en /conectores/{chatgpt,claude}.
+model ConnectorHealthCheck {
+  id           String   @id @default(cuid())
+  /// "chatgpt" | "claude"
+  connector    String   @db.VarChar(32)
+  /// Tipo de check: "landing" | "oauth_discovery" | "protected_resource"
+  /// | "mcp_initialize" | "tools_list" | "docs_page" | "privacy_page" | "terms_page" | "dpa_page"
+  checkType    String   @map("check_type") @db.VarChar(64)
+  /// URL exacta que se probó (para auditoría)
+  target       String   @db.Text
+  /// "ok" | "degraded" | "fail"
+  status       String   @db.VarChar(16)
+  /// Latencia de la petición en ms
+  latencyMs    Int      @map("latency_ms")
+  /// HTTP status code (null si error de red/timeout)
+  httpStatus   Int?     @map("http_status")
+  /// Código corto de error: "timeout" | "non_2xx" | "invalid_json" | "missing_field" | "tool_count_mismatch" | "rpc_error"
+  errorCode    String?  @map("error_code") @db.VarChar(64)
+  /// Mensaje legible del error (resumido, sin stack)
+  errorMessage String?  @map("error_message") @db.Text
+  /// Metadatos extra: { toolCount, expectedToolCount, oauthIssuer, etc. }
+  metadata     Json?
+  checkedAt    DateTime @default(now()) @map("checked_at") @db.Timestamptz
+
+  @@index([connector, checkType, checkedAt(sort: Desc)])
+  @@index([checkedAt(sort: Desc)])
+  @@map("connector_health_checks")
+}


### PR DESCRIPTION
## Summary

Sistema de **monitorización pública** de los conectores ChatGPT-Holded y Claude-Holded, con widget de estado embebido en sus landings y cron ejecutándose cada 5 min.

**Fase 1 / Opción B** acordada con el usuario:
- Cubre toda la superficie pública (sin tokens necesarios)
- Widget compacto + detalle colapsable en cada landing
- 18 checks (9 por conector): landing, docs, privacy, terms, dpa, OAuth discovery, protected-resource metadata, MCP initialize/tools-list (ChatGPT) o requires-auth (Claude), health endpoint (Claude)

## Componentes

| Pieza | Archivo |
|---|---|
| Modelo Prisma `ConnectorHealthCheck` | `packages/db/prisma/schema.prisma` + migración |
| Definición de checks declarativa | `apps/app/lib/connectorHealth/checks.ts` |
| Vercel Cron handler (POST) | `apps/app/app/api/cron/connector-health/route.ts` |
| Endpoint público (GET, edge-cached 60s + SWR 300s) | `apps/app/app/api/public/status/[connector]/route.ts` |
| Server component badge + detalle colapsable | `apps/holded/app/components/ConnectorStatusBadge.tsx` |
| Schedule | `apps/app/vercel.json` → `*/5 * * * *` |

## UI

**Widget compacto** (siempre visible en lo alto de cada landing):
```
🟢 Conector operativo — ChatGPT ↔ Holded
   Última comprobación hace 2 min · 99.7% de uptime en 24 h

   ● 9 OK     [Ver detalle por check ▾]
```

**Detalle colapsable** (click en "Ver detalle"):
| Surface check | Estado | Latencia | Uptime 24 h | Última caída |
|---|---|---|---|---|
| Página de aterrizaje | ● ok | 120 ms | 100% | — |
| OAuth discovery | ● ok | 85 ms | 99.8% | hace 8 h |
| MCP initialize | ● ok | 210 ms | 100% | — |
| MCP tools/list | ● ok | 180 ms | 100% | — |
| Privacy / Terms / DPA | ● ok | 90 ms avg | 100% | — |
| … | | | | |

**Defensivo:** si el fetch del status falla, renderiza badge "Estado desconocido" sin tirar la landing. Si la DB falla, el endpoint devuelve 200 con `overall: unknown` por el mismo motivo.

## Embed en landings

- `/conectores/chatgpt` ✅
- `/conectores/chatgpt/docs` ✅
- `/conectores/claude` ✅
- `/conectores/claude/docs` ✅

## Env vars a configurar en Vercel

**Obligatoria en producción** para apps/app:
- `CRON_SECRET` (mismo formato que la existente `/api/cron`)

**Opcionales** (defaults sensatos):
- `HEALTH_CHATGPT_EXPECTED_TOOL_COUNT` = `14` (matches manifest)
- `HEALTH_HOLDED_PUBLIC_URL`, `HEALTH_CHATGPT_MCP_URL`, `HEALTH_CLAUDE_PUBLIC_URL`, `HEALTH_CLAUDE_MCP_URL` (para staging)

**Para apps/holded:**
- `NEXT_PUBLIC_VERIFACTU_APP_URL` = `https://app.verifactu.business` (default si no se setea)

## Test plan

- [x] `pnpm --filter verifactu-app test -- --runInBand --runTestsByPath app/api/cron/connector-health/route.test.ts` → 7 pass
- [x] `pnpm --filter verifactu-app test -- --runInBand 'public/status'` → 8 pass
- [x] `pnpm --filter verifactu-app exec tsc --noEmit` → 0 errors
- [x] Migración Prisma generada y `prisma generate` ejecutado
- [ ] **Post-deploy**: el primer cron tick poblará `connector_health_checks`; el widget pasará de "Estado desconocido" a "Operativo" automáticamente en ~5 min.

## Pendientes (Fase 2)

- PAT del demo tenant + tool-level checks autenticados (validar tool calls reales)
- Página dedicada `/status` con histórico 30d + gráficos de latencia
- Alertas email a soporte cuando un check falla >15 min seguidos

🤖 Generated with [Claude Code](https://claude.com/claude-code)