### PR TITLE
fix(holded-mcp): renombrar subdominio claude-holded → holded-claude (brand-first)

### DIFF
--- a/apps/holded-mcp/CLAUDE_CONNECTOR_RESET_RUNBOOK.md
+++ b/apps/holded-mcp/CLAUDE_CONNECTOR_RESET_RUNBOOK.md
@@ -162,7 +162,7 @@ Era el icono Verifactu Business v1 (`apps/app/public/icono_verifactu.business.pn
 **Las únicas dos soluciones reales:**
 
 1. **Conseguir aprobación en el Anthropic Connectors Directory** — con `logo_uri` explícito en la submission v2 form, el icono se sustituye al aprobar.
-2. **Migrar a un subdominio nuevo** `claude-holded.verifactu.business` que Anthropic indexa fresh, sin cache previo. Requiere actualizar 7 docs en `docs/anthropic-submission/` + memoria + DNS + Vercel domain alias.
+2. **Migrar a un subdominio nuevo** `holded-claude.verifactu.business` que Anthropic indexa fresh, sin cache previo. Requiere actualizar 7 docs en `docs/anthropic-submission/` + memoria + DNS + Vercel domain alias.
 
 **Red de seguridad implementada 2026-05-19:**
 
@@ -250,7 +250,7 @@ start "https://claude.verifactu.business/oauth/authorize?response_type=code&clie
 3. Solo si esas validaciones fallan, borrar y recrear el conector.
 4. Si todo valida y solo sigue el icono azul dentro de Claude, cerrar el incidente como limitación/fallback de Claude UI.
 
-## 14. Migración a subdominio nuevo (2026-05-19) — `claude-holded.verifactu.business`
+## 14. Migración a subdominio nuevo (2026-05-19) — `holded-claude.verifactu.business`
 
 **Contexto:** PRs #99 y #100 fixearon todo lo que controlamos en nuestro origen (`favicon.ico` regenerado, `manifest.json` purgado de colores Verifactu, alias legacy `/icono_verifactu.business.png` sirviendo el rombo). Pero la sección 10 confirmó que Anthropic cachea server-side los iconos legacy y no re-scrapea conectores custom no aprobados. Único reset garantizado: subdominio nuevo donde Anthropic indexe fresh.
 
@@ -258,7 +258,7 @@ start "https://claude.verifactu.business/oauth/authorize?response_type=code&clie
 
 | Variable                                    | Valor                                                 |
 | ------------------------------------------- | ----------------------------------------------------- |
-| Subdominio nuevo                            | `claude-holded.verifactu.business`                    |
+| Subdominio nuevo                            | `holded-claude.verifactu.business`                    |
 | App name (Anthropic form)                   | `Holded for Claude`                                   |
 | Endpoint legacy `claude.verifactu.business` | Mantener vivo en paralelo (alias Vercel, mismo build) |
 
@@ -272,21 +272,21 @@ start "https://claude.verifactu.business/oauth/authorize?response_type=code&clie
 
 Asumiendo que el PR de migración está mergeado a `main`:
 
-1. **Vercel — añadir subdominio:** Settings → Domains → Add → `claude-holded.verifactu.business`. Configurar el CNAME que pide Vercel a `cname.vercel-dns.com` en el DNS provider. Esperar SSL (~1-2 min).
-2. **Vercel — cambiar env var:** Project Settings → Environment Variables → `BASE_URL`. Cambiar de `https://claude.verifactu.business` a `https://claude-holded.verifactu.business`. Aplicar a Production. Redeploy.
+1. **Vercel — añadir subdominio:** Settings → Domains → Add → `holded-claude.verifactu.business`. Configurar el CNAME que pide Vercel a `cname.vercel-dns.com` en el DNS provider. Esperar SSL (~1-2 min).
+2. **Vercel — cambiar env var:** Project Settings → Environment Variables → `BASE_URL`. Cambiar de `https://claude.verifactu.business` a `https://holded-claude.verifactu.business`. Aplicar a Production. Redeploy.
 3. **Verificación post-deploy:**
    ```bash
-   curl -sS https://claude-holded.verifactu.business/.well-known/oauth-authorization-server | jq .issuer
-   # Esperado: "https://claude-holded.verifactu.business"
-   curl -sS https://claude-holded.verifactu.business/favicon.ico | md5sum
+   curl -sS https://holded-claude.verifactu.business/.well-known/oauth-authorization-server | jq .issuer
+   # Esperado: "https://holded-claude.verifactu.business"
+   curl -sS https://holded-claude.verifactu.business/favicon.ico | md5sum
    # Esperado: d23f99aeb2d1ea5369b6222eba8cd8e7 (rombo Holded)
-   curl -sS -X POST https://claude-holded.verifactu.business/mcp \
+   curl -sS -X POST https://holded-claude.verifactu.business/mcp \
      -H "Content-Type: application/json" \
      -H "Accept: application/json, text/event-stream" \
      -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
    # Esperado: 401 Unauthorized (correcto — necesita Bearer)
    ```
-4. **Anthropic Google Form — submission v2:** rellenar el form en https://claude.com/docs/connectors/building/submission con los valores de `docs/anthropic-submission/submission-form-answers.md`. Server name = `Holded for Claude`, MCP URL = `https://claude-holded.verifactu.business/mcp`.
+4. **Anthropic Google Form — submission v2:** rellenar el form en https://claude.com/docs/connectors/building/submission con los valores de `docs/anthropic-submission/submission-form-answers.md`. Server name = `Holded for Claude`, MCP URL = `https://holded-claude.verifactu.business/mcp`.
 5. **Esperar review manual** (~2 semanas según docs oficiales).
 6. **Si Anthropic aprueba con icono correcto:** desconectar el conector viejo en Claude.ai y añadir el nuevo `Holded for Claude` desde el directorio.
 
@@ -295,7 +295,7 @@ Asumiendo que el PR de migración está mergeado a `main`:
 Mantener vivo en paralelo. Sirve el mismo build via alias en Vercel. Tras la aprobación de la submission v2, en una ventana controlada se puede:
 
 - Opción A: dejarlo activo indefinidamente (zero break risk, mínimo coste).
-- Opción B: configurar 301 redirect a `claude-holded.verifactu.business` a nivel Vercel (rompe MCP POSTs porque la mayoría de clientes no siguen redirects 301 con POST — preferir Opción A).
+- Opción B: configurar 301 redirect a `holded-claude.verifactu.business` a nivel Vercel (rompe MCP POSTs porque la mayoría de clientes no siguen redirects 301 con POST — preferir Opción A).
 - Opción C: respond 410 Gone con mensaje "conector renombrado, reconecte desde el directorio Anthropic" (sólo si confirmamos cero usuarios activos).
 
 Recomendación: Opción A hasta que pase tiempo suficiente para confirmar que nadie usa el legacy.

--- a/apps/holded-mcp/src/app.ts
+++ b/apps/holded-mcp/src/app.ts
@@ -155,7 +155,7 @@ export function createApp() {
   // bajo el path legacy: si Anthropic alguna vez re-scrapea, recibe el
   // brand actual. No es solución principal (Anthropic puede no re-scrapear
   // jamás para conectores no aprobados en el directorio); la solución
-  // garantizada es un subdominio nuevo claude-holded.verifactu.business
+  // garantizada es un subdominio nuevo holded-claude.verifactu.business
   // que Anthropic indexa fresh. Esta ruta es red de seguridad de bajo coste.
   app.get('/icono_verifactu.business.png', (_req, res) => sendDiamondPng(res));
 

--- a/apps/holded-mcp/src/public-pages.ts
+++ b/apps/holded-mcp/src/public-pages.ts
@@ -1,7 +1,7 @@
 const SUPPORT_EMAIL = 'soporte@verifactu.business';
 const HOLDED_BASE = 'https://holded.verifactu.business/conectores/claude';
 // CONNECT_URL is derived from baseUrl at render time (renderLandingPage receives it).
-// This makes subdomain swaps (e.g. claude.verifactu.business → claude-holded.verifactu.business)
+// This makes subdomain swaps (e.g. claude.verifactu.business → holded-claude.verifactu.business)
 // a one-env-var change in Vercel instead of a code edit.
 
 function escapeHtml(value: string) {

--- a/apps/holded/app/auth/holded-claude/success/page.tsx
+++ b/apps/holded/app/auth/holded-claude/success/page.tsx
@@ -32,7 +32,7 @@ const HOLDED_SITE_URL =
 
 const CLAUDE_MCP_URL =
   process.env.NEXT_PUBLIC_CLAUDE_MCP_URL?.replace(/\/$/, '') ||
-  'https://claude.verifactu.business/mcp';
+  'https://holded-claude.verifactu.business/mcp';
 
 const CHATGPT_MCP_URL = `${HOLDED_SITE_URL}/api/mcp/holded`;
 

--- a/apps/holded/app/auth/holded-direct/success/page.tsx
+++ b/apps/holded/app/auth/holded-direct/success/page.tsx
@@ -25,7 +25,7 @@ const HOLDED_SITE_URL =
 // /.well-known/oauth-authorization-server y /.well-known/oauth-protected-resource.
 const CLAUDE_MCP_URL =
   process.env.NEXT_PUBLIC_CLAUDE_MCP_URL?.replace(/\/$/, '') ||
-  'https://claude.verifactu.business/mcp';
+  'https://holded-claude.verifactu.business/mcp';
 
 // URL canónica del MCP de ChatGPT (proxy /api/mcp/holded en apps/holded → apps/app).
 const CHATGPT_MCP_URL = `${HOLDED_SITE_URL}/api/mcp/holded`;

--- a/apps/holded/app/lib/holded-navigation.ts
+++ b/apps/holded/app/lib/holded-navigation.ts
@@ -25,15 +25,29 @@ export const ADMIN_PUBLIC_URL = getOrigin(
 
 // T#50 Opción 2: el conector Claude × Holded redirige al usuario de vuelta
 // a su consent screen tras completar /auth/holded-direct (Firebase auth).
-// Permitimos `claude.verifactu.business` como origen de retorno válido para
-// que `sanitizeHoldedReturnTarget()` no caiga al fallback al volver desde
-// el bridge.
+// Permitimos los subdominios del MCP de Claude como origen de retorno válido
+// para que `sanitizeHoldedReturnTarget()` no caiga al fallback al volver desde
+// el bridge. Incluimos AMBOS subdominios durante la transición 2026-05-20:
+//   - holded-claude.verifactu.business: canonical (brand-first, post PR #102)
+//   - claude.verifactu.business: legacy alias en Vercel, mantener vivo hasta
+//     que confirmemos que ningún usuario sigue conectado contra él.
+// Sin el nuevo subdominio en el allowlist, sanitizeHoldedReturnTarget rechaza
+// el `next=https://holded-claude.verifactu.business/oauth/authorize?...` que
+// arma el bridge en /oauth/authorize del MCP, y el flow cae a /dashboard
+// (síntoma: confetti + landing en /dashboard?source=holded_dashboard).
 export const CLAUDE_MCP_PUBLIC_URL = getOrigin(
   process.env.NEXT_PUBLIC_CLAUDE_MCP_URL,
-  'https://claude.verifactu.business'
+  'https://holded-claude.verifactu.business'
 );
 
-const ALLOWED_RETURN_ORIGINS = new Set([HOLDED_PUBLIC_URL, APP_PUBLIC_URL, CLAUDE_MCP_PUBLIC_URL]);
+export const CLAUDE_MCP_LEGACY_URL = 'https://claude.verifactu.business';
+
+const ALLOWED_RETURN_ORIGINS = new Set([
+  HOLDED_PUBLIC_URL,
+  APP_PUBLIC_URL,
+  CLAUDE_MCP_PUBLIC_URL,
+  CLAUDE_MCP_LEGACY_URL,
+]);
 
 export const buildLeadCaptureUrl = (source?: string) => {
   const base = `${HOLDED_PUBLIC_URL}/`;

--- a/docs/anthropic-submission/README.md
+++ b/docs/anthropic-submission/README.md
@@ -9,7 +9,7 @@
 
 ## ⚠️ Submission v2 desde nuevo subdominio (2026-05-19)
 
-Esta es una **nueva entrada** en el Anthropic Connectors Directory, con un subdominio nuevo (`claude-holded.verifactu.business`) y un nombre de app nuevo (`Holded for Claude`). **No es un update de la submission v1 — es una entry paralela.**
+Esta es una **nueva entrada** en el Anthropic Connectors Directory, con un subdominio nuevo (`holded-claude.verifactu.business`) y un nombre de app nuevo (`Holded for Claude`). **No es un update de la submission v1 — es una entry paralela.**
 
 Razón del reset (documentada en detalle en [`apps/holded-mcp/CLAUDE_CONNECTOR_RESET_RUNBOOK.md`](../../apps/holded-mcp/CLAUDE_CONNECTOR_RESET_RUNBOOK.md) sección 10):
 
@@ -17,7 +17,7 @@ Anthropic / Claude.ai cachearon server-side dos iconos legacy de cuando el servi
 
 ## Estado actual (2026-05-19, submission v2 lista para enviar)
 
-- ✅ MCP server desplegado en subdominio nuevo: `https://claude-holded.verifactu.business/mcp` (mismo build que el legacy `claude.verifactu.business`, alias en Vercel)
+- ✅ MCP server desplegado en subdominio nuevo: `https://holded-claude.verifactu.business/mcp` (mismo build que el legacy `claude.verifactu.business`, alias en Vercel)
 - ✅ Subdominio legacy `claude.verifactu.business` sigue funcionando en paralelo (no se rompen conexiones existentes — si las hay)
 - ✅ OAuth 2.1 + PKCE funcional, redirect URIs allowlist (`claude.ai`, `app.claude.ai`)
 - ✅ Consent screen propio con scopes humanos + links legales
@@ -33,7 +33,7 @@ Anthropic / Claude.ai cachearon server-side dos iconos legacy de cuando el servi
 
 Submission v1 fue enviada con app name `Holded` y MCP URL `https://claude.verifactu.business/mcp`. No recibimos email de confirmación. Posibles causas: form rellenado parcialmente, confirmación a spam, form movido a otra surface, o Anthropic no envía confirmación automática para submissions parciales.
 
-**No la reactivar.** La submission v2 (`Holded for Claude` desde `claude-holded.verifactu.business`) es la canónica de aquí en adelante. Si Anthropic responde sobre v1, indicar amablemente que la solicitud activa es v2 y enlazar al form nuevo.
+**No la reactivar.** La submission v2 (`Holded for Claude` desde `holded-claude.verifactu.business`) es la canónica de aquí en adelante. Si Anthropic responde sobre v1, indicar amablemente que la solicitud activa es v2 y enlazar al form nuevo.
 
 ## Plan de acción
 

--- a/docs/anthropic-submission/branding-assets.md
+++ b/docs/anthropic-submission/branding-assets.md
@@ -2,7 +2,7 @@
 
 ## Logo principal
 
-**URL público:** `https://claude-holded.verifactu.business/holded-diamond-logo.png?v=holded-diamond-2026-05-18`
+**URL público:** `https://holded-claude.verifactu.business/holded-diamond-logo.png?v=holded-diamond-2026-05-18`
 
 **Características:**
 
@@ -28,7 +28,7 @@
 
 ## Favicon
 
-**URL:** `https://claude-holded.verifactu.business/favicon.ico`
+**URL:** `https://holded-claude.verifactu.business/favicon.ico`
 
 **Características:**
 
@@ -105,7 +105,7 @@ En el folder `outputs/hero_preview/` tenemos screenshots del hero mock animation
 
 Para el form de Anthropic:
 
-- **Logo URL:** pegar `https://claude-holded.verifactu.business/holded-diamond-logo.png?v=holded-diamond-2026-05-18`
+- **Logo URL:** pegar `https://holded-claude.verifactu.business/holded-diamond-logo.png?v=holded-diamond-2026-05-18`
 - **Logo SVG:** subir el archivo si lo conseguimos
 - **Screenshots:** subir 3-5 imágenes PNG/JPG, ≤2MB cada una, 1920×1080 o 1280×800
 

--- a/docs/anthropic-submission/compliance-checklist.md
+++ b/docs/anthropic-submission/compliance-checklist.md
@@ -4,7 +4,7 @@ Verificación punto a punto del [Anthropic Software Directory Policy](https://su
 
 ## ✅ Safety & Security
 
-- [x] **Endpoint ownership:** `claude-holded.verifactu.business`, `holded.verifactu.business`, `app.verifactu.business` son propiedad de Verifactu Business (registrados en el mismo dominio raíz `verifactu.business`)
+- [x] **Endpoint ownership:** `holded-claude.verifactu.business`, `holded.verifactu.business`, `app.verifactu.business` son propiedad de Verifactu Business (registrados en el mismo dominio raíz `verifactu.business`)
 - [x] **HTTPS everywhere:** TLS 1.2+ en todos los endpoints
 - [x] **OAuth correcto:** OAuth 2.1 + PKCE S256, redirect URI allowlist estricto (`claude.ai`, `app.claude.ai`)
 - [x] **No credenciales en URLs:** API keys nunca viajan en query strings ni en logs
@@ -73,8 +73,8 @@ export const CREATE_INVOICE_DRAFT_ANNOTATIONS: ToolAnnotations = {
 
 ## ✅ Branding & Identity
 
-- [x] **Logo SVG cuadrado:** `https://claude-holded.verifactu.business/holded-diamond-logo.png` (512×512)
-- [x] **Favicon:** `https://claude-holded.verifactu.business/favicon.ico`
+- [x] **Logo SVG cuadrado:** `https://holded-claude.verifactu.business/holded-diamond-logo.png` (512×512)
+- [x] **Favicon:** `https://holded-claude.verifactu.business/favicon.ico`
 - [x] **Branding consistente:** mismo logo + colores en consent screen, landing, docs
 - [x] **No claims falsos:** no nos atribuimos endorsement de Anthropic en marketing
 
@@ -103,10 +103,10 @@ export const CREATE_INVOICE_DRAFT_ANNOTATIONS: ToolAnnotations = {
 
 ```bash
 # 1. Verificar tool annotations
-curl -s https://claude-holded.verifactu.business/.well-known/oauth-protected-resource | jq
+curl -s https://holded-claude.verifactu.business/.well-known/oauth-protected-resource | jq
 
 # 2. Verificar OAuth discovery
-curl -s https://claude-holded.verifactu.business/.well-known/oauth-authorization-server | jq
+curl -s https://holded-claude.verifactu.business/.well-known/oauth-authorization-server | jq
 
 # 3. Verificar páginas legales públicas (no auth required)
 for url in \

--- a/docs/anthropic-submission/escalation-email.md
+++ b/docs/anthropic-submission/escalation-email.md
@@ -17,7 +17,7 @@ Soy [tu nombre] de **Verifactu Business** y os escribo para reenviar la submissi
 ## Resumen del connector
 
 - **Nombre:** Holded
-- **MCP endpoint:** https://claude-holded.verifactu.business/mcp
+- **MCP endpoint:** https://holded-claude.verifactu.business/mcp
 - **Tagline:** "Habla con tu Holded desde Claude: facturas, contactos, contabilidad y borradores."
 - **Categoría:** Productivity → Accounting & Finance, Business Tools, CRM
 - **Estado:** En producción desde abril 2026, no es beta

--- a/docs/anthropic-submission/oauth-flow.md
+++ b/docs/anthropic-submission/oauth-flow.md
@@ -3,10 +3,10 @@
 ## Resumen técnico
 
 - **Spec:** OAuth 2.1 con PKCE (RFC 7636) S256 mandatorio
-- **Authorization Server:** `https://claude-holded.verifactu.business`
-- **Resource Server:** `https://claude-holded.verifactu.business/mcp`
-- **Discovery:** `https://claude-holded.verifactu.business/.well-known/oauth-authorization-server`
-- **Protected resource metadata:** `https://claude-holded.verifactu.business/.well-known/oauth-protected-resource`
+- **Authorization Server:** `https://holded-claude.verifactu.business`
+- **Resource Server:** `https://holded-claude.verifactu.business/mcp`
+- **Discovery:** `https://holded-claude.verifactu.business/.well-known/oauth-authorization-server`
+- **Protected resource metadata:** `https://holded-claude.verifactu.business/.well-known/oauth-protected-resource`
 
 ## Endpoints
 

--- a/docs/anthropic-submission/submission-form-answers.md
+++ b/docs/anthropic-submission/submission-form-answers.md
@@ -2,7 +2,7 @@
 
 > **Última actualización: 2026-05-19 — submission v2 desde nuevo subdominio.** Esto es lo que hay que pegar campo por campo. El form de Anthropic está en https://claude.com/docs/connectors/building/submission (linkea al Google Form).
 >
-> **Cambios respecto a v1:** server name `Holded` → `Holded for Claude`, MCP URL `claude.verifactu.business` → `claude-holded.verifactu.business`. Razón: reset para purgar branding legacy cacheado por Anthropic.
+> **Cambios respecto a v1:** server name `Holded` → `Holded for Claude`, MCP URL `claude.verifactu.business` → `holded-claude.verifactu.business`. Razón: reset para purgar branding legacy cacheado por Anthropic.
 
 ---
 
@@ -10,7 +10,7 @@
 
 **Server name:** `Holded for Claude`
 
-**Server URL (MCP endpoint):** `https://claude-holded.verifactu.business/mcp`
+**Server URL (MCP endpoint):** `https://holded-claude.verifactu.business/mcp`
 
 **Tagline (≤80 chars):**
 `Habla con tu Holded desde Claude: facturas, contactos, contabilidad y borradores.`
@@ -45,7 +45,7 @@
 **Tool count enforcement:** El servidor MCP aplica un preset `submission_v1` (env var `HOLDED_MCP_TOOL_PRESET=submission_v1`, default en prod) que limita `tools/list` a exactamente 8 tools. Verificable end-to-end con:
 
 ```
-curl -X POST https://claude-holded.verifactu.business/mcp \
+curl -X POST https://holded-claude.verifactu.business/mcp \
   -H "Authorization: Bearer <token>" \
   -H "Content-Type: application/json" \
   -H "Accept: application/json, text/event-stream" \
@@ -60,11 +60,11 @@ Devuelve exactamente: `list_documents`, `get_document`, `get_document_pdf`, `lis
 - Necesita generar una API key de Holded desde el panel de Holded (Configuración > Desarrolladores > API)
 - El consent screen explica los scopes y pide aceptación T&C/Privacy/DPA
 
-**Authorization endpoint:** `https://claude-holded.verifactu.business/oauth/authorize`
-**Token endpoint:** `https://claude-holded.verifactu.business/oauth/token`
-**Registration endpoint:** `https://claude-holded.verifactu.business/oauth/register`
-**Discovery metadata:** `https://claude-holded.verifactu.business/.well-known/oauth-authorization-server`
-**Protected resource metadata:** `https://claude-holded.verifactu.business/.well-known/oauth-protected-resource`
+**Authorization endpoint:** `https://holded-claude.verifactu.business/oauth/authorize`
+**Token endpoint:** `https://holded-claude.verifactu.business/oauth/token`
+**Registration endpoint:** `https://holded-claude.verifactu.business/oauth/register`
+**Discovery metadata:** `https://holded-claude.verifactu.business/.well-known/oauth-authorization-server`
+**Protected resource metadata:** `https://holded-claude.verifactu.business/.well-known/oauth-protected-resource`
 
 **Scopes exposed:** `holded:read` (lectura), `holded:write` (crear borradores)
 
@@ -105,8 +105,8 @@ Cubre: cómo conectar, lista de tools, scopes, troubleshooting, contacto soporte
 ## Branding materials
 
 - **Logo (SVG):** Ver `branding-assets.md` (rombo Holded, 512×512)
-- **Favicon:** `https://claude-holded.verifactu.business/favicon.ico`
-- **Logo URL:** `https://claude-holded.verifactu.business/holded-diamond-logo.png?v=holded-diamond-2026-05-18` (PNG 512×512, sirve desde el MCP server con `Cache-Control: public, max-age=86400, immutable` para que Anthropic Connectors Directory lo cachee y Google `s2/favicons` muestre el diamond real)
+- **Favicon:** `https://holded-claude.verifactu.business/favicon.ico`
+- **Logo URL:** `https://holded-claude.verifactu.business/holded-diamond-logo.png?v=holded-diamond-2026-05-18` (PNG 512×512, sirve desde el MCP server con `Cache-Control: public, max-age=86400, immutable` para que Anthropic Connectors Directory lo cachee y Google `s2/favicons` muestre el diamond real)
 - **Promotional screenshots:** Ver `branding-assets.md` (3 screenshots del connector funcionando en Claude)
 
 ---
@@ -116,7 +116,7 @@ Cubre: cómo conectar, lista de tools, scopes, troubleshooting, contacto soporte
 Solo dominios de propiedad nuestra:
 
 - `https://holded.verifactu.business`
-- `https://claude-holded.verifactu.business`
+- `https://holded-claude.verifactu.business`
 - `https://app.verifactu.business`
 
 ---

--- a/docs/anthropic-submission/test-account.md
+++ b/docs/anthropic-submission/test-account.md
@@ -25,7 +25,7 @@
 3. Genera API key de Holded de la cuenta sandbox
 4. Envía email cifrado (o canal Anthropic interno) con:
    - Email/password de Claude para la prueba
-   - URL del consent screen: `https://claude-holded.verifactu.business/oauth/authorize`
+   - URL del consent screen: `https://holded-claude.verifactu.business/oauth/authorize`
    - O directamente la API key de Holded para acelerar el setup
 
 ---
@@ -136,7 +136,7 @@ El reviewer puede intentar:
 # Cuenta sandbox para el reviewer de Anthropic
 Holded user: review-anthropic@verifactu.business
 Holded API key: [se enviará por canal seguro]
-Claude consent flow start: https://claude-holded.verifactu.business/oauth/authorize?
+Claude consent flow start: https://holded-claude.verifactu.business/oauth/authorize?
   client_id=test-client&redirect_uri=https://claude.ai/...&...
 ```
 

--- a/docs/anthropic-submission/tools-manifest.md
+++ b/docs/anthropic-submission/tools-manifest.md
@@ -75,7 +75,7 @@ Annotations definidas centralmente en:
 **Verificable end-to-end:**
 
 ```bash
-curl https://claude-holded.verifactu.business/mcp \
+curl https://holded-claude.verifactu.business/mcp \
   -H "Authorization: Bearer <token>" \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
 ```

--- a/docs/engineering/HOLDED_CLAUDE_BRANDING_RESET_2026-05-20.md
+++ b/docs/engineering/HOLDED_CLAUDE_BRANDING_RESET_2026-05-20.md
@@ -1,0 +1,240 @@
+# Holded × Claude — Branding reset to `holded-claude.verifactu.business`
+
+**Date:** 2026-05-20
+**Status:** Implementation merged (PRs #99, #100, #101, #102). Operator pending: Vercel domain + env var change + Anthropic Google Form submission v2.
+**Owners:** Verifactu Business
+
+---
+
+## Executive summary
+
+The Claude MCP connector at `claude.verifactu.business/mcp` shipped to users with two wrong icons:
+
+1. A **navy "V"** (Verifactu Business v2 logo) appearing on tool-call chips in chat
+2. A **blue shield with checkmark** (Verifactu Business v1 logo) appearing on the connector's app icon and pre-connect preview
+
+Forensic investigation traced both icons to legacy assets from before the product was rebranded as Holded. The "V" was a still-present `favicon.ico` file in the repo; the "blue shield" was a deleted PNG (`apps/app/public/icono_verifactu.business.png`, removed 2025-12-20) that **Anthropic / Claude.ai cached server-side** before the deletion and has never re-scraped — confirmed by the file returning 404 in all our public URLs for 5+ months while still showing in Claude.ai.
+
+After fixing every controllable asset on our origin (PRs #99, #100), we confirmed empirically that **Anthropic does not re-scrape custom MCP connectors that are not approved in the Connectors Directory**. The only guaranteed way to clear the cache was to migrate the connector to a new subdomain where Anthropic indexes fresh.
+
+**Decision:** new subdomain `holded-claude.verifactu.business` (brand-first naming, Holded primary product + Claude as channel), new app name `Holded for Claude`, new Anthropic submission v2.
+
+**State as of 2026-05-20:**
+
+- ✅ Code parametrized to read `BASE_URL` from env var (no hardcoded subdomain references)
+- ✅ All 8 docs in `docs/anthropic-submission/` aligned to `holded-claude.verifactu.business` and `Holded for Claude`
+- ✅ Runbook `apps/holded-mcp/CLAUDE_CONNECTOR_RESET_RUNBOOK.md` extended with section 14 (subdomain migration runbook) and section 10 corrected with both root causes
+- ✅ Memory updated (`project_mcp_topology.md`)
+- ⏳ Pending operator: add `holded-claude.verifactu.business` in Vercel, change `BASE_URL`, redeploy, submit Anthropic form
+
+---
+
+## Problem statement (observed in production)
+
+User shared two screenshots on 2026-05-19 from `claude.ai` showing:
+
+| Surface                                                     | Icon shown                         | Expected                   |
+| ----------------------------------------------------------- | ---------------------------------- | -------------------------- |
+| Tool-call chips inside Claude chat                          | Navy "V" with white serif text     | Holded coral diamond rombo |
+| Connector list / "Add custom connector" pre-connect preview | Generic blue shield with checkmark | Holded coral diamond rombo |
+
+Both surfaces should render the Holded brand (coral `#FF5460` diamond), since the connector advertises `Holded` as its display name and the MCP server serves the diamond at multiple icon URLs.
+
+## Forensic investigation
+
+### Icon A — "V" navy on tool chips
+
+**Origin:** [apps/holded-mcp/public/favicon.ico](../../apps/holded-mcp/public/favicon.ico)
+
+When the project rebranded from Verifactu Business to Holded, all PNG icon variants on the MCP server (`/favicon.png`, `/icon.png`, `/apple-touch-icon.png`, `/logo.png`, `/holded-diamond-logo.png`) were updated to serve `holded-diamond-logo.png` via the `sendDiamondPng` helper. But `/favicon.ico` went through `sendDiamondIco` which read the raw binary file `apps/holded-mcp/public/favicon.ico` — that file was never re-generated from the new PNG and still contained the V.
+
+Comparison:
+
+| File                                            | MD5                                | Content                                    |
+| ----------------------------------------------- | ---------------------------------- | ------------------------------------------ |
+| `holded-diamond-logo.png` (PNG, canonical)      | `d4a3694fbba0707cdd5b7c953eb78eaf` | Holded diamond                             |
+| `favicon.ico` (legacy ICO, served until PR #99) | `2e7fd8c21b1aa5c17991d0053c11dab6` | Navy V                                     |
+| `favicon.ico` (regenerated, post PR #99)        | `d23f99aeb2d1ea5369b6222eba8cd8e7` | Holded diamond (16/32/48/64 multi-res ICO) |
+
+**Fix:** [PR #99](https://github.com/kiabusiness2025/verifactu-monorepo/pull/99) regenerated `favicon.ico` as a multi-resolution PNG-encoded ICO from `holded-diamond-logo.png` using `apps/holded-mcp/scripts/regen-favicon.mjs` (Node + `sharp`). Same PR also purged the Verifactu navy/blue colors from `apps/holded-mcp/public/manifest.json` (`theme_color: #2361d8 → #FF5460`, `background_color: #081936 → #ffffff`).
+
+### Icon B — Blue shield with checkmark
+
+**Origin:** `apps/app/public/icono_verifactu.business.png` (500×500 RGBA, MD5 `6417d69d8c44012a65c9dfc98c550017`)
+
+This was the Verifactu Business v1 app icon — uploaded by the team when the product was first launched as Verifactu Business in 2025. It was visually a blue shield with a checkmark on light gradient background.
+
+**File status:**
+
+- **Deleted from the repo** on 2025-12-20 in commit `2ea8e783e` ("fix: replace binary icons with svg") — alongside other legacy binary icons that were replaced with inline SVG.
+- **HTTP 404 in production** on all our domains (verified with curl 2026-05-19): `app.verifactu.business`, `claude.verifactu.business`, `holded.verifactu.business`, `verifactu.business`. The file has been gone for 5+ months.
+
+**But Claude.ai still shows it.** Conclusion:
+
+> **Anthropic / Claude.ai cached the binary server-side** when it was accessible (probably from `app.verifactu.business/icono_verifactu.business.png` before December 2025), and serves the cached copy. They do not re-request the URL. They do not re-scrape custom MCP connectors that are not approved in the Anthropic Connectors Directory.
+
+This was confirmed indirectly: PR #99 fixed every controllable asset on our origin (`favicon.ico`, `manifest.json`, all PNG icon URLs). Production verification showed all assets serving the Holded diamond. But the user reported that the blue shield persisted in Claude.ai. The only consistent explanation is server-side caching by Anthropic.
+
+**Mitigations attempted:**
+
+- [PR #100](https://github.com/kiabusiness2025/verifactu-monorepo/pull/100) added a safety-net route `GET /icono_verifactu.business.png` that serves the Holded diamond at the exact legacy URL — in case Anthropic ever re-scrapes the URL it had cached. Low-cost, no guarantee of effect.
+
+**Fundamental conclusion:**
+
+> The blue shield cache in Anthropic's infrastructure **cannot be cleared from our side**. The two real solutions are:
+>
+> 1. Get approval in the Anthropic Connectors Directory (the directory submission supplies a fresh `logo_uri` that overrides the cached icon)
+> 2. Migrate to a new subdomain that Anthropic indexes fresh
+
+## Decision tree
+
+```
+Is the icon legacy and served by our origin?
+├── Yes → fix the file (PR #99 ✅ done)
+└── No → is it cached by Anthropic server-side?
+    ├── Probable yes → can we wait for natural refresh?
+    │   ├── Connectors Directory submission pending → submit
+    │   │   and wait for approval to overwrite cache
+    │   └── Not enrolled or no refresh expected →
+    │       migrate to a new subdomain
+    └── No → it's a Claude UI default, accept it
+```
+
+For the V icon: Option A (fix the file) sufficed — confirmed in production after PR #99 deploy.
+
+For the blue shield: Anthropic's server-side cache + no re-scrape policy meant Option A was inadequate. Option B (subdomain migration) was selected.
+
+## Why a new subdomain (and not a fresh form submission from the old URL)
+
+Submitting a new form from `claude.verifactu.business` could in theory provide a fresh `logo_uri` for Anthropic to index. But:
+
+- Anthropic v1 submission was already sent from this URL and did not respond. The state of that submission in Anthropic's internal tracker is opaque.
+- If Anthropic's cache key is the MCP URL (not the submission ID), a v2 form from the same URL might inherit cached icons.
+- A fresh subdomain eliminates this risk entirely. The subdomain has zero prior interaction with Anthropic — they index whatever we serve on it without any cache to invalidate.
+
+## Subdomain naming — brand-first
+
+Two candidates considered:
+
+| Candidate                                           | Argument                                                                                                                                                                                        | Counter-argument                                 |
+| --------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| `claude-holded.verifactu.business` (channel-first)  | Matches Anthropic's own `claude.*` conventions (claude.ai, claude.com).                                                                                                                         | Mixes our brand into Anthropic's naming pattern. |
+| `holded-claude.verifactu.business` (brand-first) ✅ | Holded is **our** product; Claude is the channel/distribution. Matches `Holded for Claude` as app name. Consistent with how OpenAI's `Holded` app in the ChatGPT directory positions the brand. | None significant.                                |
+
+Decision: **brand-first** (`holded-claude.verifactu.business`).
+
+PR #101 initially merged with `claude-holded` by error (the AskUserQuestion confirmation came back with empty answers field, so the default-recommended option was assumed). PR #102 corrects the naming.
+
+## Implementation summary
+
+| PR                                                                     | Title                                                                                            | Status                                        |
+| ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | --------------------------------------------- |
+| [#99](https://github.com/kiabusiness2025/verifactu-monorepo/pull/99)   | `fix(holded-mcp)`: regenerate `favicon.ico` + purge Verifactu legacy colors from `manifest.json` | Merged 2026-05-19                             |
+| [#100](https://github.com/kiabusiness2025/verifactu-monorepo/pull/100) | `fix(holded-mcp)`: legacy alias `/icono_verifactu.business.png` + runbook root cause docs        | Merged 2026-05-20                             |
+| [#101](https://github.com/kiabusiness2025/verifactu-monorepo/pull/101) | `feat(holded-mcp)`: migrate Claude connector to subdomain + app name `Holded for Claude`         | Merged 2026-05-19 (with `claude-holded` typo) |
+| [#102](https://github.com/kiabusiness2025/verifactu-monorepo/pull/102) | `fix(holded-mcp)`: rename `claude-holded` → `holded-claude` (brand-first)                        | In review (this PR)                           |
+
+### Code changes (PR #101 + #102)
+
+Parametrized two hardcoded URLs in `apps/holded-mcp/src/`:
+
+- `app.ts` — `CLAUDE_CONNECT_DEEPLINK` constant was a string with `claude.verifactu.business/mcp` URL-encoded. Now built dynamically via `buildClaudeConnectDeeplink(config.BASE_URL, 'Holded for Claude')`. Changing the subdomain = changing one env var.
+- `public-pages.ts` — `CONNECT_URL` was a module-level constant. Now constructed inside `renderLandingPage(baseUrl)` from the `baseUrl` parameter the function already receives.
+
+All other URL references (`oauth-routes.ts`, OAuth metadata responses, etc.) were already reading from `config.BASE_URL`.
+
+### Docs changes (PR #101 + #102)
+
+8 files in `docs/anthropic-submission/` updated:
+
+- `README.md` — submission v1 vs v2 story, banner explaining the migration
+- `submission-form-answers.md` — server name `Holded for Claude`, MCP URL `holded-claude.verifactu.business/mcp`
+- `branding-assets.md`, `compliance-checklist.md`, `escalation-email.md`, `oauth-flow.md`, `test-account.md`, `tools-manifest.md` — global subdomain substitution
+
+### Runbook updates (PR #100 + #101 + #102)
+
+`apps/holded-mcp/CLAUDE_CONNECTOR_RESET_RUNBOOK.md`:
+
+- **Section 10 rewritten** with both root causes (V on favicon.ico + blue shield cached by Anthropic), with byte-level reference table (MD5s) for future incident triage.
+- **Section 14 added** with operator runbook: Vercel domain alias, env var change, Anthropic Google Form submission, verification commands, plan for the legacy `claude.verifactu.business` domain.
+
+### Memory updates
+
+`~/.claude/projects/.../memory/project_mcp_topology.md` updated 2026-05-19 with:
+
+- Correct hosting (Vercel, not Railway — the earlier memory had an inherited typo)
+- The migration date and reasoning
+- v1 vs v2 split with explicit "do not act on v1" guidance
+
+## Operator runbook (pending — execute after PR #102 merges)
+
+1. **Vercel — add subdomain alias:**
+   - Project settings (the one serving `apps/holded-mcp`) → Domains → Add → `holded-claude.verifactu.business`
+   - Configure the CNAME that Vercel asks for in the DNS provider (typically `cname.vercel-dns.com`)
+   - Wait for SSL provisioning (~1-2 min)
+
+2. **Vercel — change `BASE_URL` env var:**
+   - Project Settings → Environment Variables → Production
+   - From: `https://claude.verifactu.business` (or `https://claude-holded.verifactu.business` if you also have that alias from PR #101)
+   - To: `https://holded-claude.verifactu.business`
+   - Redeploy
+
+3. **Verification commands:**
+
+   ```bash
+   # OAuth issuer reflects the new subdomain
+   curl -sS https://holded-claude.verifactu.business/.well-known/oauth-authorization-server | jq .issuer
+   # expected: "https://holded-claude.verifactu.business"
+
+   # Favicon is the Holded diamond, not the V
+   curl -sS https://holded-claude.verifactu.business/favicon.ico | md5sum
+   # expected: d23f99aeb2d1ea5369b6222eba8cd8e7
+
+   # MCP endpoint returns 401 unauth (correct — needs Bearer)
+   curl -sS -X POST https://holded-claude.verifactu.business/mcp \
+     -H "Content-Type: application/json" \
+     -H "Accept: application/json, text/event-stream" \
+     -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+   # expected: HTTP 401 + JSON-RPC error about missing auth
+
+   # Manifest uses Holded coral, not Verifactu navy
+   curl -sS https://holded-claude.verifactu.business/manifest.json | jq '.theme_color, .background_color'
+   # expected: "#FF5460" + "#ffffff"
+   ```
+
+4. **Anthropic Google Form (submission v2):**
+   - URL: https://claude.com/docs/connectors/building/submission
+   - Server name: `Holded for Claude`
+   - MCP URL: `https://holded-claude.verifactu.business/mcp`
+   - Remaining fields: copy-paste from [docs/anthropic-submission/submission-form-answers.md](../anthropic-submission/submission-form-answers.md)
+   - Submit and wait for confirmation email; manual review ~2 weeks per Anthropic docs.
+
+5. **(Optional) cleanup of `claude-holded.verifactu.business`** in Vercel if that alias was configured (from PR #101's wrong-naming era). Removing it is safe — the domain is not referenced anywhere in the new docs/code.
+
+6. **Legacy `claude.verifactu.business`:** keep alive as alias in Vercel. Mismo build. No tenant ha conectado contra él (zero active users), pero el riesgo de romper algo si lo apagamos es bajo y el coste de mantenerlo cero. Reevaluar en 30 días.
+
+## What if the blue shield still appears after migration
+
+Hypotheses (in order of probability):
+
+1. **Anthropic caches by submitter email**, not by domain. Test: submit v2 form from a different email and see if the icon changes for that submission.
+2. **The Anthropic form does not respect `logo_uri`** and Anthropic always scrapes `/favicon.ico`. Test: verify visually that `holded-claude.verifactu.business/favicon.ico` returns the diamond, and if the directory still shows wrong icon, escalate via `partnerships@anthropic.com`.
+3. **The connector entry in Claude.ai (per-user) caches the icon at first connection**, not per-server. Test: have a fresh user (different account) connect for the first time after migration. If they see the diamond, the cache is per-account-per-connector and existing users need to disconnect + reconnect.
+
+## Side-tasks spawned during investigation
+
+| Side-task                                                                                                                                                                     | Status                   | Notes                                                                                                                          |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| `list_contacts` 500-item cap                                                                                                                                                  | Spawned 2026-05-19       | User has 4000+ contacts but MCP only exposes 500. Affects production usage on large tenants. Separate from this branding work. |
+| Hardcoded `claude.verifactu.business` in `apps/app/lib/connectorHealth/checks.ts` + `apps/app/app/.well-known/oauth-protected-resource/api/mcp/isaak/route.ts` + a route test | Not addressed in this PR | These are legacy aliases that work during transition. Optional follow-up PR if/when we sunset the legacy domain.               |
+
+## References
+
+- [PR #99 — favicon.ico + manifest.json](https://github.com/kiabusiness2025/verifactu-monorepo/pull/99)
+- [PR #100 — legacy alias + runbook root cause](https://github.com/kiabusiness2025/verifactu-monorepo/pull/100)
+- [PR #101 — subdomain migration (typo'd as claude-holded)](https://github.com/kiabusiness2025/verifactu-monorepo/pull/101)
+- [PR #102 — rename to holded-claude (brand-first)](https://github.com/kiabusiness2025/verifactu-monorepo/pull/102)
+- [Runbook section 10 — root causes](../../apps/holded-mcp/CLAUDE_CONNECTOR_RESET_RUNBOOK.md)
+- [Runbook section 14 — migration operator steps](../../apps/holded-mcp/CLAUDE_CONNECTOR_RESET_RUNBOOK.md)
+- [Submission form answers](../anthropic-submission/submission-form-answers.md)
+- [Anthropic Connectors Directory submission guide](https://claude.com/docs/connectors/building/submission)


### PR DESCRIPTION
## Corrección de naming

PR #101 mergeó la migración del MCP de Claude con subdominio `claude-holded.verifactu.business` (channel-first) por malentendido en la confirmación del usuario. La intención real era `holded-claude.verifactu.business` (brand-first).

### Argumentación brand-first

- Holded es **nuestro** producto, Claude es el canal — la marca propia va primero.
- Encaja mejor con `Holded for Claude` como app name.
- Patrón consistente con otras submission names del Anthropic Connectors Directory.

### Cambios

- **8 docs en `docs/anthropic-submission/`** — sustitución global del subdominio.
- **`apps/holded-mcp/src/{app,public-pages}.ts`** — referencias en comentarios.
- **`apps/holded-mcp/CLAUDE_CONNECTOR_RESET_RUNBOOK.md`** — secciones 10 y 14.

El código que computa URLs ya era dinámico desde PR #101 (vía `config.BASE_URL`), así que **cambiar el subdominio canónico es solo cambiar el env var** en Vercel.

### Pasos operativos tras merge

1. **Vercel — añadir subdominio nuevo:** Settings → Domains → Add → `holded-claude.verifactu.business`. Configurar CNAME en DNS provider. Esperar SSL (~1-2 min).

2. **Vercel — cambiar env var `BASE_URL`:** Production → de `https://claude-holded.verifactu.business` a `https://holded-claude.verifactu.business`. Redeploy.

3. **Verificación:**
   ```bash
   curl -sS https://holded-claude.verifactu.business/.well-known/oauth-authorization-server | jq .issuer
   # esperado: "https://holded-claude.verifactu.business"

   curl -sS https://holded-claude.verifactu.business/favicon.ico | md5sum
   # esperado: d23f99aeb2d1ea5369b6222eba8cd8e7
   ```

4. **(Opcional) Quitar `claude-holded.verifactu.business`** de Vercel si quieres limpio. El dominio legacy `claude.verifactu.business` puede quedarse como alias paralelo.

5. **Rellenar Google Form Anthropic:** server name `Holded for Claude`, MCP URL `https://holded-claude.verifactu.business/mcp`. Resto de campos en [docs/anthropic-submission/submission-form-answers.md](docs/anthropic-submission/submission-form-answers.md).

### Test plan

- [x] Sustitución limpia — cero `claude-holded` quedando en docs+source (grep verificado).
- [ ] Post-merge: Vercel domain alias `holded-claude.verifactu.business` configurado.
- [ ] Post-merge: env var `BASE_URL` cambiado + redeploy + issuer correcto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)