### PR TITLE
feat(holded): UX cluster E/F — confetti, toast, ChannelBadge, ConnectorRequirementsCard, hub público-ready

### DIFF
--- a/apps/app/app/dashboard/integrations/holded/page.tsx
+++ b/apps/app/app/dashboard/integrations/holded/page.tsx
@@ -20,6 +20,7 @@ import {
   type HoldedUiBanner,
 } from '@verifactu/integrations/holded/uiState';
 import { StatusBadge } from '@verifactu/ui';
+import { ChannelBadge } from '@/components/holded/ChannelBadge';
 import { ArrowLeft, RefreshCcw, TriangleAlert } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
@@ -1184,6 +1185,21 @@ export default function HoldedConnectorPage() {
             <StatusBadge
               label={connectionBadge.label}
               variant={badgeVariantToUiVariant(connectionBadge.variant)}
+            />
+            {/* Channel pill (ChatGPT verde / Claude amber / Panel interno gris).
+                Visible solo cuando hay una conexión activa con channelKey
+                identificado — antes esta info estaba enterrada en la
+                respuesta JSON sin pista visual al usuario. Cluster E auditoría
+                2026-05-19. */}
+            <ChannelBadge
+              channelKey={
+                (integration?.connection?.originChannel as
+                  | 'chatgpt'
+                  | 'claude'
+                  | 'dashboard'
+                  | 'legacy'
+                  | null) ?? null
+              }
             />
             <StatusBadge
               label={fiscalProfileBadge}

--- a/apps/app/components/holded/ChannelBadge.tsx
+++ b/apps/app/components/holded/ChannelBadge.tsx
@@ -1,0 +1,40 @@
+/**
+ * ChannelBadge — pill visual que indica qué canal (ChatGPT, Claude, panel) tiene
+ * conectada la integración Holded del tenant.
+ *
+ * Reutiliza `StatusBadge` de @verifactu/ui (mismo aspect que los otros badges
+ * de status que aparecen en el dashboard) pero usa colores distintos por
+ * canal — verde para ChatGPT (alineado con el branding rojo/verde de OpenAI),
+ * ámbar para Claude (paleta amber de Anthropic), neutro gris para el panel
+ * interno de Isaak ("dashboard") y para el canal legacy.
+ *
+ * Por qué existe:
+ *   El dashboard usuario antes mostraba el status de conexión sin pista
+ *   visual de qué canal estaba en uso. Para tenants con varias integraciones
+ *   activas (ChatGPT + Claude + dashboard interno) la info estaba enterrada
+ *   en el JSON de respuesta pero no era visible en UI. Este badge cierra ese
+ *   gap — ver auditoría 360 (2026-05-19) cluster E.
+ */
+
+import { StatusBadge, type StatusVariant } from '@verifactu/ui';
+
+type ChannelKey = 'chatgpt' | 'claude' | 'dashboard' | 'legacy' | null | undefined;
+
+type ChannelMeta = {
+  label: string;
+  variant: StatusVariant;
+};
+
+const CHANNEL_META: Record<NonNullable<ChannelKey>, ChannelMeta> = {
+  chatgpt: { label: 'ChatGPT', variant: 'success' },
+  claude: { label: 'Claude', variant: 'warning' },
+  dashboard: { label: 'Panel interno', variant: 'neutral' },
+  legacy: { label: 'Legacy', variant: 'neutral' },
+};
+
+export function ChannelBadge({ channelKey }: { channelKey: ChannelKey }) {
+  if (!channelKey) return null;
+  const meta = CHANNEL_META[channelKey];
+  if (!meta) return null;
+  return <StatusBadge label={`Canal ${meta.label}`} variant={meta.variant} />;
+}

--- a/apps/holded/app/auth/holded-claude/HoldedClaudeForm.tsx
+++ b/apps/holded/app/auth/holded-claude/HoldedClaudeForm.tsx
@@ -198,6 +198,7 @@ export function HoldedClaudeForm({ sessionEmail }: { sessionEmail: string | null
   const [acceptedPrivacy, setAcceptedPrivacy] = useState(false);
   const [step2Loading, setStep2Loading] = useState(false);
   const [step2Error, setStep2Error] = useState<string | null>(null);
+  const [step2Success, setStep2Success] = useState(false);
   const [apiKeyReadOnly, setApiKeyReadOnly] = useState(true);
   const [apiKeyTouched, setApiKeyTouched] = useState(false);
   const [switchingAccount, setSwitchingAccount] = useState(false);
@@ -362,7 +363,14 @@ export function HoldedClaudeForm({ sessionEmail }: { sessionEmail: string | null
         return;
       }
 
-      window.location.replace(data.redirectUrl ?? next);
+      // Mostrar confirmación visual antes del redirect — el usuario sale del
+      // dominio holded.verifactu.business y necesita feedback claro de que la
+      // conexión se ha hecho. ~1.2 s es suficiente para registrar el éxito sin
+      // hacer la espera molesta. El email de bienvenida llega en paralelo.
+      setStep2Success(true);
+      setTimeout(() => {
+        window.location.replace(data.redirectUrl ?? next);
+      }, 1200);
     } catch {
       setStep2Error(ERROR_MESSAGES.NETWORK_ERROR);
       setStep2Loading(false);
@@ -702,6 +710,22 @@ export function HoldedClaudeForm({ sessionEmail }: { sessionEmail: string | null
                       className="mt-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm leading-6 text-rose-800"
                     >
                       {step2Error}
+                    </div>
+                  ) : null}
+
+                  {step2Success ? (
+                    <div
+                      role="status"
+                      aria-live="polite"
+                      className="mt-4 flex items-center gap-3 rounded-2xl border border-emerald-200 bg-emerald-50/80 px-4 py-3 text-sm leading-6 text-emerald-900 shadow-sm"
+                    >
+                      <CheckCircle2 className="h-5 w-5 shrink-0 text-emerald-600" />
+                      <div>
+                        <p className="font-semibold">Conector activado.</p>
+                        <p className="text-xs leading-5 text-emerald-800/90">
+                          Volviendo a Claude para terminar la autorización…
+                        </p>
+                      </div>
                     </div>
                   ) : null}
 

--- a/apps/holded/app/auth/holded-claude/HoldedClaudeForm.tsx
+++ b/apps/holded/app/auth/holded-claude/HoldedClaudeForm.tsx
@@ -30,6 +30,12 @@ import Image from 'next/image';
 import { useSearchParams } from 'next/navigation';
 import { useEffect, useMemo, useState, type FormEvent } from 'react';
 
+import { useConnectorConfetti } from '../lib/useConnectorConfetti';
+
+// Paleta amber alineada con el branding Claude (la landing /conectores/claude
+// usa el rango #fffbeb..#d97757) — el confetti la usa al activar el conector.
+const CLAUDE_CONFETTI_PALETTE = ['#f59e0b', '#fbbf24', '#fcd34d', '#d97706', '#b45309', '#92400e'];
+
 const HOLDED_SITE_URL =
   process.env.NEXT_PUBLIC_HOLDED_SITE_URL || 'https://holded.verifactu.business';
 
@@ -199,6 +205,12 @@ export function HoldedClaudeForm({ sessionEmail }: { sessionEmail: string | null
   const [step2Loading, setStep2Loading] = useState(false);
   const [step2Error, setStep2Error] = useState<string | null>(null);
   const [step2Success, setStep2Success] = useState(false);
+
+  // Celebración micro-interaction al activar el conector. Holded usa
+  // confetti al crear empresa — replicamos ese momento "fiesta" cuando
+  // el OAuth + API key se han guardado. Respeta prefers-reduced-motion.
+  const { play: playConfetti } = useConnectorConfetti();
+
   const [apiKeyReadOnly, setApiKeyReadOnly] = useState(true);
   const [apiKeyTouched, setApiKeyTouched] = useState(false);
   const [switchingAccount, setSwitchingAccount] = useState(false);
@@ -368,6 +380,7 @@ export function HoldedClaudeForm({ sessionEmail }: { sessionEmail: string | null
       // conexión se ha hecho. ~1.2 s es suficiente para registrar el éxito sin
       // hacer la espera molesta. El email de bienvenida llega en paralelo.
       setStep2Success(true);
+      playConfetti({ colors: CLAUDE_CONFETTI_PALETTE, durationMs: 1100 });
       setTimeout(() => {
         window.location.replace(data.redirectUrl ?? next);
       }, 1200);

--- a/apps/holded/app/auth/holded-direct/HoldedDirectForm.tsx
+++ b/apps/holded/app/auth/holded-direct/HoldedDirectForm.tsx
@@ -47,6 +47,13 @@ import Image from 'next/image';
 import { useSearchParams } from 'next/navigation';
 import { useEffect, useMemo, useState, type FormEvent } from 'react';
 
+import { useConnectorConfetti } from '../lib/useConnectorConfetti';
+
+// Paleta inspirada en el branding OpenAI/ChatGPT (verde) + accent coral que
+// usa la landing /conectores/chatgpt — el confetti la usa al activar el
+// conector.
+const CHATGPT_CONFETTI_PALETTE = ['#10b981', '#34d399', '#6ee7b7', '#ff5460', '#fb7185', '#fecaca'];
+
 const HOLDED_SITE_URL =
   process.env.NEXT_PUBLIC_HOLDED_SITE_URL || 'https://holded.verifactu.business';
 
@@ -221,6 +228,11 @@ export function HoldedDirectForm({ sessionEmail }: { sessionEmail: string | null
   const [step2Loading, setStep2Loading] = useState(false);
   const [step2Error, setStep2Error] = useState<string | null>(null);
   const [step2Success, setStep2Success] = useState(false);
+
+  // Celebración micro-interaction al activar el conector ChatGPT. Holded usa
+  // confetti al crear empresa — replicamos ese momento "fiesta" cuando el
+  // OAuth + API key se han guardado. Respeta prefers-reduced-motion.
+  const { play: playConfetti } = useConnectorConfetti();
   const [switchingAccount, setSwitchingAccount] = useState(false);
   const [apiKeyReadOnly, setApiKeyReadOnly] = useState(true);
   const [apiKeyTouched, setApiKeyTouched] = useState(false);
@@ -408,6 +420,7 @@ export function HoldedDirectForm({ sessionEmail }: { sessionEmail: string | null
       // claro. ~1.2 s es suficiente para registrar el éxito sin molestar.
       // El email de bienvenida llega en paralelo.
       setStep2Success(true);
+      playConfetti({ colors: CHATGPT_CONFETTI_PALETTE, durationMs: 1100 });
       setTimeout(() => {
         window.location.replace(data.redirectUrl ?? next);
       }, 1200);

--- a/apps/holded/app/auth/holded-direct/HoldedDirectForm.tsx
+++ b/apps/holded/app/auth/holded-direct/HoldedDirectForm.tsx
@@ -220,6 +220,7 @@ export function HoldedDirectForm({ sessionEmail }: { sessionEmail: string | null
   const [acceptedPrivacy, setAcceptedPrivacy] = useState(false);
   const [step2Loading, setStep2Loading] = useState(false);
   const [step2Error, setStep2Error] = useState<string | null>(null);
+  const [step2Success, setStep2Success] = useState(false);
   const [switchingAccount, setSwitchingAccount] = useState(false);
   const [apiKeyReadOnly, setApiKeyReadOnly] = useState(true);
   const [apiKeyTouched, setApiKeyTouched] = useState(false);
@@ -402,7 +403,14 @@ export function HoldedDirectForm({ sessionEmail }: { sessionEmail: string | null
         return;
       }
 
-      window.location.replace(data.redirectUrl ?? next);
+      // Confirmación visual antes del redirect — el usuario va a salir del
+      // dominio holded.verifactu.business hacia ChatGPT y necesita feedback
+      // claro. ~1.2 s es suficiente para registrar el éxito sin molestar.
+      // El email de bienvenida llega en paralelo.
+      setStep2Success(true);
+      setTimeout(() => {
+        window.location.replace(data.redirectUrl ?? next);
+      }, 1200);
     } catch {
       setStep2Error(ERROR_MESSAGES.NETWORK_ERROR);
       setStep2Loading(false);
@@ -748,6 +756,22 @@ export function HoldedDirectForm({ sessionEmail }: { sessionEmail: string | null
                       className="mt-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm leading-6 text-rose-800"
                     >
                       {step2Error}
+                    </div>
+                  ) : null}
+
+                  {step2Success ? (
+                    <div
+                      role="status"
+                      aria-live="polite"
+                      className="mt-4 flex items-center gap-3 rounded-2xl border border-emerald-200 bg-emerald-50/80 px-4 py-3 text-sm leading-6 text-emerald-900 shadow-sm"
+                    >
+                      <CheckCircle2 className="h-5 w-5 shrink-0 text-emerald-600" />
+                      <div>
+                        <p className="font-semibold">Conector activado.</p>
+                        <p className="text-xs leading-5 text-emerald-800/90">
+                          Volviendo a ChatGPT para terminar la autorización…
+                        </p>
+                      </div>
                     </div>
                   ) : null}
 

--- a/apps/holded/app/auth/lib/useConnectorConfetti.ts
+++ b/apps/holded/app/auth/lib/useConnectorConfetti.ts
@@ -1,0 +1,166 @@
+/**
+ * Confetti animation hook for "connector activated" success state.
+ *
+ * Triggered by HoldedClaudeForm / HoldedDirectForm when the user completes
+ * step 2 successfully (API key validated and saved). Plays for ~800ms with
+ * two emitters from the bottom-left and bottom-right corners, then auto-stops.
+ *
+ * Implementation notes:
+ *   - Vanilla canvas particles (no dependency on canvas-confetti or similar),
+ *     so we don't add a new dep to apps/holded for what is essentially a
+ *     celebratory micro-interaction.
+ *   - Canvas is a fixed-position overlay with pointer-events: none so it
+ *     never blocks clicks on the form.
+ *   - Respects `prefers-reduced-motion: reduce` — users with motion sensitivity
+ *     don't see the animation at all (still see the static success banner).
+ *   - Uses the brand palette of the connector (amber for Claude, emerald +
+ *     coral for ChatGPT) — pass the `colors` option.
+ *   - The hook is fire-and-forget: call `play()` and forget. Multiple
+ *     overlapping calls are coalesced (the existing animation keeps running).
+ */
+
+import { useCallback, useRef } from 'react';
+
+type Particle = {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  size: number;
+  rotation: number;
+  vRotation: number;
+  color: string;
+  life: number;
+  maxLife: number;
+};
+
+type PlayOptions = {
+  /** Hex colors used for the particles. Defaults to a generic celebratory palette. */
+  colors?: string[];
+  /** Total animation duration in ms. Defaults to 1500 (1.5s) — slightly longer than the redirect delay so confetti finishes before the page unloads. */
+  durationMs?: number;
+};
+
+const DEFAULT_COLORS = ['#10b981', '#f59e0b', '#ef4444', '#3b82f6', '#a855f7', '#ec4899'];
+
+function prefersReducedMotion() {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  } catch {
+    return false;
+  }
+}
+
+export function useConnectorConfetti() {
+  const isPlayingRef = useRef(false);
+
+  const play = useCallback((options: PlayOptions = {}) => {
+    if (typeof window === 'undefined') return;
+    if (isPlayingRef.current) return; // Coalesce overlapping calls.
+    if (prefersReducedMotion()) return;
+
+    isPlayingRef.current = true;
+
+    const canvas = document.createElement('canvas');
+    canvas.style.cssText = [
+      'position:fixed',
+      'inset:0',
+      'pointer-events:none',
+      'z-index:9999',
+      'width:100vw',
+      'height:100vh',
+    ].join(';');
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      isPlayingRef.current = false;
+      return;
+    }
+
+    function resize() {
+      canvas.width = window.innerWidth * window.devicePixelRatio;
+      canvas.height = window.innerHeight * window.devicePixelRatio;
+      if (ctx) ctx.scale(window.devicePixelRatio, window.devicePixelRatio);
+    }
+    resize();
+    document.body.appendChild(canvas);
+
+    const colors = options.colors && options.colors.length > 0 ? options.colors : DEFAULT_COLORS;
+    const durationMs = options.durationMs ?? 1500;
+
+    const w = window.innerWidth;
+    const h = window.innerHeight;
+    const particles: Particle[] = [];
+
+    // Two burst sources at bottom-left and bottom-right corners.
+    const sources = [
+      { x: 0, y: h, angleMin: -Math.PI / 3, angleMax: -Math.PI / 6 }, // bottom-left, shoot up-right
+      { x: w, y: h, angleMin: Math.PI + Math.PI / 6, angleMax: Math.PI + Math.PI / 3 }, // bottom-right, shoot up-left
+    ];
+
+    const PARTICLES_PER_SOURCE = 80;
+    for (const src of sources) {
+      for (let i = 0; i < PARTICLES_PER_SOURCE; i++) {
+        const angle = src.angleMin + Math.random() * (src.angleMax - src.angleMin);
+        const speed = 8 + Math.random() * 12;
+        particles.push({
+          x: src.x,
+          y: src.y,
+          vx: Math.cos(angle) * speed,
+          vy: Math.sin(angle) * speed,
+          size: 4 + Math.random() * 6,
+          rotation: Math.random() * Math.PI * 2,
+          vRotation: (Math.random() - 0.5) * 0.3,
+          color: colors[Math.floor(Math.random() * colors.length)] ?? colors[0]!,
+          life: 0,
+          maxLife: durationMs,
+        });
+      }
+    }
+
+    const start = performance.now();
+    function frame(now: number) {
+      const elapsed = now - start;
+      if (!ctx) return;
+      ctx.clearRect(0, 0, w, h);
+
+      let alive = 0;
+      for (const p of particles) {
+        p.life = elapsed;
+        if (p.life > p.maxLife) continue;
+        alive++;
+
+        // Physics: gravity + air drag.
+        p.vy += 0.35; // gravity
+        p.vx *= 0.99;
+        p.vy *= 0.99;
+        p.x += p.vx;
+        p.y += p.vy;
+        p.rotation += p.vRotation;
+
+        // Fade out near end of life.
+        const lifeRatio = p.life / p.maxLife;
+        const alpha = lifeRatio < 0.7 ? 1 : 1 - (lifeRatio - 0.7) / 0.3;
+
+        ctx.save();
+        ctx.translate(p.x, p.y);
+        ctx.rotate(p.rotation);
+        ctx.globalAlpha = Math.max(0, alpha);
+        ctx.fillStyle = p.color;
+        // Rectangular confetti (más Holded-style que círculos).
+        ctx.fillRect(-p.size / 2, -p.size / 4, p.size, p.size / 2);
+        ctx.restore();
+      }
+
+      if (alive > 0 && elapsed < durationMs + 200) {
+        requestAnimationFrame(frame);
+      } else {
+        canvas.remove();
+        isPlayingRef.current = false;
+      }
+    }
+    requestAnimationFrame(frame);
+  }, []);
+
+  return { play };
+}

--- a/apps/holded/app/components/ConnectorLandingClient.tsx
+++ b/apps/holded/app/components/ConnectorLandingClient.tsx
@@ -28,6 +28,7 @@ import Link from 'next/link';
 import type { ComponentType } from 'react';
 import { ConnectorComparison } from '@/app/components/ConnectorComparison';
 import { ConnectorFAQ } from '@/app/components/ConnectorFAQ';
+import { ConnectorRequirementsCard } from '@/app/components/ConnectorRequirementsCard';
 
 type ConnectorId = 'claude' | 'chatgpt';
 
@@ -639,6 +640,13 @@ export function ConnectorLandingClient({ connector }: { connector: ConnectorId }
           </div>
         </div>
       </section>
+
+      {/* Requisitos y limitaciones — cláusulas ajenas al conector (licencias
+          ChatGPT/Claude, autenticación previa en claude.ai) + enlaces
+          externos a Holded/ChatGPT/Claude para usuarios que no conocen las
+          plataformas. Posicionada antes del FAQ para que las objeciones
+          comerciales se resuelvan ANTES de hacer scroll por las preguntas. */}
+      <ConnectorRequirementsCard connector={connector} />
 
       {/* FAQ — preguntas frecuentes con JSON-LD FAQPage inyectado en page.tsx.
           Posicionada justo antes de Soporte porque resuelve objeciones que

--- a/apps/holded/app/components/ConnectorRequirementsCard.tsx
+++ b/apps/holded/app/components/ConnectorRequirementsCard.tsx
@@ -1,0 +1,254 @@
+/**
+ * ConnectorRequirementsCard — bloque visible en las landings ChatGPT y Claude
+ * que cubre tres gaps reportados en la auditoría de 2026-05-19:
+ *
+ *   1. Cláusulas de limitaciones AJENAS al conector (depende de licencias
+ *      contratadas con OpenAI/Anthropic). El texto legal completo está en
+ *      `/conectores/{chatgpt|claude}/terms`, pero el usuario debe verlo en la
+ *      landing antes de intentar conectar.
+ *
+ *   2. Aviso explícito sobre el flow Claude.ai: para que el OAuth bridge
+ *      funcione el usuario tiene que estar autenticado en claude.ai ANTES de
+ *      pulsar "Añadir a Claude". Si no, la primera redirección le devuelve a
+ *      claude.ai/login y pierde el contexto. Verificado live por soporte.
+ *
+ *   3. Enlaces externos a Holded, ChatGPT y Claude para que usuarios que no
+ *      conocen ninguna de las tres plataformas puedan informarse antes de
+ *      decidir si esta integración les sirve.
+ *
+ * Renderizado en `ConnectorLandingClient`, justo después de "Trust points" y
+ * antes del bloque FAQ.
+ */
+
+import { ExternalLink, ShieldAlert, KeyRound, Sparkles, BookOpen } from 'lucide-react';
+import Link from 'next/link';
+
+type ConnectorId = 'chatgpt' | 'claude';
+
+type CopyBlock = {
+  /** Title of the connector-specific subscription requirement. */
+  subscriptionTitle: string;
+  /** Body text describing what plan(s) are required. */
+  subscriptionBody: string;
+  /** Link to the official subscription page (where to upgrade if missing). */
+  subscriptionHref: string;
+  subscriptionHrefLabel: string;
+  /** Login-prerequisite note. Only Claude has a strict pre-login requirement. */
+  loginRequirementTitle?: string;
+  loginRequirementBody?: string;
+  /** External link to the AI vendor for users unfamiliar with the platform. */
+  aiVendorHref: string;
+  aiVendorLabel: string;
+  aiVendorBlurb: string;
+  /** Theme accent classes (Tailwind). */
+  accentBorder: string;
+  accentText: string;
+  accentBg: string;
+};
+
+const COPY: Record<ConnectorId, CopyBlock> = {
+  chatgpt: {
+    subscriptionTitle: 'Necesitas una suscripción ChatGPT con conectores activos',
+    subscriptionBody:
+      'Los conectores de ChatGPT (incluido este) están disponibles en ChatGPT Plus, Pro, Business, Enterprise y Edu. No están disponibles en el plan gratuito de ChatGPT. Si tu plan no incluye conectores, debes actualizar tu suscripción con OpenAI antes — Verifactu no puede activarlos por ti.',
+    subscriptionHref: 'https://openai.com/chatgpt/pricing/',
+    subscriptionHrefLabel: 'Ver planes ChatGPT',
+    aiVendorHref: 'https://chatgpt.com',
+    aiVendorLabel: 'Conoce ChatGPT',
+    aiVendorBlurb:
+      'ChatGPT es el asistente conversacional de OpenAI. Los "conectores" permiten que ChatGPT consulte tus herramientas (como Holded) sin copy-paste manual.',
+    accentBorder: 'border-[#10a37f]/25',
+    accentText: 'text-[#10a37f]',
+    accentBg: 'bg-[#10a37f]/5',
+  },
+  claude: {
+    subscriptionTitle: 'Necesitas una suscripción Claude con conectores activos',
+    subscriptionBody:
+      'Los conectores externos de Claude (incluido este) están disponibles en Claude Pro, Team y Enterprise. No están disponibles en el plan gratuito de claude.ai. Si tu plan no incluye conectores, debes actualizar tu suscripción con Anthropic antes — Verifactu no puede activarlos por ti.',
+    subscriptionHref: 'https://www.anthropic.com/pricing',
+    subscriptionHrefLabel: 'Ver planes Claude',
+    loginRequirementTitle: 'Inicia sesión en claude.ai ANTES de pulsar "Añadir a Claude"',
+    loginRequirementBody:
+      'El botón "Añadir a Claude" usa el bridge OAuth oficial de Anthropic. Si tu navegador no tiene sesión activa en claude.ai en ese momento, te redirige a la pantalla de login y se pierde el contexto. Abre claude.ai en otra pestaña, confirma que estás dentro de tu cuenta, y vuelve aquí — el flow funciona en unos segundos.',
+    aiVendorHref: 'https://claude.ai',
+    aiVendorLabel: 'Conoce Claude',
+    aiVendorBlurb:
+      'Claude es el asistente conversacional de Anthropic. Los "conectores remotos" permiten que Claude consulte tus herramientas (como Holded) sin copy-paste manual.',
+    accentBorder: 'border-[#d97757]/25',
+    accentText: 'text-[#d97757]',
+    accentBg: 'bg-[#d97757]/5',
+  },
+};
+
+export function ConnectorRequirementsCard({ connector }: { connector: ConnectorId }) {
+  const copy = COPY[connector];
+
+  return (
+    <section className="border-y border-slate-100 bg-white py-16 sm:py-20">
+      <div className="mx-auto max-w-6xl px-4">
+        <div className="mb-8 text-center">
+          <p className="text-xs font-bold uppercase tracking-[0.18em] text-slate-400">
+            Antes de conectar
+          </p>
+          <h2 className="mt-3 text-3xl font-bold tracking-tight text-slate-950">
+            Requisitos y limitaciones.
+          </h2>
+          <p className="mx-auto mt-3 max-w-2xl text-sm leading-7 text-slate-600">
+            Este conector depende de servicios de terceros (Holded, OpenAI/Anthropic) cuyas
+            licencias contratas directamente con ellos. Verifactu Business desarrolla y mantiene la
+            integración, pero no puede activar funciones que dependen de tu suscripción con esos
+            terceros.
+          </p>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          {/* Subscription / licensing clause */}
+          <div className={`rounded-3xl border ${copy.accentBorder} ${copy.accentBg} p-6 shadow-sm`}>
+            <div className="flex items-start gap-3">
+              <ShieldAlert className={`mt-0.5 h-5 w-5 shrink-0 ${copy.accentText}`} />
+              <div>
+                <h3 className="text-base font-bold text-slate-950">{copy.subscriptionTitle}</h3>
+                <p className="mt-2 text-sm leading-6 text-slate-700">{copy.subscriptionBody}</p>
+                <a
+                  href={copy.subscriptionHref}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={`mt-3 inline-flex items-center gap-1.5 text-sm font-semibold ${copy.accentText} hover:underline`}
+                >
+                  <ExternalLink className="h-3.5 w-3.5" />
+                  {copy.subscriptionHrefLabel}
+                </a>
+              </div>
+            </div>
+          </div>
+
+          {/* Holded license clause (mismo para ambos) */}
+          <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+            <div className="flex items-start gap-3">
+              <KeyRound className="mt-0.5 h-5 w-5 shrink-0 text-[#ff5460]" />
+              <div>
+                <h3 className="text-base font-bold text-slate-950">
+                  Y una cuenta Holded con permisos de API
+                </h3>
+                <p className="mt-2 text-sm leading-6 text-slate-700">
+                  Necesitas una cuenta activa de Holded y permiso de administrador para generar una
+                  API key (Configuración → Desarrolladores → API). Las cuentas de prueba de Holded
+                  funcionan; las cuentas suspendidas o sin acceso a API no.
+                </p>
+                <a
+                  href="https://www.holded.com/es"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mt-3 inline-flex items-center gap-1.5 text-sm font-semibold text-[#ff5460] hover:underline"
+                >
+                  <ExternalLink className="h-3.5 w-3.5" />
+                  Ver planes Holded
+                </a>
+              </div>
+            </div>
+          </div>
+
+          {/* Claude-only: login prerequisite */}
+          {copy.loginRequirementTitle ? (
+            <div
+              className={`md:col-span-2 rounded-3xl border ${copy.accentBorder} ${copy.accentBg} p-6 shadow-sm`}
+            >
+              <div className="flex items-start gap-3">
+                <Sparkles className={`mt-0.5 h-5 w-5 shrink-0 ${copy.accentText}`} />
+                <div>
+                  <h3 className="text-base font-bold text-slate-950">
+                    {copy.loginRequirementTitle}
+                  </h3>
+                  <p className="mt-2 text-sm leading-6 text-slate-700">
+                    {copy.loginRequirementBody}
+                  </p>
+                  <a
+                    href="https://claude.ai/login"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={`mt-3 inline-flex items-center gap-1.5 text-sm font-semibold ${copy.accentText} hover:underline`}
+                  >
+                    <ExternalLink className="h-3.5 w-3.5" />
+                    Abrir claude.ai en otra pestaña
+                  </a>
+                </div>
+              </div>
+            </div>
+          ) : null}
+        </div>
+
+        {/* Vendor info cards — para usuarios que no conocen las plataformas */}
+        <div className="mt-8 rounded-3xl border border-slate-200 bg-slate-50 p-6">
+          <div className="mb-5 flex items-center gap-2">
+            <BookOpen className="h-4 w-4 text-slate-500" />
+            <h3 className="text-xs font-bold uppercase tracking-[0.18em] text-slate-500">
+              ¿No conoces estas plataformas?
+            </h3>
+          </div>
+          <div className="grid gap-4 md:grid-cols-3">
+            <a
+              href="https://www.holded.com/es"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group rounded-2xl border border-slate-200 bg-white p-4 transition hover:shadow-md"
+            >
+              <div className="text-sm font-semibold text-slate-900 group-hover:text-[#ff5460]">
+                Holded
+              </div>
+              <p className="mt-1.5 text-xs leading-5 text-slate-600">
+                Software de gestión empresarial todo-en-uno (facturación, contabilidad, CRM,
+                proyectos) usado por más de 100.000 PYMEs en España y Europa.
+              </p>
+              <span className="mt-2 inline-flex items-center gap-1 text-xs font-semibold text-slate-500 group-hover:text-[#ff5460]">
+                holded.com
+                <ExternalLink className="h-3 w-3" />
+              </span>
+            </a>
+            <a
+              href={copy.aiVendorHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group rounded-2xl border border-slate-200 bg-white p-4 transition hover:shadow-md"
+            >
+              <div
+                className={`text-sm font-semibold text-slate-900 group-hover:${copy.accentText}`}
+              >
+                {copy.aiVendorLabel.replace('Conoce ', '')}
+              </div>
+              <p className="mt-1.5 text-xs leading-5 text-slate-600">{copy.aiVendorBlurb}</p>
+              <span
+                className={`mt-2 inline-flex items-center gap-1 text-xs font-semibold text-slate-500 group-hover:${copy.accentText}`}
+              >
+                {copy.aiVendorHref.replace('https://', '')}
+                <ExternalLink className="h-3 w-3" />
+              </span>
+            </a>
+            <Link
+              href="/conectores"
+              className="group rounded-2xl border border-slate-200 bg-white p-4 transition hover:shadow-md"
+            >
+              <div className="text-sm font-semibold text-slate-900 group-hover:text-[#ff5460]">
+                ¿No sabes cuál usar?
+              </div>
+              <p className="mt-1.5 text-xs leading-5 text-slate-600">
+                Si ya tienes ChatGPT o Claude en tu trabajo, usa el conector correspondiente. Si no
+                usas ninguno, prueba primero la plataforma gratuita y vuelve aquí cuando hayas
+                upgrade a un plan con conectores.
+              </p>
+              <span className="mt-2 inline-flex items-center gap-1 text-xs font-semibold text-slate-500 group-hover:text-[#ff5460]">
+                Hub de conectores
+                <ExternalLink className="h-3 w-3" />
+              </span>
+            </Link>
+          </div>
+        </div>
+
+        <p className="mt-6 text-center text-xs text-slate-500">
+          Verifactu Business es una integración independiente — no somos Holded, OpenAI ni
+          Anthropic. Cada plataforma mantiene sus propios términos de servicio, privacidad y
+          condiciones comerciales.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/apps/holded/app/conectores/page.tsx
+++ b/apps/holded/app/conectores/page.tsx
@@ -3,11 +3,47 @@ import type { Metadata } from 'next';
 import Image from 'next/image';
 import Link from 'next/link';
 
+const SITE_URL = process.env.NEXT_PUBLIC_HOLDED_SITE_URL || 'https://holded.verifactu.business';
+const HUB_URL = `${SITE_URL}/conectores`;
+const OG_IMAGE = `${SITE_URL}/brand/holded/holded-diamond-logo.png`;
+
 export const metadata: Metadata = {
   title: 'Holded con IA | Conectores ChatGPT y Claude',
   description:
-    'Elige cómo conectar Holded con ChatGPT o Claude. Consulta facturas, contactos, contabilidad, CRM y proyectos en lenguaje natural.',
+    'Conecta Holded con ChatGPT o Claude y consulta facturas, contactos, contabilidad y proyectos en lenguaje natural. Borradores solo con confirmación. Integración independiente, gratuita en lanzamiento.',
+  keywords: [
+    'Holded IA',
+    'Holded ChatGPT',
+    'Holded Claude',
+    'conector Holded',
+    'IA contabilidad',
+    'IA facturación',
+    'asistente Holded',
+    'Verifactu Business',
+  ],
   alternates: { canonical: '/conectores' },
+  openGraph: {
+    title: 'Holded con IA — Conectores ChatGPT y Claude',
+    description:
+      'Pregunta a tu Holded en lenguaje natural desde ChatGPT o Claude. Solo lectura por defecto, borradores con confirmación, credenciales protegidas.',
+    url: HUB_URL,
+    siteName: 'Holded by Verifactu Business',
+    images: [{ url: OG_IMAGE, width: 1200, height: 630, alt: 'Holded con IA' }],
+    locale: 'es_ES',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Holded con IA — Conectores ChatGPT y Claude',
+    description:
+      'Conecta Holded a ChatGPT o Claude en minutos. Facturas, contactos, contabilidad y proyectos en lenguaje natural.',
+    images: [OG_IMAGE],
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: { index: true, follow: true, 'max-snippet': -1, 'max-image-preview': 'large' },
+  },
 };
 
 const connectors = [
@@ -204,6 +240,110 @@ export default function HoldedConnectorsHubPage() {
               <Link href="/contacto" className="font-medium text-[#ff5460] hover:underline">
                 Pregúntanos →
               </Link>
+            </p>
+          </div>
+
+          {/* Requisitos previos — bloque público pensado también para gente
+              que descubre el conector por redes sociales y no conoce las 3
+              plataformas. Tres tarjetas (Holded, ChatGPT, Claude) con
+              enlaces externos para informarse antes de pulsar "Conectar". */}
+          <div className="mt-8 rounded-[1.75rem] border border-slate-200 bg-white p-6 shadow-sm">
+            <h2 className="text-[10px] font-bold uppercase tracking-wider text-slate-400">
+              Requisitos previos
+            </h2>
+            <p className="mt-3 text-sm leading-7 text-slate-700">
+              Esta integración conecta <strong>3 servicios distintos</strong> que mantienen sus
+              propios planes y términos. Verifactu Business desarrolla y mantiene el conector, pero
+              cada usuario contrata su suscripción directamente con el proveedor correspondiente.
+            </p>
+            <div className="mt-5 grid gap-4 md:grid-cols-3">
+              <a
+                href="https://www.holded.com/es"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group rounded-2xl border border-slate-200 bg-white p-4 transition hover:shadow-md"
+              >
+                <div className="flex items-center gap-2">
+                  <Image
+                    src="/brand/holded/holded-diamond-logo.png"
+                    alt="Holded"
+                    width={20}
+                    height={20}
+                    className="h-5 w-5 object-contain"
+                  />
+                  <span className="text-sm font-bold text-slate-900 group-hover:text-[#ff5460]">
+                    Holded
+                  </span>
+                </div>
+                <p className="mt-2 text-xs leading-5 text-slate-600">
+                  Software de gestión empresarial todo-en-uno: facturación, contabilidad, CRM,
+                  proyectos. Necesitas cuenta activa con permiso para generar API key.
+                </p>
+                <span className="mt-2 inline-flex items-center gap-1 text-xs font-semibold text-slate-500 group-hover:text-[#ff5460]">
+                  holded.com
+                  <ExternalLink className="h-3 w-3" />
+                </span>
+              </a>
+              <a
+                href="https://chatgpt.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group rounded-2xl border border-slate-200 bg-white p-4 transition hover:shadow-md"
+              >
+                <div className="flex items-center gap-2">
+                  <Image
+                    src="/brand/chatgpt-logo.png"
+                    alt="ChatGPT"
+                    width={20}
+                    height={20}
+                    className="h-5 w-5 object-contain"
+                  />
+                  <span className="text-sm font-bold text-slate-900 group-hover:text-[#10a37f]">
+                    ChatGPT
+                  </span>
+                </div>
+                <p className="mt-2 text-xs leading-5 text-slate-600">
+                  Asistente de OpenAI. Conectores disponibles en planes Plus, Pro, Business,
+                  Enterprise y Edu — no en el plan gratuito.
+                </p>
+                <span className="mt-2 inline-flex items-center gap-1 text-xs font-semibold text-slate-500 group-hover:text-[#10a37f]">
+                  chatgpt.com
+                  <ExternalLink className="h-3 w-3" />
+                </span>
+              </a>
+              <a
+                href="https://claude.ai"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group rounded-2xl border border-slate-200 bg-white p-4 transition hover:shadow-md"
+              >
+                <div className="flex items-center gap-2">
+                  <Image
+                    src="/brand/claude-logo.svg"
+                    alt="Claude"
+                    width={20}
+                    height={20}
+                    className="h-5 w-5 object-contain"
+                  />
+                  <span className="text-sm font-bold text-slate-900 group-hover:text-[#D4570C]">
+                    Claude
+                  </span>
+                </div>
+                <p className="mt-2 text-xs leading-5 text-slate-600">
+                  Asistente de Anthropic. Conectores remotos disponibles en planes Pro, Team y
+                  Enterprise — no en el plan gratuito. Login activo en claude.ai requerido antes de
+                  conectar.
+                </p>
+                <span className="mt-2 inline-flex items-center gap-1 text-xs font-semibold text-slate-500 group-hover:text-[#D4570C]">
+                  claude.ai
+                  <ExternalLink className="h-3 w-3" />
+                </span>
+              </a>
+            </div>
+            <p className="mt-4 text-xs leading-5 text-slate-500">
+              Si no tienes ninguna suscripción activa (Holded + ChatGPT/Claude), el conector
+              técnicamente no puede funcionar. Verifactu no puede activar funciones de terceros por
+              ti.
             </p>
           </div>
 

--- a/docs/openai-submission/PORTAL_FORM_ANSWERS.md
+++ b/docs/openai-submission/PORTAL_FORM_ANSWERS.md
@@ -1,0 +1,267 @@
+# OpenAI App Portal — Respuestas literales para cada campo
+
+Documento operativo de copy-paste para el formulario de OpenAI App Review. Cada bloque está listo para pegar en el campo correspondiente del portal sin cambios. Mantén el orden tal cual aparece en el portal.
+
+> **Última actualización: 2026-05-19.** Validado contra el `tools/list` live del MCP que devuelve exactamente las 10 tools de este documento.
+
+---
+
+## MCP Server URL
+
+```
+https://holded.verifactu.business/api/mcp/holded
+```
+
+⚠️ **Importante**: NO usar `https://app.verifactu.business/api/mcp/holded` aunque funcione. Razón: el `oauth-protected-resource` metadata declara `resource: "https://holded.verifactu.business/api/mcp/holded"` y `authorization_servers: ["https://holded.verifactu.business"]`. Si OpenAI ve un URL en el form distinto del declarado en la metadata, lo flagea como inconsistencia.
+
+## Authentication
+
+OAuth 2.0 (Authorization Code + PKCE S256, public client without client secret).
+
+Discovery automática: el portal lee `https://holded.verifactu.business/.well-known/oauth-authorization-server`. Todos los endpoints (authorize, token, register, revoke) están ahí declarados.
+
+**Advanced settings**: dejar por defecto. Nuestra discovery metadata cubre todo.
+
+---
+
+## Tool justifications (10 tools × 3 hints = 30 respuestas)
+
+Cada tool tiene 3 campos obligatorios. Las justificaciones están redactadas en inglés porque el portal está en inglés y los reviewers son angloparlantes.
+
+---
+
+### 1. `holded_list_invoices`
+
+**Read Only: True**
+
+```
+This tool only retrieves a list of sales invoices from the authenticated user's connected Holded account. It does not create, update, send, or delete invoices.
+```
+
+**Open World: False**
+
+```
+This tool is restricted to the tenant-scoped Holded connection already authorized in Verifactu. It does not browse the web, access arbitrary third-party resources, or read data outside the user's own connected Holded tenant.
+```
+
+**Destructive: False**
+
+```
+This tool is a pure read operation. It does not alter, overwrite, remove, send, issue, or delete invoice data.
+```
+
+---
+
+### 2. `holded_get_invoice`
+
+**Read Only: True**
+
+```
+This tool retrieves the details of one existing sales invoice from the authenticated user's connected Holded account. It does not edit or change the invoice.
+```
+
+**Open World: False**
+
+```
+This tool only reads invoice data within the authenticated user's connected Holded tenant. It does not interact with external systems or unrelated data sources.
+```
+
+**Destructive: False**
+
+```
+This tool performs no write or delete operations. It only reads existing invoice data.
+```
+
+---
+
+### 3. `holded_list_documents`
+
+**Read Only: True**
+
+```
+This tool lists existing commercial documents (sales receipts, credit notes, estimates, proformas, sales orders, purchase orders, purchases, purchase refunds, waybills) from the authenticated user's connected Holded account, filtered by document type and date range. It does not create, modify, send, or delete any document.
+```
+
+**Open World: False**
+
+```
+This tool is scoped to document data inside the authenticated tenant's connected Holded account. It does not browse the web or access unrelated third-party resources.
+```
+
+**Destructive: False**
+
+```
+This tool is a pure read operation. It does not alter, send, issue, finalize, or delete commercial document data.
+```
+
+---
+
+### 4. `holded_get_document`
+
+**Read Only: True**
+
+```
+This tool retrieves the full details of a single Holded commercial document by document type and ID. It does not edit, send, or delete the document.
+```
+
+**Open World: False**
+
+```
+This tool only accesses document data within the authenticated tenant's connected Holded account. It does not access external systems or other tenants.
+```
+
+**Destructive: False**
+
+```
+This tool is a read-only lookup. It does not perform any write, send, or delete operation.
+```
+
+---
+
+### 5. `holded_get_document_pdf`
+
+**Read Only: True**
+
+```
+This tool retrieves the rendered PDF representation of one existing Holded commercial document as a base64-encoded payload. It does not regenerate, modify, send, or store the PDF elsewhere — it only reads the current rendering.
+```
+
+**Open World: False**
+
+```
+This tool is restricted to the PDF rendering of documents already present in the authenticated tenant's connected Holded account. It does not fetch arbitrary PDFs from the web or access unrelated third-party resources.
+```
+
+**Destructive: False**
+
+```
+This tool performs no write or delete operation on the underlying document. It returns a read-only PDF rendering of an existing document.
+```
+
+---
+
+### 6. `holded_list_contacts`
+
+**Read Only: True**
+
+```
+This tool retrieves a list of existing contacts or customers from the authenticated user's connected Holded account. It does not create, update, merge, or delete contacts.
+```
+
+**Open World: False**
+
+```
+This tool is limited to contact data inside the authenticated user's connected Holded tenant. It does not browse the web or access unrelated third-party resources.
+```
+
+**Destructive: False**
+
+```
+This tool has no side effects. It only returns existing contact records and does not modify or remove any data.
+```
+
+---
+
+### 7. `holded_get_contact`
+
+**Read Only: True**
+
+```
+This tool retrieves the details of one existing Holded contact by ID. It does not update, merge, or delete the contact.
+```
+
+**Open World: False**
+
+```
+This tool only accesses contact data within the authenticated user's connected Holded account. It does not browse external sources or access arbitrary third-party systems.
+```
+
+**Destructive: False**
+
+```
+This tool is a read-only lookup. It does not perform any write, delete, merge, or destructive operation.
+```
+
+---
+
+### 8. `holded_list_accounts`
+
+**Read Only: True**
+
+```
+This tool retrieves accounting accounts from the authenticated user's connected Holded chart of accounts. It does not create, modify, or delete accounts.
+```
+
+**Open World: False**
+
+```
+This tool is limited to accounting data inside the tenant's authorized Holded integration. It does not access open web resources or unrelated external systems.
+```
+
+**Destructive: False**
+
+```
+This tool performs no write or delete action. It only returns existing accounting account records.
+```
+
+---
+
+### 9. `holded_list_daily_ledger`
+
+**Read Only: True**
+
+```
+This tool retrieves existing daily ledger entries from the authenticated user's connected Holded account for an explicit start and end date range. It does not create, edit, or delete accounting entries.
+```
+
+**Open World: False**
+
+```
+This tool is limited to ledger data inside the tenant's authorized Holded integration. It cannot browse the web, consult external documentation, or access unrelated third-party resources.
+```
+
+**Destructive: False**
+
+```
+This tool is a pure read operation without side effects. It does not create, update, delete, reverse, or post accounting entries.
+```
+
+---
+
+### 10. `holded_create_invoice_draft` ⚠️ (única write tool)
+
+**Read Only: False**
+
+```
+This tool creates a new sales invoice draft in the authenticated user's connected Holded account, so it is a real write operation. The connector enforces Holded `approveDoc: false` at the wire level, which means the draft is never auto-issued, sent, charged, emailed, or transmitted to AEAT/Verifactu. The tool also requires explicit user confirmation (`confirm: true`) before execution — the assistant must obtain user approval in the conversation before calling.
+```
+
+**Open World: False**
+
+```
+Although this tool writes data, it is still scoped to the authenticated user's connected Holded tenant. It does not operate on arbitrary open-world resources, browse the web, or affect other tenants.
+```
+
+**Destructive: False**
+
+```
+This tool only creates a draft invoice after explicit user confirmation. It does not delete, overwrite, send, issue, charge, email, finalize, or irreversibly destroy invoices or other existing records. The draft can still be reviewed, edited, or discarded by the user from the Holded UI before it has any legal effect.
+```
+
+---
+
+## Verificación end-to-end antes de submit
+
+```bash
+curl -sS -X POST https://holded.verifactu.business/api/mcp/holded \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
+  | node -e "const d=JSON.parse(require('fs').readFileSync(0,'utf8')); console.log('count:',d.result.tools.length); d.result.tools.forEach(t=>console.log(' ',t.name,'→',JSON.stringify(t.annotations)))"
+```
+
+Debe imprimir las 10 tools en el orden de este documento, todas con `readOnlyHint`/`destructiveHint`/`openWorldHint` que coincidan con lo que pega arriba.
+
+## Si el portal pide un outputSchema (recomendación)
+
+Es opcional ("Recommended: Add an outputSchema..."). El portal no rechaza por no tenerlo, pero mejora la calidad del razonamiento del modelo. Si quieres añadirlo, hay que tocar `apps/app/lib/integrations/holdedMcpTools.ts` y definir `outputSchema: { ... }` en cada `server.tool()` call. Recomiendo **dejarlo para una iteración post-aprobación** (submission v3) para no añadir variables nuevas al review actual.


### PR DESCRIPTION
## Summary

Cherry-picks de `fix/oauth-proxy-metadata-sync` que quedaron fuera del squash de PR #90:

- **Toast post-conexión**: notificación visual al completar el OAuth flow en dashboard  
- **ChannelBadge** (`apps/app/components/holded/ChannelBadge.tsx`): badge de canal (ChatGPT/Claude/dashboard) en el dashboard  
- **Confetti hook** (`apps/holded/app/auth/lib/useConnectorConfetti.ts`): efecto confetti al conectar exitosamente  
- **Confetti en ambos forms**: disparado en holded-form y claude-form al completar la conexión  
- **ConnectorRequirementsCard** (`apps/holded/app/components/ConnectorRequirementsCard.tsx`): card de requisitos en las landings de cada conector  
- **Hub público-ready**: auditoría de landings `/conectores/chatgpt` y `/conectores/claude` — copy actualizado, card de requisitos integrada

## Test plan

- [ ] Conectar vía ChatGPT → dashboard muestra ChannelBadge "ChatGPT" + toast de bienvenida
- [ ] Conectar vía Claude → ChannelBadge "Claude" + toast
- [ ] `/conectores/chatgpt` muestra ConnectorRequirementsCard con checklist
- [ ] `/conectores/claude` idem
- [ ] Confetti se dispara al completar ambos forms (holded-form + claude-form)

🤖 Generated with [Claude Code](https://claude.com/claude-code)