### PR TITLE
fix(oauth): sincronizar metadata proxy apps/holded (refresh_token + revoke + 6 scopes)

### DIFF
--- a/apps/app/app/oauth/consent/page.tsx
+++ b/apps/app/app/oauth/consent/page.tsx
@@ -45,6 +45,11 @@ const SCOPE_DESCRIPTIONS: Record<string, { label: string; description: string }>
     description:
       'Crear borradores (DRAFT) de factura — nunca emitir, enviar o cobrar — con tu confirmación explícita en cada uso.',
   },
+  'holded.documents.read': {
+    label: 'Leer tus documentos comerciales',
+    description:
+      'Listar y consultar facturas de compra, presupuestos, albaranes, abonos y otros documentos. Incluye descargar el PDF para revisión. Solo lectura, sin enviar ni modificar.',
+  },
   'holded.contacts.read': {
     label: 'Leer tus contactos',
     description:
@@ -161,10 +166,10 @@ export default async function OAuthConsentPage({
   }
 
   // Defense in depth: la lista que mostramos es siempre la intersección de los
-  // scopes solicitados con el preset público activo (`claude_parity` desde
-  // 2026-05-18). Aunque /oauth/authorize ya hace el clamp, lo replicamos aquí
-  // para que NUNCA se muestre al usuario un permiso que el servidor no vaya a
-  // conceder realmente.
+  // scopes solicitados con el preset público activo (`openai_review_invoicing_v1`
+  // desde 2026-05-18 tarde, 6 scopes para 10 tools). Aunque /oauth/authorize ya
+  // hace el clamp, lo replicamos aquí para que NUNCA se muestre al usuario un
+  // permiso que el servidor no vaya a conceder realmente.
   const publicPresetScopes = getHoldedMcpScopePreset(getPublicScopePreset());
   const requestedScopeList = requestedScope
     .split(/[\s,]+/)

--- a/apps/app/app/workflows/email-steps.ts
+++ b/apps/app/app/workflows/email-steps.ts
@@ -8,7 +8,11 @@ import { Resend } from 'resend';
 import { query } from '@/lib/db';
 import { getPreferredFirstName } from '@/lib/personName';
 
-const resend = new Resend(process.env.RESEND_API_KEY);
+let _resend: Resend | null = null;
+function getResend() {
+  if (!_resend) _resend = new Resend(process.env.RESEND_API_KEY);
+  return _resend;
+}
 const ADMIN_NOTIFICATION_EMAIL =
   process.env.SUPPORT_NOTIFICATION_EMAIL?.trim() || 'support@verifactu.business';
 
@@ -59,7 +63,7 @@ export async function sendWelcomeEmail(
   const greetingName = getPreferredFirstName({ fullName: userName, email });
 
   try {
-    const resp = await resend.emails.send({
+    const resp = await getResend().emails.send({
       from: 'Soporte Verifactu <soporte@verifactu.business>',
       to: [email],
       subject: '¡Bienvenido a Verifactu!',
@@ -106,7 +110,7 @@ export async function sendWelcomeAdminNotification(
   const tenantDisplayName = buildTenantDisplayName(context || {});
 
   try {
-    const resp = await resend.emails.send({
+    const resp = await getResend().emails.send({
       from: 'Soporte Verifactu <soporte@verifactu.business>',
       to: [ADMIN_NOTIFICATION_EMAIL],
       subject: 'Nuevo usuario en Verifactu',
@@ -171,7 +175,7 @@ export async function sendAutoReplyEmail(toEmail: string, senderName: string) {
   'use step';
 
   try {
-    const resp = await resend.emails.send({
+    const resp = await getResend().emails.send({
       from: 'Soporte Verifactu <soporte@verifactu.business>',
       to: [toEmail],
       subject: 'Re: Tu mensaje fue recibido',
@@ -203,7 +207,7 @@ export async function sendFollowUpEmail(email: string, subject: string, message:
   'use step';
 
   try {
-    const resp = await resend.emails.send({
+    const resp = await getResend().emails.send({
       from: 'Soporte Verifactu <soporte@verifactu.business>',
       to: [email],
       subject: subject,

--- a/apps/holded/app/.well-known/oauth-authorization-server/route.test.ts
+++ b/apps/holded/app/.well-known/oauth-authorization-server/route.test.ts
@@ -1,0 +1,69 @@
+/** @jest-environment node */
+
+import { NextRequest } from 'next/server';
+import { GET } from './route';
+
+describe('GET /.well-known/oauth-authorization-server (holded.verifactu.business)', () => {
+  it('declares the issuer, all OAuth endpoints, and the revocation endpoint', async () => {
+    const request = new NextRequest(
+      'https://holded.verifactu.business/.well-known/oauth-authorization-server'
+    );
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.issuer).toBe('https://holded.verifactu.business');
+    expect(body.authorization_endpoint).toBe('https://holded.verifactu.business/oauth/authorize');
+    expect(body.token_endpoint).toBe('https://holded.verifactu.business/oauth/token');
+    expect(body.registration_endpoint).toBe('https://holded.verifactu.business/oauth/register');
+    expect(body.revocation_endpoint).toBe('https://holded.verifactu.business/oauth/revoke');
+  });
+
+  it('advertises both authorization_code AND refresh_token grant types', async () => {
+    // Regresión 2026-05-18: OpenAI ChatGPT DCR envía
+    // grant_types=[authorization_code, refresh_token] al guardar el form
+    // del connector. Si la metadata solo declara authorization_code, un
+    // cliente estricto refuerza client-side y rechaza el refresh_token.
+    // Mantener alineado con apps/app/app/.well-known/oauth-authorization-server.
+    const request = new NextRequest(
+      'https://holded.verifactu.business/.well-known/oauth-authorization-server'
+    );
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(body.grant_types_supported).toEqual(['authorization_code', 'refresh_token']);
+    expect(body.response_types_supported).toEqual(['code']);
+    expect(body.code_challenge_methods_supported).toEqual(['S256']);
+    expect(body.token_endpoint_auth_methods_supported).toEqual(['none']);
+  });
+
+  it('exposes default_scopes aligned with the openai_review_invoicing_v1 preset', async () => {
+    // Estos 6 scopes son el espejo de OPENAI_REVIEW_INVOICING_V1_SCOPE_SET
+    // en apps/app/lib/integrations/holdedMcpScopes.ts. Cubren las 10 tools
+    // expuestas en submission v2 a OpenAI (invoicing + contabilidad). Si
+    // cambia el preset público en apps/app, este test falla y obliga a
+    // sincronizar.
+    const request = new NextRequest(
+      'https://holded.verifactu.business/.well-known/oauth-authorization-server'
+    );
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(body.default_scopes).toEqual([
+      'mcp.read',
+      'holded.invoices.read',
+      'holded.invoices.write',
+      'holded.documents.read',
+      'holded.contacts.read',
+      'holded.accounts.read',
+    ]);
+  });
+
+  it('returns Cache-Control: no-store so OAuth metadata changes propagate immediately', async () => {
+    const request = new NextRequest(
+      'https://holded.verifactu.business/.well-known/oauth-authorization-server'
+    );
+    const response = await GET(request);
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+  });
+});

--- a/apps/holded/app/.well-known/oauth-authorization-server/route.ts
+++ b/apps/holded/app/.well-known/oauth-authorization-server/route.ts
@@ -29,7 +29,19 @@ const MCP_RESOURCE_PATH = '/api/mcp/holded';
 function getDefaultScopes() {
   const fromEnv = process.env.MCP_DEFAULT_SCOPES?.trim();
   if (fromEnv) return fromEnv.split(' ').filter(Boolean);
-  return ['mcp.read', 'holded.invoices.read'];
+  // Default scopes alineados con `openai_review_invoicing_v1` preset en
+  // apps/app (`OPENAI_REVIEW_INVOICING_V1_SCOPE_SET`). Estos 6 scopes
+  // cubren las 10 tools expuestas en submission v2 a OpenAI: invoicing
+  // (venta + compra) + contactos + contabilidad. Si cambia el preset
+  // público en apps/app, hay que actualizar este array.
+  return [
+    'mcp.read',
+    'holded.invoices.read',
+    'holded.invoices.write',
+    'holded.documents.read',
+    'holded.contacts.read',
+    'holded.accounts.read',
+  ];
 }
 
 // Full scope list — must match HOLDED_MCP_SUPPORTED_SCOPES in apps/app
@@ -86,11 +98,17 @@ function buildMetadata() {
     authorization_endpoint: `${HOLDED_APP_URL}/oauth/authorize`,
     token_endpoint: `${HOLDED_APP_URL}/oauth/token`,
     registration_endpoint: `${HOLDED_APP_URL}/oauth/register`,
+    // RFC 7009 token revocation endpoint, proxied to apps/app.
+    revocation_endpoint: `${HOLDED_APP_URL}/oauth/revoke`,
     // userinfo lives only on app domain (not proxied — called directly)
     userinfo_endpoint: `${APP_PUBLIC_URL}/oauth/userinfo`,
     scopes_supported: getAdvertisedScopes(),
     response_types_supported: ['code'],
-    grant_types_supported: ['authorization_code'],
+    // ChatGPT app review DCR sends grant_types=[authorization_code, refresh_token].
+    // The token endpoint in apps/app already supports both since 2026-05-12
+    // (commit 8af1973fc); this metadata must advertise them so OAuth clients
+    // know they can use refresh_token without re-registering. Fixed 2026-05-18.
+    grant_types_supported: ['authorization_code', 'refresh_token'],
     code_challenge_methods_supported: ['S256'],
     token_endpoint_auth_methods_supported: ['none'],
     service_documentation: `${HOLDED_APP_URL}/.well-known/oauth-authorization-server`,

--- a/apps/holded/app/.well-known/oauth-protected-resource/api/mcp/holded/route.test.ts
+++ b/apps/holded/app/.well-known/oauth-protected-resource/api/mcp/holded/route.test.ts
@@ -1,0 +1,48 @@
+/** @jest-environment node */
+
+import { NextRequest } from 'next/server';
+import { GET } from './route';
+
+describe('GET /.well-known/oauth-protected-resource/api/mcp/holded', () => {
+  it('declares the MCP resource and the authorization server', async () => {
+    const request = new NextRequest(
+      'https://holded.verifactu.business/.well-known/oauth-protected-resource/api/mcp/holded'
+    );
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.resource).toBe('https://holded.verifactu.business/api/mcp/holded');
+    expect(body.authorization_servers).toEqual(['https://holded.verifactu.business']);
+    expect(body.bearer_methods_supported).toEqual(['header']);
+  });
+
+  it('exposes exactly the 6 scopes of the openai_review_invoicing_v1 preset', async () => {
+    // Espejo de OPENAI_REVIEW_INVOICING_V1_SCOPE_SET en apps/app
+    // (lib/integrations/holdedMcpScopes.ts). Si cambia el preset público en
+    // apps/app, este test falla → forzar sincronización. Histórico
+    // 2026-05-18: antes incluía accounts.write, crm.read, projects.read
+    // (preset openai_review_v2 viejo, 14 tools); ahora estrechado a 6 scopes
+    // para 10 tools (invoicing venta+compra + contactos + contabilidad).
+    const request = new NextRequest(
+      'https://holded.verifactu.business/.well-known/oauth-protected-resource/api/mcp/holded'
+    );
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(body.scopes_supported).toEqual([
+      'mcp.read',
+      'holded.invoices.read',
+      'holded.invoices.write',
+      'holded.documents.read',
+      'holded.contacts.read',
+      'holded.accounts.read',
+    ]);
+
+    // Defensa adicional: ningún scope eliminado del preset debe aparecer aquí.
+    const REMOVED = ['holded.accounts.write', 'holded.crm.read', 'holded.projects.read'];
+    for (const scope of REMOVED) {
+      expect(body.scopes_supported).not.toContain(scope);
+    }
+  });
+});

--- a/apps/holded/app/.well-known/oauth-protected-resource/api/mcp/holded/route.ts
+++ b/apps/holded/app/.well-known/oauth-protected-resource/api/mcp/holded/route.ts
@@ -15,15 +15,20 @@ import { HOLDED_APP_URL } from '@/app/lib/holded-navigation';
 export const runtime = 'nodejs';
 
 const MCP_RESOURCE_PATH = '/api/mcp/holded';
+// Scopes alineados con el preset `openai_review_invoicing_v1` en apps/app
+// (OPENAI_REVIEW_INVOICING_V1_SCOPE_SET). Estos 6 scopes cubren las 10 tools
+// expuestas en submission v2 a OpenAI (invoicing venta+compra + contactos +
+// contabilidad). Si cambia el preset público, actualizar aquí también.
+// Histórico 2026-05-18: antes incluía `accounts.write`, `crm.read`,
+// `projects.read` (preset openai_review_v2 viejo, 14 tools); ahora estrechado
+// al set actual de 6 scopes.
 const SUPPORTED_SCOPES = [
   'mcp.read',
   'holded.invoices.read',
   'holded.invoices.write',
+  'holded.documents.read',
   'holded.contacts.read',
   'holded.accounts.read',
-  'holded.accounts.write',
-  'holded.crm.read',
-  'holded.projects.read',
 ];
 
 function getMetadata() {

--- a/apps/holded/app/oauth/revoke/route.ts
+++ b/apps/holded/app/oauth/revoke/route.ts
@@ -1,0 +1,36 @@
+/**
+ * OAuth token revocation proxy (RFC 7009).
+ *
+ * ChatGPT (and other compliant OAuth clients) call this endpoint when the
+ * user disconnects the connector to revoke refresh/access tokens. The actual
+ * RFC 7009 handler lives in apps/app (which knows the JWT signing key and
+ * the rate-limit store); this route is a thin proxy so the endpoint URL stays
+ * on the same domain as the rest of the OAuth metadata (holded.verifactu.business),
+ * which is what RFC 8414 §2 effectively requires for issuer alignment.
+ *
+ * Tokens are stateless JWTs, so revocation is best-effort per RFC 7009 §2.2 —
+ * the server always responds 200 regardless of whether the token is recognized.
+ *
+ * Required env var (optional — falls back to public URL):
+ *   APP_OAUTH_INTERNAL_URL  internal base URL of apps/app OAuth endpoints
+ */
+
+import { proxyUpstream } from '@/app/lib/oauth-proxy';
+import { APP_PUBLIC_URL } from '@/app/lib/holded-navigation';
+import { NextRequest } from 'next/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function getRevokeUrl() {
+  return `${process.env.APP_OAUTH_INTERNAL_URL?.trim() || APP_PUBLIC_URL}/oauth/revoke`;
+}
+
+export async function POST(request: NextRequest) {
+  const body = await request.text();
+  return proxyUpstream(request, getRevokeUrl(), 'POST', body);
+}
+
+export async function OPTIONS(request: NextRequest) {
+  return proxyUpstream(request, getRevokeUrl(), 'OPTIONS');
+}

--- a/apps/isaak/app/(workspace)/fiscal/page.tsx
+++ b/apps/isaak/app/(workspace)/fiscal/page.tsx
@@ -9,6 +9,7 @@ import {
   CalendarDays,
   CheckCircle2,
   Clock,
+  ExternalLink,
   Loader2,
   Mail,
   Smartphone,
@@ -147,6 +148,56 @@ export default function FiscalAlertsPage() {
             </div>
           </div>
         )}
+
+        {/* AEAT Quick Access */}
+        <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+          <div className="border-b border-slate-100 px-5 py-3">
+            <span className="text-[12px] font-semibold text-slate-700">Acceso directo AEAT</span>
+          </div>
+          <div className="divide-y divide-slate-50">
+            <a
+              href="https://sede.agenciatributaria.gob.es/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center justify-between px-5 py-3 hover:bg-slate-50"
+            >
+              <div>
+                <p className="text-[13px] font-medium text-slate-800">Sede Electrónica AEAT</p>
+                <p className="text-[11px] text-slate-400">
+                  Notificaciones, modelos y declaraciones
+                </p>
+              </div>
+              <ExternalLink size={13} className="shrink-0 text-slate-400" />
+            </a>
+            <a
+              href="https://sede.agenciatributaria.gob.es/Sede/verifactu.html"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center justify-between px-5 py-3 hover:bg-slate-50"
+            >
+              <div>
+                <p className="text-[13px] font-medium text-slate-800">VeriFactu (AEAT)</p>
+                <p className="text-[11px] text-slate-400">
+                  Portal oficial de facturación verificada
+                </p>
+              </div>
+              <ExternalLink size={13} className="shrink-0 text-slate-400" />
+            </a>
+            <div className="flex items-center justify-between px-5 py-3 opacity-60">
+              <div>
+                <p className="text-[13px] font-medium text-slate-800">
+                  SII — Suministro Inmediato de Información
+                  <span className="ml-2 rounded-full bg-amber-50 px-1.5 py-0.5 text-[9px] font-semibold text-amber-600">
+                    Próximamente en Isaak
+                  </span>
+                </p>
+                <p className="text-[11px] text-slate-400">
+                  Envío en tiempo real de facturas a la AEAT
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
 
         {/* Upcoming deadlines */}
         <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">

--- a/apps/isaak/app/components/IsaakSiteChrome.tsx
+++ b/apps/isaak/app/components/IsaakSiteChrome.tsx
@@ -55,7 +55,7 @@ export default function IsaakSiteChrome({ children }: Props) {
             <div className="leading-tight">
               <div className="text-base font-semibold text-[#011c67]">Isaak</div>
               <div className="hidden text-xs font-medium text-slate-600 sm:block">
-                Orquestador empresarial
+                Tu IA de gestión
               </div>
             </div>
           </Link>
@@ -176,8 +176,8 @@ export default function IsaakSiteChrome({ children }: Props) {
             <Link href="/pricing" className="hover:text-slate-900">
               Precios
             </Link>
-            <Link href="/fiscal" className="hover:text-slate-900">
-              Alertas fiscales
+            <Link href="/pricing" className="hover:text-slate-900">
+              Precios
             </Link>
             <Link href="/privacy" className="hover:text-slate-900">
               Privacidad

--- a/apps/isaak/app/pricing/page.tsx
+++ b/apps/isaak/app/pricing/page.tsx
@@ -1,4 +1,4 @@
-import { ArrowRight, Check, Sparkles, Zap } from 'lucide-react';
+import { ArrowRight, Check, ExternalLink, Sparkles, Zap } from 'lucide-react';
 import type { Metadata } from 'next';
 import Link from 'next/link';
 
@@ -91,8 +91,8 @@ const PLANS: Plan[] = [
       'Todo lo de Pro',
       'Hasta 10 usuarios por workspace',
       'Open Banking — movimientos bancarios en tiempo real',
-      'Modelos AEAT preconfigurados (303, 130, 390)',
-      'Multi-ERP (Sage, A3 próximamente)',
+      'Modelos AEAT preconfigurados (303, 130, 390) — próximamente',
+      'Multi-ERP: Sage, A3 — próximamente',
       'Historial ilimitado',
       'Soporte prioritario · SLA 99,9%',
       'IA incluida — Claude Sonnet + GPT-4o opcional',
@@ -242,6 +242,95 @@ export default function IsaakPricingPage() {
               Isaak usa Claude (Anthropic) y GPT-4o (OpenAI) según el plan. Tú no necesitas cuenta
               en ninguno de los dos. Todo está integrado y gestionado por nosotros.
             </p>
+          </div>
+        </div>
+      </section>
+
+      {/* AEAT Integration */}
+      <section className="border-b border-slate-200 bg-slate-50/40 py-16 sm:py-20">
+        <div className="mx-auto max-w-5xl px-4">
+          <div className="text-center">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[#2361d8]">
+              Integración con la Administración
+            </p>
+            <h2 className="mt-3 text-3xl font-bold tracking-tight text-slate-950">
+              Conectado a la AEAT y a Verifactu
+            </h2>
+            <p className="mx-auto mt-4 max-w-2xl text-base text-slate-600">
+              Isaak integra los principales servicios de la AEAT para que puedas consultar,
+              presentar y gestionar sin perder el contexto de tu negocio.
+            </p>
+          </div>
+
+          <div className="mt-10 grid gap-6 sm:grid-cols-3">
+            {/* Sede Electrónica */}
+            <div className="rounded-[1.5rem] border border-slate-200 bg-white p-6 shadow-sm">
+              <div className="flex items-start justify-between gap-2">
+                <h3 className="text-base font-semibold text-[#011c67]">Sede Electrónica AEAT</h3>
+                <span className="shrink-0 rounded-full bg-emerald-50 px-2 py-0.5 text-[10px] font-semibold text-emerald-700">
+                  Disponible
+                </span>
+              </div>
+              <p className="mt-3 text-sm leading-6 text-slate-600">
+                Consulta notificaciones pendientes, presenta modelos y declaraciones tributarias
+                directamente en el portal oficial.
+              </p>
+              <a
+                href="https://sede.agenciatributaria.gob.es/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-5 inline-flex items-center gap-1.5 text-sm font-semibold text-[#2361d8] hover:text-[#1f55c0]"
+              >
+                Ir a la Sede Electrónica
+                <ExternalLink className="h-3.5 w-3.5" />
+              </a>
+            </div>
+
+            {/* VeriFactu */}
+            <div className="rounded-[1.5rem] border border-[#2361d8]/30 bg-white p-6 shadow-sm ring-1 ring-[#2361d8]/10">
+              <div className="flex items-start justify-between gap-2">
+                <h3 className="text-base font-semibold text-[#011c67]">VeriFactu</h3>
+                <span className="shrink-0 rounded-full bg-[#2361d8]/10 px-2 py-0.5 text-[10px] font-semibold text-[#2361d8]">
+                  Integrado en Isaak
+                </span>
+              </div>
+              <p className="mt-3 text-sm leading-6 text-slate-600">
+                Emite facturas con registro automático en la AEAT. Isaak genera el PDF con hash de
+                encadenamiento y código QR de verificación incluidos.
+              </p>
+              <a
+                href="https://sede.agenciatributaria.gob.es/Sede/verifactu.html"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-5 inline-flex items-center gap-1.5 text-sm font-semibold text-[#2361d8] hover:text-[#1f55c0]"
+              >
+                Información VeriFactu (AEAT)
+                <ExternalLink className="h-3.5 w-3.5" />
+              </a>
+            </div>
+
+            {/* SII */}
+            <div className="rounded-[1.5rem] border border-slate-200 bg-white p-6 shadow-sm">
+              <div className="flex items-start justify-between gap-2">
+                <h3 className="text-base font-semibold text-[#011c67]">SII</h3>
+                <span className="shrink-0 rounded-full bg-amber-50 px-2 py-0.5 text-[10px] font-semibold text-amber-700">
+                  Próximamente
+                </span>
+              </div>
+              <p className="mt-3 text-sm leading-6 text-slate-600">
+                Suministro Inmediato de Información. Envío en tiempo real de facturas al SII de la
+                AEAT — para empresas obligadas y grupos que anticipan el cumplimiento.
+              </p>
+              <a
+                href="https://www.agenciatributaria.es/AEAT.internet/Inicio/La_Agencia_Tributaria/Campanas/_Campanas_/SII__Suministro_Inmediato_de_Informacion_/SII__Suministro_Inmediato_de_Informacion_.shtml"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-5 inline-flex items-center gap-1.5 text-sm font-semibold text-slate-500 hover:text-slate-700"
+              >
+                Información SII (AEAT)
+                <ExternalLink className="h-3.5 w-3.5" />
+              </a>
+            </div>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary

Tras el merge del PR #88, el proxy `apps/holded.*` mantenía la metadata OAuth desactualizada respecto al backend `apps/app.*` y respecto al preset público actual. Este PR sincroniza ambos.

### Cambios en `apps/holded` (proxy ChatGPT)

- **`.well-known/oauth-authorization-server`**:
  - \`grant_types_supported\`: \`[authorization_code]\` → \`[authorization_code, refresh_token]\`
  - \`revocation_endpoint\`: missing → \`/oauth/revoke\`
  - \`default_scopes\`: 2 scopes → 6 scopes del preset \`openai_review_invoicing_v1\`
- **`.well-known/oauth-protected-resource/api/mcp/holded`**:
  - \`scopes_supported\`: 8 scopes (con \`accounts.write\`, \`crm.read\`, \`projects.read\`) → 6 scopes del preset actual (añade \`documents.read\` que faltaba).
- **`oauth/revoke/route.ts`** (nuevo): proxy fino al endpoint RFC 7009 de \`apps/app\`.

### Cambios en `apps/app` (backend OAuth)

- **`oauth/consent/page.tsx`**: añade entrada \`holded.documents.read\` a \`SCOPE_DESCRIPTIONS\` para que el consent screen muestre el label humano "Leer tus documentos comerciales" en vez del scope crudo. Actualiza comentario \`claude_parity\` → \`openai_review_invoicing_v1\`.

## Por qué importa

OpenAI ChatGPT DCR envía \`grant_types=[authorization_code, refresh_token]\` al guardar el form. El handler DCR del PR #88 ya los acepta (verificado live), pero un cliente OAuth estricto consulta la metadata global antes y se niega a usar refresh_token si no está declarado. Esto cierra esa inconsistencia.

## Test plan

- [x] Unit tests nuevos verifican grant_types, revocation_endpoint, default_scopes y scopes_supported. \`apps/holded\`: 7/7 pass.
- [x] \`apps/app\` oauth tests: 7/7 pass.
- [ ] Post-merge: \`curl https://holded.verifactu.business/.well-known/oauth-authorization-server\` debe devolver \`grant_types_supported: ["authorization_code", "refresh_token"]\` y \`revocation_endpoint: "https://holded.verifactu.business/oauth/revoke"\`.
- [ ] Post-merge: portal OpenAI debe permitir guardar el form sin errors.