### PR TITLE
feat(holded): OG images por conector + sender names ChatGPT/Claude x Holded

### DIFF
--- a/apps/holded/app/api/og/chatgpt/route.tsx
+++ b/apps/holded/app/api/og/chatgpt/route.tsx
@@ -1,0 +1,69 @@
+import { ImageResponse } from 'next/og';
+import { readFileSync } from 'fs';
+import path from 'path';
+
+export const runtime = 'nodejs';
+
+function loadAsBase64(filePath: string, mime: string): string {
+  const buf = readFileSync(path.join(process.cwd(), filePath));
+  return `data:${mime};base64,${buf.toString('base64')}`;
+}
+
+export async function GET() {
+  const chatgptLogo = loadAsBase64('public/brand/chatgpt-logo-official.png', 'image/png');
+  const holdedLogo = loadAsBase64('public/brand/holded/holded-diamond-logo.png', 'image/png');
+
+  return new ImageResponse(
+    <div
+      style={{
+        display: 'flex',
+        width: '1200px',
+        height: '630px',
+        background: '#0F172A',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexDirection: 'column',
+        gap: '28px',
+        fontFamily: 'sans-serif',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: '48px' }}>
+        <img
+          src={chatgptLogo}
+          width={160}
+          height={160}
+          style={{ borderRadius: '32px' }}
+          alt="ChatGPT"
+        />
+        <span style={{ fontSize: '80px', color: '#334155', lineHeight: '1', fontWeight: '300' }}>
+          ×
+        </span>
+        <img
+          src={holdedLogo}
+          width={160}
+          height={160}
+          style={{ borderRadius: '32px' }}
+          alt="Holded"
+        />
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: '12px',
+        }}
+      >
+        <span
+          style={{ fontSize: '48px', color: '#F1F5F9', fontWeight: '700', letterSpacing: '-1px' }}
+        >
+          ChatGPT × Holded
+        </span>
+        <span style={{ fontSize: '22px', color: '#64748B' }}>
+          Consulta tus datos de Holded desde ChatGPT
+        </span>
+      </div>
+    </div>,
+    { width: 1200, height: 630 }
+  );
+}

--- a/apps/holded/app/api/og/claude/route.tsx
+++ b/apps/holded/app/api/og/claude/route.tsx
@@ -1,0 +1,73 @@
+import { ImageResponse } from 'next/og';
+import { readFileSync } from 'fs';
+import path from 'path';
+
+export const runtime = 'nodejs';
+
+function loadAsBase64(filePath: string, mime: string): string {
+  const buf = readFileSync(path.join(process.cwd(), filePath));
+  return `data:${mime};base64,${buf.toString('base64')}`;
+}
+
+export async function GET() {
+  const claudeLogoSvg = readFileSync(
+    path.join(process.cwd(), 'public/brand/claude-logo.svg'),
+    'utf8'
+  );
+  const claudeLogo = `data:image/svg+xml;base64,${Buffer.from(claudeLogoSvg).toString('base64')}`;
+  const holdedLogo = loadAsBase64('public/brand/holded/holded-diamond-logo.png', 'image/png');
+
+  return new ImageResponse(
+    <div
+      style={{
+        display: 'flex',
+        width: '1200px',
+        height: '630px',
+        background: '#0F172A',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexDirection: 'column',
+        gap: '28px',
+        fontFamily: 'sans-serif',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: '48px' }}>
+        <img
+          src={claudeLogo}
+          width={160}
+          height={160}
+          style={{ borderRadius: '32px' }}
+          alt="Claude"
+        />
+        <span style={{ fontSize: '80px', color: '#334155', lineHeight: '1', fontWeight: '300' }}>
+          ×
+        </span>
+        <img
+          src={holdedLogo}
+          width={160}
+          height={160}
+          style={{ borderRadius: '32px' }}
+          alt="Holded"
+        />
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: '12px',
+        }}
+      >
+        <span
+          style={{ fontSize: '48px', color: '#F1F5F9', fontWeight: '700', letterSpacing: '-1px' }}
+        >
+          Claude × Holded
+        </span>
+        <span style={{ fontSize: '22px', color: '#64748B' }}>
+          Consulta tus datos de Holded desde Claude
+        </span>
+      </div>
+    </div>,
+    { width: 1200, height: 630 }
+  );
+}

--- a/apps/holded/app/conectores/chatgpt/page.tsx
+++ b/apps/holded/app/conectores/chatgpt/page.tsx
@@ -6,7 +6,7 @@ import { getFaqJsonLd } from '@/app/components/ConnectorFAQData';
 
 const SITE_URL = process.env.NEXT_PUBLIC_HOLDED_SITE_URL || 'https://holded.verifactu.business';
 const PAGE_URL = `${SITE_URL}/conectores/chatgpt`;
-const OG_IMAGE = `${SITE_URL}/brand/holded/holded-diamond-logo.png`;
+const OG_IMAGE = `${SITE_URL}/api/og/chatgpt`;
 
 export const metadata: Metadata = {
   title: 'Pregunta a Holded desde ChatGPT | Verifactu Business',

--- a/apps/holded/app/conectores/claude/page.tsx
+++ b/apps/holded/app/conectores/claude/page.tsx
@@ -6,7 +6,7 @@ import { getFaqJsonLd } from '@/app/components/ConnectorFAQData';
 
 const SITE_URL = process.env.NEXT_PUBLIC_HOLDED_SITE_URL || 'https://holded.verifactu.business';
 const PAGE_URL = `${SITE_URL}/conectores/claude`;
-const OG_IMAGE = `${SITE_URL}/brand/holded/holded-diamond-logo.png`;
+const OG_IMAGE = `${SITE_URL}/api/og/claude`;
 
 export const metadata: Metadata = {
   title: 'Pregunta a Holded desde Claude | Verifactu Business',

--- a/apps/holded/app/lib/communications/holded-email-service.ts
+++ b/apps/holded/app/lib/communications/holded-email-service.ts
@@ -76,8 +76,12 @@ function readEmailList(...values: Array<string | undefined | null>) {
   );
 }
 
-function resolveLeadSender() {
-  const holdedFallback = 'Holded <no-reply@holded.verifactu.business>';
+function resolveLeadSender(channel?: string) {
+  const addr = 'no-reply@holded.verifactu.business';
+  if (channel === 'chatgpt') return `ChatGPT x Holded <${addr}>`;
+  if (channel === 'claude') return `Claude x Holded <${addr}>`;
+
+  const holdedFallback = `Holded <${addr}>`;
   const configured =
     cleanEnv(process.env.RESEND_FROM_HOLDED) || cleanEnv(process.env.RESEND_FROM) || holdedFallback;
 
@@ -88,10 +92,10 @@ function resolveLeadSender() {
   return configured;
 }
 
-function createResendTransport() {
+function createResendTransport(channel?: string) {
   return {
     resend: new Resend(readRequiredEnv('RESEND_API_KEY')),
-    from: resolveLeadSender(),
+    from: resolveLeadSender(channel),
     replyTo: readOptionalEnv('RESEND_REPLY_TO', 'soporte@verifactu.business'),
   };
 }
@@ -164,7 +168,7 @@ export async function sendHoldedLeadCommunication(input: LeadPayload) {
 }
 
 export async function sendHoldedConnectedCommunication(input: ConnectedPayload) {
-  const { resend, from, replyTo } = createResendTransport();
+  const { resend, from, replyTo } = createResendTransport(input.channel);
   const configuredAdminRecipients = readEmailList(
     process.env.HOLDED_ADMIN_NOTIFICATION_EMAILS,
     process.env.HOLDED_ADMIN_EMAILS,
@@ -319,7 +323,7 @@ export async function sendHoldedDisconnectedCommunication(input: {
   companyName: string;
   channel: 'dashboard' | 'chatgpt' | 'claude' | 'mobile';
 }) {
-  const { resend, from, replyTo } = createResendTransport();
+  const { resend, from, replyTo } = createResendTransport(input.channel);
 
   const holdedSiteUrl =
     cleanEnv(process.env.NEXT_PUBLIC_HOLDED_SITE_URL) || 'https://holded.verifactu.business';
@@ -526,7 +530,7 @@ export async function sendHoldedFirstActivityNotification(input: {
   toolUsed: string | null;
   detectedAt?: Date;
 }) {
-  const { resend, from, replyTo } = createResendTransport();
+  const { resend, from, replyTo } = createResendTransport(input.channel);
   const adminRecipients = readAdminEmailList();
   if (adminRecipients.length === 0) {
     return { sent: false, reason: 'no_admin_recipients' as const };
@@ -564,7 +568,7 @@ export async function sendHoldedInvoiceDraftNotification(input: {
   currency: string | null;
   detectedAt?: Date;
 }) {
-  const { resend, from, replyTo } = createResendTransport();
+  const { resend, from, replyTo } = createResendTransport(input.channel);
   const adminRecipients = readAdminEmailList();
   if (adminRecipients.length === 0) {
     return { sent: false, reason: 'no_admin_recipients' as const };
@@ -604,7 +608,7 @@ export async function sendHoldedAuthFailuresBurst(input: {
   windowMinutes: number;
   detectedAt?: Date;
 }) {
-  const { resend, from, replyTo } = createResendTransport();
+  const { resend, from, replyTo } = createResendTransport(input.channel);
   const adminRecipients = readAdminEmailList();
   const supportEmail = readOptionalEnv('SUPPORT_NOTIFICATION_EMAIL', 'soporte@verifactu.business');
   const reconnectUrl = `${readOptionalEnv('NEXT_PUBLIC_HOLDED_SITE_URL', 'https://holded.verifactu.business')}/auth/holded-direct?source=auth_failures_burst`;


### PR DESCRIPTION
## Summary

- **OG images dinámicas**: nuevas rutas `/api/og/chatgpt` y `/api/og/claude` generan imágenes 1200×630 con `ImageResponse` de `next/og` — logos reales de ChatGPT/Claude + Holded sobre fondo oscuro
- **Sender names**: emails enviados desde flujos ChatGPT muestran `ChatGPT x Holded`, desde Claude muestran `Claude x Holded` (mismo dominio `no-reply@holded.verifactu.business`)
- **Scope**: `resolveLeadSender(channel)` + `createResendTransport(channel)` propagado en connected/disconnected/firstActivity/invoiceDraft/authFailures

## Test plan

- [ ] `https://holded.verifactu.business/api/og/chatgpt` devuelve PNG 1200×630 con los dos logos
- [ ] `https://holded.verifactu.business/api/og/claude` devuelve PNG 1200×630 con los dos logos
- [ ] Compartir link de `/conectores/chatgpt` en WhatsApp/Telegram muestra la preview con ambos iconos
- [ ] Compartir link de `/conectores/claude` muestra preview con iconos Claude + Holded
- [ ] Email de bienvenida tras conectar vía ChatGPT muestra remitente `ChatGPT x Holded`
- [ ] Email de bienvenida tras conectar vía Claude muestra remitente `Claude x Holded`

🤖 Generated with [Claude Code](https://claude.com/claude-code)