### PR TITLE
feat(holded-mcp): migrar conector Claude a claude-holded.verifactu.business + 'Holded for Claude'

### DIFF
--- a/apps/holded-mcp/CLAUDE_CONNECTOR_RESET_RUNBOOK.md
+++ b/apps/holded-mcp/CLAUDE_CONNECTOR_RESET_RUNBOOK.md
@@ -221,3 +221,60 @@ start "https://claude.verifactu.business/oauth/authorize?response_type=code&clie
 2. Si no cambia, validar primero URLs públicas y OAuth page.
 3. Solo si esas validaciones fallan, borrar y recrear el conector.
 4. Si todo valida y solo sigue el icono azul dentro de Claude, cerrar el incidente como limitación/fallback de Claude UI.
+
+## 14. Migración a subdominio nuevo (2026-05-19) — `claude-holded.verifactu.business`
+
+**Contexto:** PRs #99 y #100 fixearon todo lo que controlamos en nuestro origen (`favicon.ico` regenerado, `manifest.json` purgado de colores Verifactu, alias legacy `/icono_verifactu.business.png` sirviendo el rombo). Pero la sección 10 confirmó que Anthropic cachea server-side los iconos legacy y no re-scrapea conectores custom no aprobados. Único reset garantizado: subdominio nuevo donde Anthropic indexe fresh.
+
+### Decisiones tomadas
+
+| Variable                                    | Valor                                                 |
+| ------------------------------------------- | ----------------------------------------------------- |
+| Subdominio nuevo                            | `claude-holded.verifactu.business`                    |
+| App name (Anthropic form)                   | `Holded for Claude`                                   |
+| Endpoint legacy `claude.verifactu.business` | Mantener vivo en paralelo (alias Vercel, mismo build) |
+
+### Cambios en el código (PR de migración)
+
+1. `apps/holded-mcp/src/app.ts` — `CLAUDE_CONNECT_DEEPLINK` parametrizado vía función `buildClaudeConnectDeeplink(baseUrl, connectorName)` que toma `config.BASE_URL` en lugar del string hardcoded `claude.verifactu.business`. Cambiar el subdominio es ahora un env var change.
+2. `apps/holded-mcp/src/public-pages.ts` — `CONNECT_URL` ya no es constante de módulo: `renderLandingPage(baseUrl)` lo construye en cada render desde `baseUrl.replace(/\/$/, '') + '/launch'`.
+3. Docs en `docs/anthropic-submission/*.md` actualizados al subdominio nuevo y app name `Holded for Claude`.
+
+### Pasos operativos (Vercel + Anthropic Google Form)
+
+Asumiendo que el PR de migración está mergeado a `main`:
+
+1. **Vercel — añadir subdominio:** Settings → Domains → Add → `claude-holded.verifactu.business`. Configurar el CNAME que pide Vercel a `cname.vercel-dns.com` en el DNS provider. Esperar SSL (~1-2 min).
+2. **Vercel — cambiar env var:** Project Settings → Environment Variables → `BASE_URL`. Cambiar de `https://claude.verifactu.business` a `https://claude-holded.verifactu.business`. Aplicar a Production. Redeploy.
+3. **Verificación post-deploy:**
+   ```bash
+   curl -sS https://claude-holded.verifactu.business/.well-known/oauth-authorization-server | jq .issuer
+   # Esperado: "https://claude-holded.verifactu.business"
+   curl -sS https://claude-holded.verifactu.business/favicon.ico | md5sum
+   # Esperado: d23f99aeb2d1ea5369b6222eba8cd8e7 (rombo Holded)
+   curl -sS -X POST https://claude-holded.verifactu.business/mcp \
+     -H "Content-Type: application/json" \
+     -H "Accept: application/json, text/event-stream" \
+     -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+   # Esperado: 401 Unauthorized (correcto — necesita Bearer)
+   ```
+4. **Anthropic Google Form — submission v2:** rellenar el form en https://claude.com/docs/connectors/building/submission con los valores de `docs/anthropic-submission/submission-form-answers.md`. Server name = `Holded for Claude`, MCP URL = `https://claude-holded.verifactu.business/mcp`.
+5. **Esperar review manual** (~2 semanas según docs oficiales).
+6. **Si Anthropic aprueba con icono correcto:** desconectar el conector viejo en Claude.ai y añadir el nuevo `Holded for Claude` desde el directorio.
+
+### Qué hacer con el dominio legacy `claude.verifactu.business`
+
+Mantener vivo en paralelo. Sirve el mismo build via alias en Vercel. Tras la aprobación de la submission v2, en una ventana controlada se puede:
+
+- Opción A: dejarlo activo indefinidamente (zero break risk, mínimo coste).
+- Opción B: configurar 301 redirect a `claude-holded.verifactu.business` a nivel Vercel (rompe MCP POSTs porque la mayoría de clientes no siguen redirects 301 con POST — preferir Opción A).
+- Opción C: respond 410 Gone con mensaje "conector renombrado, reconecte desde el directorio Anthropic" (sólo si confirmamos cero usuarios activos).
+
+Recomendación: Opción A hasta que pase tiempo suficiente para confirmar que nadie usa el legacy.
+
+### Si el problema NO se resuelve con el subdominio nuevo
+
+Si tras la submission v2 + aprobación, el directorio Anthropic sigue mostrando branding incorrecto, las hipótesis son:
+
+1. Anthropic está cacheando por `submitter email` u otro identificador, no por dominio. (Improbable, pero verificable cambiando el email de submission.)
+2. El form de submission no respeta el `logo_uri` proporcionado y Anthropic sigue scraping `/favicon.ico` del dominio. En ese caso confirmar visualmente que el subdominio nuevo sirve el rombo y abrir ticket a `partnerships@anthropic.com`.

--- a/apps/holded-mcp/src/app.ts
+++ b/apps/holded-mcp/src/app.ts
@@ -19,8 +19,16 @@ const __dirname = path.dirname(__filename);
 const publicDir = path.join(__dirname, '..', 'public');
 
 // Deep-link to Claude's "add custom connector" dialog with our MCP URL pre-filled.
-const CLAUDE_CONNECT_DEEPLINK =
-  'https://claude.ai/customize/connectors?modal=add-custom-connector&connectorName=Holded&connectorUrl=https%3A%2F%2Fclaude.verifactu.business%2Fmcp';
+// Built dynamically from config.BASE_URL so swapping subdomains is one env var change.
+function buildClaudeConnectDeeplink(baseUrl: string, connectorName = 'Holded for Claude'): string {
+  const mcpUrl = `${baseUrl.replace(/\/$/, '')}/mcp`;
+  const params = new URLSearchParams({
+    modal: 'add-custom-connector',
+    connectorName,
+    connectorUrl: mcpUrl,
+  });
+  return `https://claude.ai/customize/connectors?${params.toString()}`;
+}
 
 // Read the shared __session JWT from the request cookies.
 // Returns tenantId if the user has an existing Verifactu connection, null otherwise.
@@ -157,7 +165,7 @@ export function createApp() {
   app.get('/launch', async (req, res) => {
     const session = await readLaunchSession(req);
     if (session?.tenantId) {
-      res.redirect(302, CLAUDE_CONNECT_DEEPLINK);
+      res.redirect(302, buildClaudeConnectDeeplink(config.BASE_URL));
       return;
     }
     const bridgeUrl = new URL('/auth/holded-claude', config.HOLDED_PUBLIC_URL);

--- a/apps/holded-mcp/src/public-pages.ts
+++ b/apps/holded-mcp/src/public-pages.ts
@@ -1,6 +1,8 @@
 const SUPPORT_EMAIL = 'soporte@verifactu.business';
 const HOLDED_BASE = 'https://holded.verifactu.business/conectores/claude';
-const CONNECT_URL = 'https://claude.verifactu.business/launch';
+// CONNECT_URL is derived from baseUrl at render time (renderLandingPage receives it).
+// This makes subdomain swaps (e.g. claude.verifactu.business → claude-holded.verifactu.business)
+// a one-env-var change in Vercel instead of a code edit.
 
 function escapeHtml(value: string) {
   return value
@@ -87,8 +89,8 @@ const TRUST_POINTS = [
   'No envía, emite, cobra, finaliza, elimina ni sobrescribe facturas o registros existentes.',
 ];
 
-export function renderLandingPage(_baseUrl: string) {
-  const connectHref = escapeHtml(CONNECT_URL);
+export function renderLandingPage(baseUrl: string) {
+  const connectHref = escapeHtml(`${baseUrl.replace(/\/$/, '')}/launch`);
   const holdedBase = escapeHtml(HOLDED_BASE);
 
   const capsHtml = CAPABILITIES.map(

--- a/docs/anthropic-submission/README.md
+++ b/docs/anthropic-submission/README.md
@@ -1,33 +1,39 @@
 # Anthropic Connectors Directory — Submission Package
 
-**Connector:** Holded × Claude
+**Connector:** Holded for Claude
+**App name (Anthropic form):** `Holded for Claude`
 **Submitter:** Verifactu Business
 **Email de contacto:** soporte@verifactu.business
 **Email de escalation Anthropic:** partnerships@anthropic.com
 **Form URL:** https://claude.com/docs/connectors/building/submission (la página linkea al Google Form actual)
 
-## Estado actual (post-2026-05-18, submission v2)
+## ⚠️ Submission v2 desde nuevo subdominio (2026-05-19)
 
-- ✅ MCP server desplegado: `https://claude.verifactu.business/mcp`
+Esta es una **nueva entrada** en el Anthropic Connectors Directory, con un subdominio nuevo (`claude-holded.verifactu.business`) y un nombre de app nuevo (`Holded for Claude`). **No es un update de la submission v1 — es una entry paralela.**
+
+Razón del reset (documentada en detalle en [`apps/holded-mcp/CLAUDE_CONNECTOR_RESET_RUNBOOK.md`](../../apps/holded-mcp/CLAUDE_CONNECTOR_RESET_RUNBOOK.md) sección 10):
+
+Anthropic / Claude.ai cachearon server-side dos iconos legacy de cuando el servicio se brandeaba como Verifactu Business (la "V" y el "escudo azul con check"). Los archivos llevan 5+ meses devueltos como 404 en nuestro origen, pero Claude.ai no re-scrapea conectores custom no aprobados en el directorio — sirve la copia cacheada. Migrar a un subdominio nuevo es la única forma garantizada de que Anthropic indexe el branding correcto sin cache previo.
+
+## Estado actual (2026-05-19, submission v2 lista para enviar)
+
+- ✅ MCP server desplegado en subdominio nuevo: `https://claude-holded.verifactu.business/mcp` (mismo build que el legacy `claude.verifactu.business`, alias en Vercel)
+- ✅ Subdominio legacy `claude.verifactu.business` sigue funcionando en paralelo (no se rompen conexiones existentes — si las hay)
 - ✅ OAuth 2.1 + PKCE funcional, redirect URIs allowlist (`claude.ai`, `app.claude.ai`)
 - ✅ Consent screen propio con scopes humanos + links legales
 - ✅ **8 tools expuestas** (preset `submission_v1`), todas con `readOnlyHint` o write annotation correcta. Las otras 16 tools del catálogo siguen implementadas pero no se registran (reactivables con `HOLDED_MCP_TOOL_PRESET=full` para submission v3 post-aprobación).
 - ✅ Solo 1 tool de escritura: `create_invoice_draft` (forced `approveDoc=false`)
 - ✅ Alineación funcional 1:1 con el conector ChatGPT (10 tools en ChatGPT vs 8 en Claude, la diferencia es solo de naming: Claude usa `list_documents` polimórfico)
-- ✅ Privacy policy + Terms + DPA publicados
+- ✅ Privacy policy + Terms + DPA publicados — DPA actualizado con sub-procesadores reales (Vercel + Railway + Neon Frankfurt EU)
 - ✅ Fixes del PR #88: brotli silent decoding, paginación client-side, default `endtmp`, `$ref` schema dedup
-- ⏳ Pendiente: enviar form de Remote MCP Submission
+- ✅ Branding correcto en el nuevo dominio: `favicon.ico` ya regenerado (MD5 `d23f99ae`, rombo Holded multi-res), `manifest.json` purgado de colores Verifactu (`theme_color: "#FF5460"`, `background_color: "#ffffff"`)
+- ⏳ Pendiente: enviar form de Remote MCP Submission con la URL nueva y app name nuevo
 
-## Submission previa
+## Submission v1 (histórica, no actuar sobre ella)
 
-El usuario ya envió **una vez** el Google Form de submission, pero **no recibió email de confirmación**.
+Submission v1 fue enviada con app name `Holded` y MCP URL `https://claude.verifactu.business/mcp`. No recibimos email de confirmación. Posibles causas: form rellenado parcialmente, confirmación a spam, form movido a otra surface, o Anthropic no envía confirmación automática para submissions parciales.
 
-Posibles causas:
-
-1. Form rellenado parcialmente o con campo obligatorio incorrecto (los reviewers no responden si la submission no pasa los checks automáticos iniciales)
-2. Confirmación a spam
-3. Form movido a otra surface (la doc oficial dice que se está moviendo a Claude.ai native)
-4. Anthropic no envía confirmación automática para submissions parciales
+**No la reactivar.** La submission v2 (`Holded for Claude` desde `claude-holded.verifactu.business`) es la canónica de aquí en adelante. Si Anthropic responde sobre v1, indicar amablemente que la solicitud activa es v2 y enlazar al form nuevo.
 
 ## Plan de acción
 

--- a/docs/anthropic-submission/branding-assets.md
+++ b/docs/anthropic-submission/branding-assets.md
@@ -2,7 +2,7 @@
 
 ## Logo principal
 
-**URL público:** `https://claude.verifactu.business/holded-diamond-logo.png?v=holded-diamond-2026-05-18`
+**URL público:** `https://claude-holded.verifactu.business/holded-diamond-logo.png?v=holded-diamond-2026-05-18`
 
 **Características:**
 
@@ -28,7 +28,7 @@
 
 ## Favicon
 
-**URL:** `https://claude.verifactu.business/favicon.ico`
+**URL:** `https://claude-holded.verifactu.business/favicon.ico`
 
 **Características:**
 
@@ -105,7 +105,7 @@ En el folder `outputs/hero_preview/` tenemos screenshots del hero mock animation
 
 Para el form de Anthropic:
 
-- **Logo URL:** pegar `https://claude.verifactu.business/holded-diamond-logo.png?v=holded-diamond-2026-05-18`
+- **Logo URL:** pegar `https://claude-holded.verifactu.business/holded-diamond-logo.png?v=holded-diamond-2026-05-18`
 - **Logo SVG:** subir el archivo si lo conseguimos
 - **Screenshots:** subir 3-5 imágenes PNG/JPG, ≤2MB cada una, 1920×1080 o 1280×800
 

--- a/docs/anthropic-submission/compliance-checklist.md
+++ b/docs/anthropic-submission/compliance-checklist.md
@@ -4,7 +4,7 @@ Verificación punto a punto del [Anthropic Software Directory Policy](https://su
 
 ## ✅ Safety & Security
 
-- [x] **Endpoint ownership:** `claude.verifactu.business`, `holded.verifactu.business`, `app.verifactu.business` son propiedad de Verifactu Business (registrados en el mismo dominio raíz `verifactu.business`)
+- [x] **Endpoint ownership:** `claude-holded.verifactu.business`, `holded.verifactu.business`, `app.verifactu.business` son propiedad de Verifactu Business (registrados en el mismo dominio raíz `verifactu.business`)
 - [x] **HTTPS everywhere:** TLS 1.2+ en todos los endpoints
 - [x] **OAuth correcto:** OAuth 2.1 + PKCE S256, redirect URI allowlist estricto (`claude.ai`, `app.claude.ai`)
 - [x] **No credenciales en URLs:** API keys nunca viajan en query strings ni en logs
@@ -73,8 +73,8 @@ export const CREATE_INVOICE_DRAFT_ANNOTATIONS: ToolAnnotations = {
 
 ## ✅ Branding & Identity
 
-- [x] **Logo SVG cuadrado:** `https://claude.verifactu.business/holded-diamond-logo.png` (512×512)
-- [x] **Favicon:** `https://claude.verifactu.business/favicon.ico`
+- [x] **Logo SVG cuadrado:** `https://claude-holded.verifactu.business/holded-diamond-logo.png` (512×512)
+- [x] **Favicon:** `https://claude-holded.verifactu.business/favicon.ico`
 - [x] **Branding consistente:** mismo logo + colores en consent screen, landing, docs
 - [x] **No claims falsos:** no nos atribuimos endorsement de Anthropic en marketing
 
@@ -103,10 +103,10 @@ export const CREATE_INVOICE_DRAFT_ANNOTATIONS: ToolAnnotations = {
 
 ```bash
 # 1. Verificar tool annotations
-curl -s https://claude.verifactu.business/.well-known/oauth-protected-resource | jq
+curl -s https://claude-holded.verifactu.business/.well-known/oauth-protected-resource | jq
 
 # 2. Verificar OAuth discovery
-curl -s https://claude.verifactu.business/.well-known/oauth-authorization-server | jq
+curl -s https://claude-holded.verifactu.business/.well-known/oauth-authorization-server | jq
 
 # 3. Verificar páginas legales públicas (no auth required)
 for url in \

--- a/docs/anthropic-submission/escalation-email.md
+++ b/docs/anthropic-submission/escalation-email.md
@@ -17,7 +17,7 @@ Soy [tu nombre] de **Verifactu Business** y os escribo para reenviar la submissi
 ## Resumen del connector
 
 - **Nombre:** Holded
-- **MCP endpoint:** https://claude.verifactu.business/mcp
+- **MCP endpoint:** https://claude-holded.verifactu.business/mcp
 - **Tagline:** "Habla con tu Holded desde Claude: facturas, contactos, contabilidad y borradores."
 - **Categoría:** Productivity → Accounting & Finance, Business Tools, CRM
 - **Estado:** En producción desde abril 2026, no es beta

--- a/docs/anthropic-submission/oauth-flow.md
+++ b/docs/anthropic-submission/oauth-flow.md
@@ -3,10 +3,10 @@
 ## Resumen técnico
 
 - **Spec:** OAuth 2.1 con PKCE (RFC 7636) S256 mandatorio
-- **Authorization Server:** `https://claude.verifactu.business`
-- **Resource Server:** `https://claude.verifactu.business/mcp`
-- **Discovery:** `https://claude.verifactu.business/.well-known/oauth-authorization-server`
-- **Protected resource metadata:** `https://claude.verifactu.business/.well-known/oauth-protected-resource`
+- **Authorization Server:** `https://claude-holded.verifactu.business`
+- **Resource Server:** `https://claude-holded.verifactu.business/mcp`
+- **Discovery:** `https://claude-holded.verifactu.business/.well-known/oauth-authorization-server`
+- **Protected resource metadata:** `https://claude-holded.verifactu.business/.well-known/oauth-protected-resource`
 
 ## Endpoints
 

--- a/docs/anthropic-submission/submission-form-answers.md
+++ b/docs/anthropic-submission/submission-form-answers.md
@@ -1,14 +1,16 @@
 # Anthropic Remote MCP Submission — Respuestas literales del form
 
-> Esto es lo que hay que pegar campo por campo. El form de Anthropic está en https://claude.com/docs/connectors/building/submission (linkea al Google Form).
+> **Última actualización: 2026-05-19 — submission v2 desde nuevo subdominio.** Esto es lo que hay que pegar campo por campo. El form de Anthropic está en https://claude.com/docs/connectors/building/submission (linkea al Google Form).
+>
+> **Cambios respecto a v1:** server name `Holded` → `Holded for Claude`, MCP URL `claude.verifactu.business` → `claude-holded.verifactu.business`. Razón: reset para purgar branding legacy cacheado por Anthropic.
 
 ---
 
 ## Server basics
 
-**Server name:** `Holded`
+**Server name:** `Holded for Claude`
 
-**Server URL (MCP endpoint):** `https://claude.verifactu.business/mcp`
+**Server URL (MCP endpoint):** `https://claude-holded.verifactu.business/mcp`
 
 **Tagline (≤80 chars):**
 `Habla con tu Holded desde Claude: facturas, contactos, contabilidad y borradores.`
@@ -43,7 +45,7 @@
 **Tool count enforcement:** El servidor MCP aplica un preset `submission_v1` (env var `HOLDED_MCP_TOOL_PRESET=submission_v1`, default en prod) que limita `tools/list` a exactamente 8 tools. Verificable end-to-end con:
 
 ```
-curl -X POST https://claude.verifactu.business/mcp \
+curl -X POST https://claude-holded.verifactu.business/mcp \
   -H "Authorization: Bearer <token>" \
   -H "Content-Type: application/json" \
   -H "Accept: application/json, text/event-stream" \
@@ -58,11 +60,11 @@ Devuelve exactamente: `list_documents`, `get_document`, `get_document_pdf`, `lis
 - Necesita generar una API key de Holded desde el panel de Holded (Configuración > Desarrolladores > API)
 - El consent screen explica los scopes y pide aceptación T&C/Privacy/DPA
 
-**Authorization endpoint:** `https://claude.verifactu.business/oauth/authorize`
-**Token endpoint:** `https://claude.verifactu.business/oauth/token`
-**Registration endpoint:** `https://claude.verifactu.business/oauth/register`
-**Discovery metadata:** `https://claude.verifactu.business/.well-known/oauth-authorization-server`
-**Protected resource metadata:** `https://claude.verifactu.business/.well-known/oauth-protected-resource`
+**Authorization endpoint:** `https://claude-holded.verifactu.business/oauth/authorize`
+**Token endpoint:** `https://claude-holded.verifactu.business/oauth/token`
+**Registration endpoint:** `https://claude-holded.verifactu.business/oauth/register`
+**Discovery metadata:** `https://claude-holded.verifactu.business/.well-known/oauth-authorization-server`
+**Protected resource metadata:** `https://claude-holded.verifactu.business/.well-known/oauth-protected-resource`
 
 **Scopes exposed:** `holded:read` (lectura), `holded:write` (crear borradores)
 
@@ -103,8 +105,8 @@ Cubre: cómo conectar, lista de tools, scopes, troubleshooting, contacto soporte
 ## Branding materials
 
 - **Logo (SVG):** Ver `branding-assets.md` (rombo Holded, 512×512)
-- **Favicon:** `https://claude.verifactu.business/favicon.ico`
-- **Logo URL:** `https://claude.verifactu.business/holded-diamond-logo.png?v=holded-diamond-2026-05-18` (PNG 512×512, sirve desde el MCP server con `Cache-Control: public, max-age=86400, immutable` para que Anthropic Connectors Directory lo cachee y Google `s2/favicons` muestre el diamond real)
+- **Favicon:** `https://claude-holded.verifactu.business/favicon.ico`
+- **Logo URL:** `https://claude-holded.verifactu.business/holded-diamond-logo.png?v=holded-diamond-2026-05-18` (PNG 512×512, sirve desde el MCP server con `Cache-Control: public, max-age=86400, immutable` para que Anthropic Connectors Directory lo cachee y Google `s2/favicons` muestre el diamond real)
 - **Promotional screenshots:** Ver `branding-assets.md` (3 screenshots del connector funcionando en Claude)
 
 ---
@@ -114,7 +116,7 @@ Cubre: cómo conectar, lista de tools, scopes, troubleshooting, contacto soporte
 Solo dominios de propiedad nuestra:
 
 - `https://holded.verifactu.business`
-- `https://claude.verifactu.business`
+- `https://claude-holded.verifactu.business`
 - `https://app.verifactu.business`
 
 ---

--- a/docs/anthropic-submission/test-account.md
+++ b/docs/anthropic-submission/test-account.md
@@ -25,7 +25,7 @@
 3. Genera API key de Holded de la cuenta sandbox
 4. Envía email cifrado (o canal Anthropic interno) con:
    - Email/password de Claude para la prueba
-   - URL del consent screen: `https://claude.verifactu.business/oauth/authorize`
+   - URL del consent screen: `https://claude-holded.verifactu.business/oauth/authorize`
    - O directamente la API key de Holded para acelerar el setup
 
 ---
@@ -136,7 +136,7 @@ El reviewer puede intentar:
 # Cuenta sandbox para el reviewer de Anthropic
 Holded user: review-anthropic@verifactu.business
 Holded API key: [se enviará por canal seguro]
-Claude consent flow start: https://claude.verifactu.business/oauth/authorize?
+Claude consent flow start: https://claude-holded.verifactu.business/oauth/authorize?
   client_id=test-client&redirect_uri=https://claude.ai/...&...
 ```
 

--- a/docs/anthropic-submission/tools-manifest.md
+++ b/docs/anthropic-submission/tools-manifest.md
@@ -75,7 +75,7 @@ Annotations definidas centralmente en:
 **Verificable end-to-end:**
 
 ```bash
-curl https://claude.verifactu.business/mcp \
+curl https://claude-holded.verifactu.business/mcp \
   -H "Authorization: Bearer <token>" \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
 ```


### PR DESCRIPTION
## Plan B — reset completo del conector Claude

Tras confirmar en producción que PRs #99 y #100 no eliminan el branding legacy (Anthropic cachea server-side y no re-scrapea), migramos a un subdominio nuevo donde Anthropic indexa fresh.

### Contexto

| Icono observado | Origen | Estado tras PR #99/#100 |
|---|---|---|
| V navy con letra blanca | `apps/holded-mcp/public/favicon.ico` legacy | ✅ Fixed |
| Escudo azul con check | `apps/app/public/icono_verifactu.business.png` (eliminado 2025-12-20) | ❌ Sigue cacheado en Anthropic — no re-scrapean |

Detalle completo en `apps/holded-mcp/CLAUDE_CONNECTOR_RESET_RUNBOOK.md` sección 10.

### Decisiones (confirmadas por usuario)

| Variable | Valor |
|---|---|
| Subdominio | `claude-holded.verifactu.business` (ya configurado en Vercel con DNS + SSL — verificado live antes de este PR) |
| App name (Anthropic form) | `Holded for Claude` |
| Endpoint legacy `claude.verifactu.business` | Sigue vivo en paralelo (alias Vercel) |

### Cambios

**Código (parametrización):**
- `apps/holded-mcp/src/app.ts` — `CLAUDE_CONNECT_DEEPLINK` ahora se construye en cada request desde `config.BASE_URL` vía `buildClaudeConnectDeeplink(baseUrl, 'Holded for Claude')`. Cambiar subdominio = cambiar env var.
- `apps/holded-mcp/src/public-pages.ts` — `CONNECT_URL` ya no es constante. `renderLandingPage(baseUrl)` lo construye en cada render.

**Docs (8 ficheros):**
- `docs/anthropic-submission/README.md` — banner de migración v2 + cambio de campo respecto a v1.
- `docs/anthropic-submission/submission-form-answers.md` — server name `Holded` → `Holded for Claude`, MCP URL nueva.
- 6 docs adicionales: sustitución global `claude.verifactu.business` → `claude-holded.verifactu.business` (sed).

**Runbook:**
- `apps/holded-mcp/CLAUDE_CONNECTOR_RESET_RUNBOOK.md` sección 14 nueva con pasos operativos, comandos de verificación, y plan para el dominio legacy.

**Memory:**
- `~/.claude/projects/.../memory/project_mcp_topology.md` actualizado con la migración 2026-05-19. (No va en este commit — está en el filesystem de memoria, no en el repo.)

### Pasos operativos tras mergear

1. **Vercel — cambiar env var `BASE_URL`:** Settings → Environment Variables → Production. De `https://claude.verifactu.business` a `https://claude-holded.verifactu.business`. Redeploy.

2. **Verificación post-deploy:**
   ```bash
   curl -sS https://claude-holded.verifactu.business/.well-known/oauth-authorization-server | jq .issuer
   # Esperado: \"https://claude-holded.verifactu.business\"

   curl -sS https://claude-holded.verifactu.business/favicon.ico | md5sum
   # Esperado: d23f99aeb2d1ea5369b6222eba8cd8e7

   curl -sS -X POST https://claude-holded.verifactu.business/mcp \
     -H \"Content-Type: application/json\" \
     -H \"Accept: application/json, text/event-stream\" \
     -d '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}'
   # Esperado: 401 Unauthorized (correcto, necesita Bearer)
   ```

3. **Anthropic Google Form — submission v2:** rellenar https://claude.com/docs/connectors/building/submission con los valores en `docs/anthropic-submission/submission-form-answers.md`. Server name = `Holded for Claude`, MCP URL = `https://claude-holded.verifactu.business/mcp`.

4. **Esperar review** (~2 semanas según docs Anthropic).

### Test plan

- [x] Subdominio `claude-holded.verifactu.business` responde 200 en `/`, `/favicon.ico`, `/manifest.json`, `/.well-known/oauth-authorization-server` y 401 en `/mcp` (verificado antes de este PR).
- [x] Código parametrizado — no quedan strings `claude.verifactu.business` hardcoded en `apps/holded-mcp/src/{app,public-pages}.ts` salvo en comentarios históricos.
- [x] Los 8 docs en `docs/anthropic-submission/` referencian `claude-holded.verifactu.business`.
- [ ] Post-merge: env var `BASE_URL` cambiado en Vercel + redeploy + `issuer` correcto en metadata.
- [ ] Post-merge: Anthropic Google Form rellenado con app name `Holded for Claude`.

### Side-tasks no abordados aquí

3 referencias hardcoded en `apps/app` (no en holded-mcp) que pueden quedar como aliases legacy:
- `apps/app/lib/connectorHealth/checks.ts:67`
- `apps/app/app/.well-known/oauth-protected-resource/api/mcp/isaak/route.ts:24` (lista claude.verifactu.business en authorization_servers del Isaak MCP)
- `apps/app/app/api/public/status/[connector]/route.test.ts:24` (test mock)

Recomendación: dejarlas, son aliases válidos durante la transición. Follow-up PR opcional cuando se decida apagar el dominio legacy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)