### PR TITLE
feat(vf): VF-3/VF-4 - Sede Electronica AEAT proxy + chat tools + template wiring

### DIFF
--- a/apps/isaak/app/(workspace)/components/IsaakSidebar.tsx
+++ b/apps/isaak/app/(workspace)/components/IsaakSidebar.tsx
@@ -61,6 +61,7 @@ const NAV_SECTIONS = [
   { href: '/equipo', label: 'Equipo', icon: Users2 },
   { href: '/calendario', label: 'Calendario Fiscal', icon: CalendarDays },
   { href: '/fiscal', label: 'Alertas Fiscales', icon: Bell },
+  { href: '/sede', label: 'Sede Electrónica', icon: PlugZap },
   { href: '/banking', label: 'Open Banking', icon: Landmark },
   { href: '/mail', label: 'Gmail Facturas', icon: Mail },
   { href: '/advisor', label: 'Mis clientes', icon: Building2 },

--- a/apps/isaak/app/(workspace)/sede/page.tsx
+++ b/apps/isaak/app/(workspace)/sede/page.tsx
@@ -1,0 +1,415 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import {
+  AlertTriangle,
+  Bell,
+  Building,
+  CheckCircle2,
+  ExternalLink,
+  Loader2,
+  RefreshCw,
+  ShieldCheck,
+  XCircle,
+} from 'lucide-react';
+import Link from 'next/link';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type CertMeta = {
+  id: string;
+  nif: string;
+  commonName: string;
+  certType: string;
+  validTo: string;
+};
+
+type Notification = {
+  id: string;
+  title: string;
+  emisor: string;
+  fecha: string;
+  estado: 'pendiente' | 'leida' | 'expirada';
+  tipo: string;
+};
+
+type CensusData = {
+  nif: string;
+  nombre: string;
+  domicilioFiscal?: string;
+  municipio?: string;
+  provincia?: string;
+  epigrafesIAE?: string[];
+  situacionCensal?: string;
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function daysUntil(iso: string) {
+  return Math.ceil((new Date(iso).getTime() - Date.now()) / 86400000);
+}
+
+function fmtDate(iso: string) {
+  return new Date(iso).toLocaleDateString('es-ES', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+function estadoBadge(estado: Notification['estado']) {
+  if (estado === 'pendiente')
+    return (
+      <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-semibold text-amber-700">
+        Pendiente
+      </span>
+    );
+  if (estado === 'expirada')
+    return (
+      <span className="rounded-full bg-red-100 px-2 py-0.5 text-[10px] font-semibold text-red-600">
+        Expirada
+      </span>
+    );
+  return (
+    <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-semibold text-slate-500">
+      Leída
+    </span>
+  );
+}
+
+// ── No-cert CTA ──────────────────────────────────────────────────────────────
+
+function NoCertCard() {
+  return (
+    <div className="rounded-2xl border border-dashed border-slate-300 bg-slate-50 p-8 text-center">
+      <ShieldCheck className="mx-auto mb-3 h-10 w-10 text-slate-300" />
+      <p className="mb-1 text-[15px] font-semibold text-slate-700">
+        Certificado digital no configurado
+      </p>
+      <p className="mb-4 text-[13px] text-slate-400">
+        Sube tu certificado digital FNMT (P12/PFX) para acceder a la Sede Electrónica de la AEAT.
+      </p>
+      <Link
+        href="/settings"
+        className="inline-flex items-center gap-1.5 rounded-lg bg-blue-600 px-4 py-2 text-[13px] font-semibold text-white hover:bg-blue-700"
+      >
+        <ShieldCheck size={14} />
+        Configurar certificado
+      </Link>
+    </div>
+  );
+}
+
+// ── Main Page ─────────────────────────────────────────────────────────────────
+
+export default function SedeElectronicaPage() {
+  const [cert, setCert] = useState<CertMeta | null | undefined>(undefined);
+  const [notifications, setNotifications] = useState<Notification[] | null>(null);
+  const [notifError, setNotifError] = useState<string | null>(null);
+  const [census, setCensus] = useState<CensusData | null>(null);
+  const [censusError, setCensusError] = useState<string | null>(null);
+  const [loadingNotif, setLoadingNotif] = useState(false);
+  const [loadingCensus, setLoadingCensus] = useState(false);
+
+  const loadCert = useCallback(async () => {
+    const res = await fetch('/api/isaak/certificates').catch(() => null);
+    if (!res?.ok) {
+      setCert(null);
+      return;
+    }
+    const data = (await res.json()) as { certs: CertMeta[] };
+    setCert(data.certs?.[0] ?? null);
+  }, []);
+
+  const loadNotifications = useCallback(async () => {
+    setLoadingNotif(true);
+    setNotifError(null);
+    try {
+      const res = await fetch('/api/isaak/sede/notifications');
+      const data = (await res.json()) as { notifications?: Notification[]; error?: string };
+      if (data.error === 'no_cert') {
+        setNotifications([]);
+        return;
+      }
+      if (!res.ok || data.error) {
+        setNotifError(data.error ?? 'Error al conectar con la AEAT');
+        setNotifications([]);
+        return;
+      }
+      setNotifications(data.notifications ?? []);
+    } finally {
+      setLoadingNotif(false);
+    }
+  }, []);
+
+  const loadCensus = useCallback(async () => {
+    setLoadingCensus(true);
+    setCensusError(null);
+    try {
+      const res = await fetch('/api/isaak/sede/census');
+      const data = (await res.json()) as { data?: CensusData; error?: string };
+      if (data.error === 'no_cert') return;
+      if (!res.ok || data.error) {
+        setCensusError(data.error ?? 'Error al consultar datos censales');
+        return;
+      }
+      setCensus(data.data ?? null);
+    } finally {
+      setLoadingCensus(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadCert();
+  }, [loadCert]);
+
+  useEffect(() => {
+    if (cert) {
+      void loadNotifications();
+      void loadCensus();
+    }
+  }, [cert, loadNotifications, loadCensus]);
+
+  const certDays = cert ? daysUntil(cert.validTo) : null;
+  const pendingCount = notifications?.filter((n) => n.estado === 'pendiente').length ?? 0;
+
+  // ── Loading state ───────────────────────────────────────────────────────────
+  if (cert === undefined) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <Loader2 className="h-6 w-6 animate-spin text-slate-400" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-8">
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-[22px] font-bold text-slate-900">Sede Electrónica AEAT</h1>
+          <p className="mt-0.5 text-[13px] text-slate-500">
+            Consulta notificaciones y datos censales directamente desde la AEAT.
+          </p>
+        </div>
+        <a
+          href="https://sede.agenciatributaria.gob.es"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-1.5 rounded-lg border border-slate-200 px-3 py-1.5 text-[12px] font-medium text-slate-600 hover:bg-slate-50"
+        >
+          <ExternalLink size={13} />
+          Abrir Sede AEAT
+        </a>
+      </div>
+
+      {/* No cert */}
+      {!cert && <NoCertCard />}
+
+      {cert && (
+        <div className="space-y-5">
+          {/* Cert card */}
+          <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex items-start gap-3">
+                <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-green-50">
+                  <CheckCircle2 className="h-5 w-5 text-green-500" />
+                </div>
+                <div>
+                  <p className="text-[14px] font-semibold text-slate-900">{cert.commonName}</p>
+                  <p className="text-[12px] text-slate-500">NIF: {cert.nif}</p>
+                  <p className="mt-1 text-[12px] text-slate-400">
+                    {cert.certType === 'entidad' ? 'Persona jurídica (entidad)' : 'Persona física'}
+                  </p>
+                </div>
+              </div>
+              <div className="text-right">
+                {certDays !== null && certDays < 30 ? (
+                  <span className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-semibold text-amber-700">
+                    <AlertTriangle size={10} />
+                    Caduca en {certDays}d
+                  </span>
+                ) : (
+                  <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-[10px] font-semibold text-green-700">
+                    <ShieldCheck size={10} />
+                    Válido
+                  </span>
+                )}
+                <p className="mt-1 text-[11px] text-slate-400">
+                  Válido hasta {cert ? fmtDate(cert.validTo) : ''}
+                </p>
+              </div>
+            </div>
+            <div className="mt-3 flex gap-2">
+              <Link href="/settings" className="text-[11px] text-blue-600 hover:underline">
+                Gestionar certificados →
+              </Link>
+            </div>
+          </div>
+
+          {/* AEAT quick links */}
+          <div className="grid grid-cols-3 gap-3">
+            {[
+              {
+                label: 'Mis notificaciones',
+                url: 'https://sede.agenciatributaria.gob.es/Sede/procedimientoini/GC02.shtml',
+                icon: Bell,
+                color: 'bg-amber-50 text-amber-600',
+              },
+              {
+                label: 'Datos censales',
+                url: 'https://sede.agenciatributaria.gob.es/Sede/procedimientoini/G322.shtml',
+                icon: Building,
+                color: 'bg-blue-50 text-blue-600',
+              },
+              {
+                label: 'Expedientes',
+                url: 'https://sede.agenciatributaria.gob.es/Sede/procedimientoini/G320.shtml',
+                icon: ShieldCheck,
+                color: 'bg-purple-50 text-purple-600',
+              },
+            ].map(({ label, url, icon: Icon, color }) => (
+              <a
+                key={label}
+                href={url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex flex-col items-center gap-2 rounded-xl border border-slate-200 bg-white p-4 text-center shadow-sm hover:bg-slate-50"
+              >
+                <span className={`flex h-9 w-9 items-center justify-center rounded-xl ${color}`}>
+                  <Icon size={18} />
+                </span>
+                <span className="text-[11px] font-medium text-slate-700 leading-tight">
+                  {label}
+                </span>
+                <ExternalLink size={10} className="text-slate-300" />
+              </a>
+            ))}
+          </div>
+
+          {/* Notifications */}
+          <div className="rounded-2xl border border-slate-200 bg-white shadow-sm">
+            <div className="flex items-center justify-between border-b border-slate-100 px-5 py-3.5">
+              <div className="flex items-center gap-2">
+                <Bell size={15} className="text-slate-500" />
+                <span className="text-[13px] font-semibold text-slate-800">
+                  Notificaciones AEAT
+                </span>
+                {pendingCount > 0 && (
+                  <span className="rounded-full bg-amber-500 px-1.5 py-0.5 text-[10px] font-bold text-white">
+                    {pendingCount}
+                  </span>
+                )}
+              </div>
+              <button
+                onClick={() => void loadNotifications()}
+                disabled={loadingNotif}
+                className="flex items-center gap-1 text-[11px] text-slate-400 hover:text-slate-600 disabled:opacity-50"
+              >
+                <RefreshCw size={12} className={loadingNotif ? 'animate-spin' : ''} />
+                Actualizar
+              </button>
+            </div>
+
+            <div className="divide-y divide-slate-100">
+              {loadingNotif && notifications === null && (
+                <div className="flex items-center justify-center py-8">
+                  <Loader2 className="h-5 w-5 animate-spin text-slate-400" />
+                </div>
+              )}
+              {notifError && (
+                <div className="flex items-start gap-2 px-5 py-4 text-[12px] text-slate-500">
+                  <XCircle size={14} className="mt-0.5 shrink-0 text-red-400" />
+                  <span>
+                    No se han podido cargar las notificaciones. Asegúrate de que tu certificado está
+                    activo y tiene acceso a la Sede Electrónica.
+                    <br />
+                    <span className="font-mono text-[10px] text-slate-400">{notifError}</span>
+                  </span>
+                </div>
+              )}
+              {!loadingNotif && !notifError && notifications?.length === 0 && (
+                <div className="px-5 py-6 text-center text-[13px] text-slate-400">
+                  No hay notificaciones pendientes.
+                </div>
+              )}
+              {notifications?.map((n) => (
+                <div key={n.id} className="flex items-start gap-3 px-5 py-3.5">
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <p className="truncate text-[13px] font-medium text-slate-800">{n.title}</p>
+                      {estadoBadge(n.estado)}
+                    </div>
+                    <p className="mt-0.5 text-[11px] text-slate-400">
+                      {n.emisor} · {n.fecha ? fmtDate(n.fecha) : ''} · {n.tipo}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Census data */}
+          {(census || censusError || loadingCensus) && (
+            <div className="rounded-2xl border border-slate-200 bg-white shadow-sm">
+              <div className="flex items-center gap-2 border-b border-slate-100 px-5 py-3.5">
+                <Building size={15} className="text-slate-500" />
+                <span className="text-[13px] font-semibold text-slate-800">Datos Censales</span>
+              </div>
+              <div className="px-5 py-4">
+                {loadingCensus && !census && (
+                  <div className="flex items-center gap-2 text-[12px] text-slate-400">
+                    <Loader2 size={13} className="animate-spin" /> Consultando...
+                  </div>
+                )}
+                {censusError && (
+                  <p className="text-[12px] text-slate-400">
+                    No se pudieron obtener los datos censales.{' '}
+                    <a
+                      href="https://sede.agenciatributaria.gob.es/Sede/procedimientoini/G322.shtml"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-500 hover:underline"
+                    >
+                      Consultar en Sede AEAT →
+                    </a>
+                  </p>
+                )}
+                {census && (
+                  <dl className="grid grid-cols-2 gap-x-6 gap-y-3 text-[12px]">
+                    {[
+                      { label: 'Nombre/Razón social', value: census.nombre },
+                      { label: 'NIF', value: census.nif },
+                      { label: 'Domicilio fiscal', value: census.domicilioFiscal },
+                      { label: 'Municipio', value: census.municipio },
+                      { label: 'Provincia', value: census.provincia },
+                      { label: 'Situación censal', value: census.situacionCensal },
+                    ]
+                      .filter((r) => r.value)
+                      .map(({ label, value }) => (
+                        <div key={label}>
+                          <dt className="text-[10px] font-medium uppercase tracking-wide text-slate-400">
+                            {label}
+                          </dt>
+                          <dd className="mt-0.5 font-medium text-slate-800">{value}</dd>
+                        </div>
+                      ))}
+                    {(census.epigrafesIAE?.length ?? 0) > 0 && (
+                      <div className="col-span-2">
+                        <dt className="text-[10px] font-medium uppercase tracking-wide text-slate-400">
+                          Epígrafes IAE
+                        </dt>
+                        <dd className="mt-0.5 font-medium text-slate-800">
+                          {census.epigrafesIAE!.join(', ')}
+                        </dd>
+                      </div>
+                    )}
+                  </dl>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/isaak/app/api/holded/chat/route.ts
+++ b/apps/isaak/app/api/holded/chat/route.ts
@@ -23,8 +23,26 @@ import {
   storeSimpleMemoryFact,
 } from '@/app/lib/holded-chat';
 import { prisma } from '@/app/lib/prisma';
+import { getAeatNotifications, loadTenantCertPem } from '@/app/lib/aeat-sede';
 
 export const runtime = 'nodejs';
+
+function isAeatQuery(message: string) {
+  const t = message.toLowerCase();
+  return (
+    t.includes('aeat') ||
+    t.includes('sede electronica') ||
+    t.includes('sede electrónica') ||
+    t.includes('notificacion') ||
+    t.includes('notificación') ||
+    t.includes('hacienda') ||
+    t.includes('certificado digital') ||
+    t.includes('datos censales') ||
+    t.includes('buzon') ||
+    t.includes('buzón') ||
+    t.includes('agencia tributaria')
+  );
+}
 
 function isConnectionDiagnosticRequest(message: string) {
   const text = message.toLowerCase();
@@ -236,6 +254,7 @@ function buildLlmInstructions(input: {
   snapshot: NonNullable<Awaited<ReturnType<typeof loadIsaakBusinessContext>>['holded']['snapshot']>;
   diagnosticProbe: Awaited<ReturnType<typeof probeHoldedConnection>> | null;
   workspaceSignalsBlock: string | null;
+  aeatBlock?: string | null;
   recentFacts?: { category: string; factKey: string; valueJson: unknown }[];
   fewShotExamples?: { question: string; response: string }[];
 }) {
@@ -321,6 +340,7 @@ function buildLlmInstructions(input: {
     input.workspaceSignalsBlock
       ? `Estado del workspace:\n${input.workspaceSignalsBlock}`
       : 'Estado del workspace: no disponible.',
+    ...(input.aeatBlock ? [`\nDatos AEAT en tiempo real:\n${input.aeatBlock}`] : []),
     'Si faltan datos fiscales o de empresa para orientar mejor, abre una micro-entrevista de una sola pregunta y ofrece siempre las opciones "Prefiero no decirlo" y "No lo sé".',
     'Si responde "No lo sé", explica cómo averiguarlo y cuándo conviene revisar la Sede Electrónica de la AEAT o el certificado electrónico.',
     // L3: memory facts del tenant
@@ -390,6 +410,7 @@ async function buildLlmReply(input: {
   snapshot: NonNullable<Awaited<ReturnType<typeof loadIsaakBusinessContext>>['holded']['snapshot']>;
   diagnosticProbe: Awaited<ReturnType<typeof probeHoldedConnection>> | null;
   workspaceSignalsBlock: string | null;
+  aeatBlock?: string | null;
   modelConfig?: HoldedChatModelConfig;
   memoryContext?: MemoryContext | null;
   fewShotExamples?: { question: string; response: string }[];
@@ -410,6 +431,7 @@ async function buildLlmReply(input: {
         snapshot: input.snapshot,
         diagnosticProbe: input.diagnosticProbe,
         workspaceSignalsBlock: input.workspaceSignalsBlock,
+        aeatBlock: input.aeatBlock,
         recentFacts: input.memoryContext?.recentFacts ?? [],
         fewShotExamples: input.fewShotExamples ?? [],
       }),
@@ -1138,6 +1160,33 @@ export async function POST(request: NextRequest) {
     const planCode = await loadTenantPlanCode(session.tenantId);
     const modelConfig = resolveHoldedChatModel(planCode);
 
+    // VF-4: Load AEAT context when user asks about AEAT-related topics
+    let aeatBlock: string | null = null;
+    if (isAeatQuery(message)) {
+      const [certRow, notifResult] = await Promise.all([
+        loadTenantCertPem(session.tenantId).catch(() => null),
+        getAeatNotifications(session.tenantId).catch(() => ({
+          ok: false,
+          notifications: [] as { estado: string; title: string; tipo: string; fecha: string }[],
+          error: 'timeout',
+        })),
+      ]);
+      const certLine = certRow
+        ? `Certificado configurado: ${certRow.commonName} (NIF ${certRow.nif})`
+        : 'Sin certificado digital configurado. Recordar al usuario que puede subirlo en Ajustes.';
+      let notifLine = '';
+      if (notifResult.ok && notifResult.notifications.length > 0) {
+        const pending = notifResult.notifications.filter((n) => n.estado === 'pendiente');
+        notifLine =
+          pending.length > 0
+            ? `Notificaciones AEAT pendientes (${pending.length}): ${pending.map((n) => n.title).join('; ')}`
+            : 'No hay notificaciones AEAT pendientes.';
+      } else if (!notifResult.ok && notifResult.error !== 'no_cert') {
+        notifLine = 'No se han podido cargar las notificaciones AEAT en este momento.';
+      }
+      aeatBlock = [certLine, notifLine].filter(Boolean).join('\n');
+    }
+
     const [memoryContext, fewShotExamples] = await Promise.all([
       conversation
         ? getSimpleMemoryContext(
@@ -1155,6 +1204,7 @@ export async function POST(request: NextRequest) {
         snapshot,
         diagnosticProbe: connectionProbe,
         workspaceSignalsBlock,
+        aeatBlock,
         modelConfig,
         memoryContext,
         fewShotExamples,

--- a/apps/isaak/app/api/isaak/certificates/route.ts
+++ b/apps/isaak/app/api/isaak/certificates/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getHoldedSession } from '@/app/lib/holded-session';
 import { prisma } from '@/app/lib/prisma';
 import { encryptCert } from '@/app/lib/certificate-crypto';
-import { readP12 } from '@/app/lib/p12-reader';
+import { extractPemFromP12, readP12 } from '@/app/lib/p12-reader';
 
 export const runtime = 'nodejs';
 
@@ -74,8 +74,18 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  // Encrypt P12 before storing
-  const { encrypted, iv, authTag } = encryptCert(p12Buffer);
+  // Extract PEM (cert + private key) so we can later use mTLS without the original password
+  let pemPair: { certPem: string; keyPem: string };
+  try {
+    pemPair = extractPemFromP12(p12Buffer, password);
+  } catch {
+    return NextResponse.json(
+      { error: 'No se pudo extraer la clave privada del certificado.' },
+      { status: 422 }
+    );
+  }
+  const pemJson = JSON.stringify({ cert: pemPair.certPem, key: pemPair.keyPem });
+  const { encrypted, iv, authTag } = encryptCert(Buffer.from(pemJson, 'utf8'));
 
   // Remove any existing cert with same NIF (only one per NIF per tenant)
   await prisma.tenantCertificate.deleteMany({

--- a/apps/isaak/app/api/isaak/sede/census/route.ts
+++ b/apps/isaak/app/api/isaak/sede/census/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import { getHoldedSession } from '@/app/lib/holded-session';
+import { getAeatCensusData } from '@/app/lib/aeat-sede';
+
+export const runtime = 'nodejs';
+
+export async function GET() {
+  const session = await getHoldedSession().catch(() => null);
+  if (!session?.tenantId) return NextResponse.json({ error: 'No autenticado' }, { status: 401 });
+
+  const result = await getAeatCensusData(session.tenantId);
+
+  if (!result.ok && result.error === 'no_cert') {
+    return NextResponse.json({ error: 'no_cert' }, { status: 200 });
+  }
+
+  if (!result.ok) {
+    return NextResponse.json(
+      { error: result.error ?? 'Error al consultar la AEAT' },
+      { status: 502 }
+    );
+  }
+
+  return NextResponse.json({ data: result.data });
+}

--- a/apps/isaak/app/api/isaak/sede/notifications/route.ts
+++ b/apps/isaak/app/api/isaak/sede/notifications/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import { getHoldedSession } from '@/app/lib/holded-session';
+import { getAeatNotifications } from '@/app/lib/aeat-sede';
+
+export const runtime = 'nodejs';
+
+export async function GET() {
+  const session = await getHoldedSession().catch(() => null);
+  if (!session?.tenantId) return NextResponse.json({ error: 'No autenticado' }, { status: 401 });
+
+  const result = await getAeatNotifications(session.tenantId);
+
+  if (!result.ok && result.error === 'no_cert') {
+    return NextResponse.json({ error: 'no_cert', notifications: [] }, { status: 200 });
+  }
+
+  if (!result.ok) {
+    return NextResponse.json(
+      { error: result.error ?? 'Error al consultar la AEAT', notifications: [] },
+      { status: 502 }
+    );
+  }
+
+  return NextResponse.json({ notifications: result.notifications });
+}

--- a/apps/isaak/app/api/ventas/invoices/[id]/pdf/route.ts
+++ b/apps/isaak/app/api/ventas/invoices/[id]/pdf/route.ts
@@ -46,7 +46,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
     return NextResponse.json({ ok: false, error: 'ID de factura no válido' }, { status: 400 });
   }
 
-  const [invoice, tenantProfile] = await Promise.all([
+  const [invoice, tenantProfile, defaultTemplate] = await Promise.all([
     prisma.invoice.findFirst({
       where: { id, tenantId: session.tenantId },
       select: {
@@ -84,13 +84,31 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
         adminEditHistory: true,
       },
     }),
+    prisma.invoiceTemplate.findFirst({
+      where: { tenantId: session.tenantId, isDefault: true },
+      select: { primaryColor: true, secondaryColor: true, accentColor: true, logoUrl: true },
+    }),
   ]);
 
   if (!invoice) {
     return NextResponse.json({ ok: false, error: 'Factura no encontrada' }, { status: 404 });
   }
 
-  const branding = readBranding(tenantProfile?.adminEditHistory);
+  // Tenant's saved template takes precedence over admin-set branding
+  const templateBranding = defaultTemplate
+    ? {
+        primaryColor: defaultTemplate.primaryColor ?? undefined,
+        secondaryColor: defaultTemplate.secondaryColor ?? undefined,
+        logoUrl: defaultTemplate.logoUrl ?? undefined,
+      }
+    : null;
+  const adminBranding = readBranding(tenantProfile?.adminEditHistory);
+  const branding = templateBranding
+    ? {
+        ...adminBranding,
+        ...Object.fromEntries(Object.entries(templateBranding).filter(([, v]) => v != null)),
+      }
+    : adminBranding;
 
   const issuerName =
     tenantProfile?.legalName || tenantProfile?.tradeName || invoice.tenant.name || '';

--- a/apps/isaak/app/lib/aeat-sede.ts
+++ b/apps/isaak/app/lib/aeat-sede.ts
@@ -1,0 +1,213 @@
+import https from 'https';
+import { prisma } from '@/app/lib/prisma';
+import { decryptCert } from './certificate-crypto';
+
+// ── Certificate loading ───────────────────────────────────────────────────────
+
+type CertPemPair = { certPem: string; keyPem: string; nif: string; commonName: string };
+
+export async function loadTenantCertPem(tenantId: string): Promise<CertPemPair | null> {
+  const row = await prisma.tenantCertificate.findFirst({
+    where: { tenantId },
+    orderBy: { createdAt: 'desc' },
+    select: {
+      encryptedP12: true,
+      iv: true,
+      authTag: true,
+      nif: true,
+      commonName: true,
+    },
+  });
+  if (!row) return null;
+
+  const buf = decryptCert(row.encryptedP12, row.iv, row.authTag);
+  const parsed = JSON.parse(buf.toString('utf8')) as { cert?: string; key?: string };
+  if (!parsed.cert || !parsed.key) return null;
+
+  return { certPem: parsed.cert, keyPem: parsed.key, nif: row.nif, commonName: row.commonName };
+}
+
+function buildAgent(certPem: string, keyPem: string): https.Agent {
+  return new https.Agent({ cert: certPem, key: keyPem, rejectUnauthorized: true });
+}
+
+// ── Raw SOAP helper ───────────────────────────────────────────────────────────
+
+function httpsPost(
+  url: string,
+  soapAction: string,
+  body: string,
+  agent: https.Agent
+): Promise<string> {
+  const envelope = `<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+  <soapenv:Header/>
+  <soapenv:Body>${body}</soapenv:Body>
+</soapenv:Envelope>`;
+
+  return new Promise((resolve, reject) => {
+    const urlObj = new URL(url);
+    const bodyBuf = Buffer.from(envelope, 'utf8');
+    const req = https.request(
+      {
+        hostname: urlObj.hostname,
+        port: urlObj.port || 443,
+        path: urlObj.pathname + urlObj.search,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'text/xml; charset=utf-8',
+          SOAPAction: `"${soapAction}"`,
+          'Content-Length': bodyBuf.length,
+        },
+        agent,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (c: Buffer) => chunks.push(c));
+        res.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+      }
+    );
+    req.on('error', reject);
+    req.write(bodyBuf);
+    req.end();
+  });
+}
+
+// ── Simple XML value extractor ─────────────────────────────────────────────────
+
+function extractXmlValues(xml: string, tag: string): string[] {
+  const results: string[] = [];
+  const re = new RegExp(`<[^:>]*:?${tag}[^>]*>([^<]*)</[^:>]*:?${tag}>`, 'gi');
+  let m;
+  while ((m = re.exec(xml)) !== null) results.push(m[1].trim());
+  return results;
+}
+
+function extractXmlBlocks(xml: string, tag: string): string[] {
+  const results: string[] = [];
+  const re = new RegExp(`<[^:>]*:?${tag}[^>]*>([\\s\\S]*?)</[^:>]*:?${tag}>`, 'gi');
+  let m;
+  while ((m = re.exec(xml)) !== null) results.push(m[1]);
+  return results;
+}
+
+// ── AEAT Notificaciones (Buzón Electrónico) ───────────────────────────────────
+
+const AEAT_NOTIF_URL =
+  process.env.AEAT_NOTIF_WS_URL ??
+  'https://www1.agenciatributaria.gob.es/wlpl/BUZA-CONT/ws/BuzElecWS';
+
+export type AeatNotification = {
+  id: string;
+  title: string;
+  emisor: string;
+  fecha: string;
+  estado: 'pendiente' | 'leida' | 'expirada';
+  tipo: string;
+};
+
+export async function getAeatNotifications(
+  tenantId: string
+): Promise<{ ok: boolean; notifications: AeatNotification[]; error?: string }> {
+  const cert = await loadTenantCertPem(tenantId);
+  if (!cert) return { ok: false, notifications: [], error: 'no_cert' };
+
+  const agent = buildAgent(cert.certPem, cert.keyPem);
+  const requestBody = `<buz:ConsultarNotificaciones xmlns:buz="https://www2.agenciatributaria.gob.es/static_files/common/internet/dep/informatica/es/desarrollo/proyecto_tramitacion/doc/BUZA_CONT.WSDL">
+    <buz:NIF>${cert.nif}</buz:NIF>
+  </buz:ConsultarNotificaciones>`;
+
+  let xml: string;
+  try {
+    xml = await httpsPost(AEAT_NOTIF_URL, 'ConsultarNotificaciones', requestBody, agent);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { ok: false, notifications: [], error: `soap_error: ${msg}` };
+  }
+
+  if (xml.includes('faultstring') || xml.includes('Fault')) {
+    const fault = extractXmlValues(xml, 'faultstring')[0] ?? 'SOAP Fault';
+    return { ok: false, notifications: [], error: fault };
+  }
+
+  const blocks = extractXmlBlocks(xml, 'Notificacion');
+  const notifications: AeatNotification[] = blocks.map((block) => {
+    const estadoRaw = (extractXmlValues(block, 'Estado')[0] ?? '').toLowerCase();
+    const estado: AeatNotification['estado'] = estadoRaw.includes('pendiente')
+      ? 'pendiente'
+      : estadoRaw.includes('expir')
+        ? 'expirada'
+        : 'leida';
+    return {
+      id: extractXmlValues(block, 'IdNotificacion')[0] ?? extractXmlValues(block, 'Id')[0] ?? '',
+      title:
+        extractXmlValues(block, 'Descripcion')[0] ??
+        extractXmlValues(block, 'Titulo')[0] ??
+        'Sin título',
+      emisor: extractXmlValues(block, 'Emisor')[0] ?? 'AEAT',
+      fecha:
+        extractXmlValues(block, 'FechaEmision')[0] ?? extractXmlValues(block, 'Fecha')[0] ?? '',
+      estado,
+      tipo: extractXmlValues(block, 'TipoNotificacion')[0] ?? 'Notificación',
+    };
+  });
+
+  return { ok: true, notifications };
+}
+
+// ── AEAT Datos Censales ───────────────────────────────────────────────────────
+
+const AEAT_CENSUS_URL =
+  process.env.AEAT_CENSUS_WS_URL ??
+  'https://www1.agenciatributaria.gob.es/wlpl/OVSC-CONT/ws/ConsultaInformacion/ConsultaInformacion';
+
+export type AeatCensusData = {
+  nif: string;
+  nombre: string;
+  domicilioFiscal?: string;
+  municipio?: string;
+  provincia?: string;
+  epigrafesIAE?: string[];
+  situacionCensal?: string;
+};
+
+export async function getAeatCensusData(
+  tenantId: string
+): Promise<{ ok: boolean; data?: AeatCensusData; error?: string }> {
+  const cert = await loadTenantCertPem(tenantId);
+  if (!cert) return { ok: false, error: 'no_cert' };
+
+  const agent = buildAgent(cert.certPem, cert.keyPem);
+  const requestBody = `<con:ConsultaInformacion xmlns:con="https://www2.agenciatributaria.gob.es/static_files/common/internet/dep/informatica/es/desarrollo/proyecto_tramitacion/doc/OVSC_CONT.WSDL">
+    <con:NIF>${cert.nif}</con:NIF>
+  </con:ConsultaInformacion>`;
+
+  let xml: string;
+  try {
+    xml = await httpsPost(AEAT_CENSUS_URL, 'ConsultaInformacion', requestBody, agent);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: `soap_error: ${msg}` };
+  }
+
+  if (xml.includes('faultstring') || xml.includes('Fault')) {
+    const fault = extractXmlValues(xml, 'faultstring')[0] ?? 'SOAP Fault';
+    return { ok: false, error: fault };
+  }
+
+  const data: AeatCensusData = {
+    nif: cert.nif,
+    nombre:
+      extractXmlValues(xml, 'NombreRazonSocial')[0] ??
+      extractXmlValues(xml, 'Nombre')[0] ??
+      cert.commonName,
+    domicilioFiscal:
+      extractXmlValues(xml, 'DomicilioFiscal')[0] ?? extractXmlValues(xml, 'DireccionFiscal')[0],
+    municipio: extractXmlValues(xml, 'Municipio')[0] ?? extractXmlValues(xml, 'Localidad')[0],
+    provincia: extractXmlValues(xml, 'Provincia')[0],
+    epigrafesIAE: extractXmlValues(xml, 'EpigrafeIAE').filter(Boolean),
+    situacionCensal: extractXmlValues(xml, 'SituacionCensal')[0],
+  };
+
+  return { ok: true, data };
+}

--- a/apps/isaak/app/lib/p12-reader.ts
+++ b/apps/isaak/app/lib/p12-reader.ts
@@ -38,6 +38,36 @@ function isCertEntity(subject: forge.pki.CertificateField[]): boolean {
   );
 }
 
+export type CertPem = { certPem: string; keyPem: string };
+
+export function extractPemFromP12(p12Buffer: Buffer, password: string): CertPem {
+  const p12Der = forge.util.createBuffer(p12Buffer.toString('binary'));
+  const p12Asn1 = forge.asn1.fromDer(p12Der);
+  const p12 = forge.pkcs12.pkcs12FromAsn1(p12Asn1, password);
+
+  // Extract certificate
+  const certBags = p12.getBags({ bagType: forge.pki.oids.certBag });
+  const cert = certBags[forge.pki.oids.certBag]?.[0]?.cert;
+  if (!cert) throw new Error('Certificado no encontrado en el P12');
+  const certPem = forge.pki.certificateToPem(cert);
+
+  // Extract private key (shrouded or plain)
+  let privateKey: forge.pki.rsa.PrivateKey | null = null;
+  const shroudedBags = p12.getBags({ bagType: forge.pki.oids.pkcs8ShroudedKeyBag });
+  const shrouded = shroudedBags[forge.pki.oids.pkcs8ShroudedKeyBag]?.[0];
+  if (shrouded?.key) {
+    privateKey = shrouded.key as forge.pki.rsa.PrivateKey;
+  } else {
+    const keyBags = p12.getBags({ bagType: forge.pki.oids.keyBag });
+    const plain = keyBags[forge.pki.oids.keyBag]?.[0];
+    if (plain?.key) privateKey = plain.key as forge.pki.rsa.PrivateKey;
+  }
+  if (!privateKey) throw new Error('Clave privada no encontrada en el P12');
+  const keyPem = forge.pki.privateKeyToPem(privateKey);
+
+  return { certPem, keyPem };
+}
+
 export function readP12(p12Buffer: Buffer, password: string): CertInfo {
   const p12Der = forge.util.createBuffer(p12Buffer.toString('binary'));
   const p12Asn1 = forge.asn1.fromDer(p12Der);


### PR DESCRIPTION
## Summary

- **VF-3** AEAT Sede Electronica proxy via mTLS using tenant's own digital certificate. Cert upload now stores PEM (cert+key) AES-256-GCM encrypted, so mTLS works without the original P12 password. HTTPS agent + SOAP helpers for notificaciones (BuzElecWS) and datos censales. API routes /api/isaak/sede/notifications and /sede/census. Workspace page /sede: cert status card, AEAT quick-access links (notificaciones, datos censales, expedientes), live notification list, census data panel. Sidebar entry 'Sede Electronica'.
- **VF-4** Chat context injection: isAeatQuery() detects AEAT-related messages, loads real-time cert status and pending AEAT notifications, injects them into Isaak's LLM system prompt so it can answer AEAT questions with live data.
- **Template wiring** PDF route now loads tenant's default InvoiceTemplate and merges branding (primaryColor, secondaryColor, logoUrl) over the admin-set fallback.

## AEAT WS endpoints (configurable via env vars)
- AEAT_NOTIF_WS_URL (default: https://www1.agenciatributaria.gob.es/wlpl/BUZA-CONT/ws/BuzElecWS)
- AEAT_CENSUS_WS_URL (default: https://www1.agenciatributaria.gob.es/wlpl/OVSC-CONT/ws/ConsultaInformacion/ConsultaInformacion)

## Test plan
- [ ] Upload P12 cert in /settings -> verify cert stored as PEM-JSON (new format)
- [ ] Navigate to /sede -> cert card shows, AEAT quick links visible
- [ ] With cert: /sede loads notifications (will show SOAP error if AEAT endpoint changes, graceful UI)
- [ ] Ask Isaak 'Tengo notificaciones de la AEAT?' -> verify cert status in response
- [ ] Generate invoice PDF -> verify tenant template colors/logo applied

Generated with Claude Code