### PR TITLE
fix(isaak): prisma migrate deploy en buildCommand Vercel

### DIFF
--- a/apps/isaak/vercel.json
+++ b/apps/isaak/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
   "installCommand": "cd ../.. && npx -y pnpm@10.27.0 install --no-frozen-lockfile",
-  "buildCommand": "cd ../.. && npx -y pnpm@10.27.0 turbo run build --filter=verifactu-isaak",
+  "buildCommand": "cd ../.. && npx -y pnpm@10.27.0 --filter @verifactu/db run db:migrate:deploy && npx -y pnpm@10.27.0 turbo run build --filter=verifactu-isaak",
   "outputDirectory": ".next",
   "crons": [
     {


### PR DESCRIPTION
## Summary

Añade `prisma migrate deploy` al buildCommand de `apps/isaak/vercel.json` antes del paso de Turbo.

Crea las tablas `invoice_templates` y `tenant_certificates` en producción (migración `20260519120000_invoice_templates_and_tenant_certificates`). Sin esto, VF-T (plantillas) y VF-2 (certificados digitales) fallan en producción.

La operación es **idempotente** — Prisma solo aplica migraciones no aplicadas previamente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)