### PR TITLE
feat(isaak): Holded API full coverage + resiliencia HTTP + Plan Maestro RRHH/RED

### DIFF
--- a/apps/app/__mocks__/react-markdown.tsx
+++ b/apps/app/__mocks__/react-markdown.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+/**
+ * Stub de `react-markdown` para Jest.
+ *
+ * `react-markdown` es ESM puro y arrastra un árbol grande de dependencias ESM
+ * (unified, remark-*, micromark*, mdast-*, hast-*, ...) que Jest no transforma
+ * por defecto. Ningún test de apps/app valida el render de markdown — solo
+ * necesitamos que el árbol de componentes (`@verifactu/ui` → IsaakDock) cargue.
+ */
+export default function ReactMarkdown({ children }: { children?: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/apps/app/__mocks__/remark-gfm.js
+++ b/apps/app/__mocks__/remark-gfm.js
@@ -1,0 +1,3 @@
+// Stub de `remark-gfm` para Jest — plugin ESM de react-markdown. No-op: los
+// tests no validan el render de markdown (ver __mocks__/react-markdown.tsx).
+module.exports = function remarkGfm() {};

--- a/apps/app/app/api/public/status/[connector]/route.test.ts
+++ b/apps/app/app/api/public/status/[connector]/route.test.ts
@@ -25,6 +25,16 @@ jest.mock('@/lib/connectorHealth/checks', () => ({
   ]),
 }));
 
+jest.mock('@/lib/connectorHealth/run', () => ({
+  HEALTH_STALE_AFTER_MS: 15 * 60 * 1000,
+  refreshConnectorHealthInBackground: jest.fn(),
+}));
+
+jest.mock('next/server', () => {
+  const actual = jest.requireActual('next/server');
+  return { ...actual, after: jest.fn() };
+});
+
 import { NextRequest } from 'next/server';
 import { GET } from './route';
 import prisma from '@/lib/prisma';

--- a/apps/app/app/api/public/status/[connector]/route.ts
+++ b/apps/app/app/api/public/status/[connector]/route.ts
@@ -96,8 +96,14 @@ export async function GET(_req: NextRequest, ctx: { params: Promise<{ connector:
         return samples[idx];
       })();
 
+      // `kind` viene de la definición; fallback por prefijo `tool_` para
+      // tolerar definiciones antiguas o mocks de test sin el campo.
+      const kind =
+        ('kind' in def && def.kind) || (def.checkType.startsWith('tool_') ? 'tool' : 'surface');
+
       return {
         checkType: def.checkType,
+        kind,
         target: def.target,
         status: latest?.status ?? 'unknown',
         latencyMs: latest?.latencyMs ?? null,
@@ -134,6 +140,11 @@ export async function GET(_req: NextRequest, ctx: { params: Promise<{ connector:
       return Math.round((sum / sampled.length) * 10) / 10;
     })();
 
+    // Resumen separado de la familia `tool` (revisión en vivo de cada tool
+    // del conector) — alimenta el bloque "tools operativas X/Y" del badge.
+    const toolChecks = checks.filter((c) => c.kind === 'tool');
+    const surfaceChecks = checks.filter((c) => c.kind !== 'tool');
+
     return applyCors(
       NextResponse.json({
         connector,
@@ -144,6 +155,13 @@ export async function GET(_req: NextRequest, ctx: { params: Promise<{ connector:
         checksDegraded: checks.filter((c) => c.status === 'degraded').length,
         checksFail: checks.filter((c) => c.status === 'fail').length,
         checksUnknown: checks.filter((c) => c.status === 'unknown').length,
+        surfaceTotal: surfaceChecks.length,
+        surfaceOk: surfaceChecks.filter((c) => c.status === 'ok').length,
+        toolsTotal: toolChecks.length,
+        toolsOk: toolChecks.filter((c) => c.status === 'ok').length,
+        toolsDegraded: toolChecks.filter((c) => c.status === 'degraded').length,
+        toolsFail: toolChecks.filter((c) => c.status === 'fail').length,
+        toolsUnknown: toolChecks.filter((c) => c.status === 'unknown').length,
         overallUptime24hPct,
         checks,
       })
@@ -163,6 +181,9 @@ export async function GET(_req: NextRequest, ctx: { params: Promise<{ connector:
           error: 'status_unavailable',
           checks: expectedChecks.map((def) => ({
             checkType: def.checkType,
+            kind:
+              ('kind' in def && def.kind) ||
+              (def.checkType.startsWith('tool_') ? 'tool' : 'surface'),
             target: def.target,
             status: 'unknown',
             latencyMs: null,

--- a/apps/app/app/api/public/status/[connector]/route.ts
+++ b/apps/app/app/api/public/status/[connector]/route.ts
@@ -20,7 +20,11 @@
 
 import prisma from '@/lib/prisma';
 import { getCheckDefinitions, type ConnectorId } from '@/lib/connectorHealth/checks';
-import { NextRequest, NextResponse } from 'next/server';
+import {
+  HEALTH_STALE_AFTER_MS,
+  refreshConnectorHealthInBackground,
+} from '@/lib/connectorHealth/run';
+import { NextRequest, NextResponse, after } from 'next/server';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -131,6 +135,20 @@ export async function GET(_req: NextRequest, ctx: { params: Promise<{ connector:
       if (!acc) return c.lastCheckedAt;
       return c.lastCheckedAt > acc ? c.lastCheckedAt : acc;
     }, null);
+
+    // Autocuración: si el dato está obsoleto (el cron de Vercel dejó de
+    // dispararse), programamos un refresco en segundo plano que se ejecuta
+    // tras enviar la respuesta. El throttle vive dentro del helper.
+    const isStale =
+      !lastCheckedAt || Date.now() - new Date(lastCheckedAt).getTime() > HEALTH_STALE_AFTER_MS;
+    if (isStale) {
+      try {
+        after(refreshConnectorHealthInBackground);
+      } catch {
+        // `after()` fuera de contexto de request (p.ej. tests) — el cron
+        // sigue siendo el respaldo, no degradamos la respuesta.
+      }
+    }
 
     const okCount = checks.filter((c) => c.status === 'ok').length;
     const overallUptime24hPct = (() => {

--- a/apps/app/jest.config.mjs
+++ b/apps/app/jest.config.mjs
@@ -15,6 +15,10 @@ const customJestConfig = {
   testEnvironment: 'jest-environment-jsdom',
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',
+    // react-markdown y remark-gfm son ESM puro con un árbol de dependencias
+    // que Jest no transforma — los stubbeamos (ningún test valida markdown).
+    '^react-markdown$': '<rootDir>/__mocks__/react-markdown.tsx',
+    '^remark-gfm$': '<rootDir>/__mocks__/remark-gfm.js',
   },
 }
 

--- a/apps/app/lib/connectorHealth/checks.ts
+++ b/apps/app/lib/connectorHealth/checks.ts
@@ -1,13 +1,27 @@
 /**
  * Conector health checks: definición + ejecución.
  *
- * Cada check es una probe HTTP a un endpoint público del conector (sin token).
- * Diseñado para Vercel Cron — corre los ~16 checks en paralelo, persiste
+ * Dos familias de checks:
+ *
+ *  1. Superficie pública (`kind: 'surface'`) — probes HTTP a endpoints
+ *     públicos del conector SIN token: landings, OAuth discovery, MCP
+ *     initialize, tools/list. Verifican que el conector está "de cara".
+ *
+ *  2. Tools en vivo (`kind: 'tool'`) — probes autenticados a la API de
+ *     Holded (api.holded.com) usando `HOLDED_TEST_API_KEY`, una por cada
+ *     tool expuesta por cada conector. Verifican que el dato que la tool
+ *     consume está realmente accesible (no HTML, no 5xx, JSON bien formado).
+ *     Solo se registran si `HOLDED_TEST_API_KEY` está configurada — en
+ *     entornos sin la clave la familia entera queda fuera (degradación
+ *     limpia, sin falsos rojos).
+ *
+ * Diseñado para Vercel Cron — corre todos los checks en paralelo, persiste
  * resultados en `connector_health_checks`, y alimenta el endpoint público
  * /api/public/status/{connector} que la landing renderiza.
  */
 
 export type ConnectorId = 'chatgpt' | 'claude';
+export type CheckKind = 'surface' | 'tool';
 export type CheckStatus = 'ok' | 'degraded' | 'fail';
 export type CheckErrorCode =
   | 'timeout'
@@ -17,7 +31,9 @@ export type CheckErrorCode =
   | 'missing_field'
   | 'tool_count_mismatch'
   | 'rpc_error'
-  | 'unexpected_status';
+  | 'unexpected_status'
+  | 'html_response'
+  | 'soft_error';
 
 export interface HealthCheckResult {
   connector: ConnectorId;
@@ -29,6 +45,27 @@ export interface HealthCheckResult {
   errorCode: CheckErrorCode | null;
   errorMessage: string | null;
   metadata: Record<string, unknown> | null;
+}
+
+/** Resultado de un probe a la tool (familia `tool`). */
+interface ToolProbeOutcome {
+  error: CheckErrorCode | null;
+  message: string | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+/** Resultado crudo de un GET a la API de Holded. */
+interface HoldedGetResult {
+  ok: boolean;
+  httpStatus: number;
+  isHtml: boolean;
+  softError: boolean;
+  json: unknown;
+}
+
+interface ToolProbeContext {
+  /** GET a un path de api.holded.com con la `key` de test + 1 reintento. */
+  get: (path: string) => Promise<HoldedGetResult>;
 }
 
 type ProbeMode =
@@ -43,10 +80,17 @@ type ProbeMode =
         message: string | null;
         metadata?: Record<string, unknown> | null;
       };
+    }
+  | {
+      kind: 'holded_tool';
+      /** Path principal que la tool consume (solo para auditoría en `target`). */
+      primaryPath: string;
+      run: (ctx: ToolProbeContext) => Promise<ToolProbeOutcome>;
     };
 
 interface CheckDefinition {
   connector: ConnectorId;
+  kind: CheckKind;
   checkType: string;
   target: string;
   probe: ProbeMode;
@@ -59,6 +103,11 @@ interface CheckDefinition {
 const DEFAULT_TIMEOUT_MS = 8000;
 const DEFAULT_DEGRADED_ABOVE_MS = 3000;
 
+// Las tools en vivo pueden encadenar 2 llamadas a Holded (list + get) y la
+// API de Holded es más lenta que nuestra propia superficie pública.
+const TOOL_TIMEOUT_MS = 12000;
+const TOOL_DEGRADED_ABOVE_MS = 6000;
+
 const HOLDED_PUBLIC_URL =
   process.env.HEALTH_HOLDED_PUBLIC_URL?.trim() || 'https://holded.verifactu.business';
 const CHATGPT_MCP_URL =
@@ -66,6 +115,16 @@ const CHATGPT_MCP_URL =
 const CLAUDE_PUBLIC_URL =
   process.env.HEALTH_CLAUDE_PUBLIC_URL?.trim() || 'https://claude.verifactu.business';
 const CLAUDE_MCP_URL = process.env.HEALTH_CLAUDE_MCP_URL?.trim() || `${CLAUDE_PUBLIC_URL}/mcp`;
+const HOLDED_API_BASE =
+  process.env.HEALTH_HOLDED_API_BASE?.trim() || 'https://api.holded.com';
+
+/**
+ * API key de la cuenta Holded de pruebas. La misma que usan los smoke-tests
+ * del panel admin. Si no está configurada, la familia `tool` no se registra.
+ */
+function getHoldedTestApiKey(): string | null {
+  return process.env.HOLDED_TEST_API_KEY?.trim() || null;
+}
 
 // 2026-05-18 (tarde): VUELTO a 10 al cambiar DEFAULT_PUBLIC_SCOPE_PRESET de
 // `claude_parity` (29) a `openai_review_invoicing_v1` (10: 9 read + 1 write).
@@ -98,53 +157,364 @@ function expectClaudeHealth(body: unknown): string | null {
   return null;
 }
 
-function checks(): CheckDefinition[] {
+// ─── Probes de tools en vivo (familia `tool`) ────────────────────────────────
+
+/** Detecta el error blando de Holded: 200 OK con `{ status: 0, info: "..." }`. */
+function isHoldedSoftError(json: unknown): boolean {
+  return (
+    !!json &&
+    typeof json === 'object' &&
+    !Array.isArray(json) &&
+    'status' in json &&
+    (json as { status?: unknown }).status === 0
+  );
+}
+
+/** GET a la API de Holded con `key` header, 1 reintento ante fallo transitorio. */
+async function holdedGet(
+  apiKey: string,
+  path: string,
+  signal: AbortSignal
+): Promise<HoldedGetResult> {
+  let lastErr: unknown;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const res = await fetch(`${HOLDED_API_BASE}${path}`, {
+        method: 'GET',
+        headers: {
+          key: apiKey,
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          // Holded devuelve a veces brotli que undici decodifica mal detrás de
+          // proxies edge — forzamos identity, igual que HoldedClient.
+          'Accept-Encoding': 'identity',
+        },
+        redirect: 'follow',
+        cache: 'no-store',
+        signal,
+      });
+      const text = await res.text();
+      const isHtml = text.trimStart().startsWith('<');
+      let json: unknown = null;
+      if (!isHtml && text) {
+        try {
+          json = JSON.parse(text);
+        } catch {
+          json = null;
+        }
+      }
+      // Reintentar una vez ante 429 / 5xx transitorio.
+      if ((res.status === 429 || res.status >= 500) && attempt === 0) {
+        await new Promise((r) => setTimeout(r, 400));
+        continue;
+      }
+      return {
+        ok: res.ok,
+        httpStatus: res.status,
+        isHtml,
+        softError: isHoldedSoftError(json),
+        json,
+      };
+    } catch (err) {
+      lastErr = err;
+      if (attempt === 0 && !(err instanceof Error && err.name === 'AbortError')) {
+        await new Promise((r) => setTimeout(r, 400));
+        continue;
+      }
+      throw lastErr;
+    }
+  }
+  throw lastErr ?? new Error(`holdedGet failed: ${path}`);
+}
+
+/** Valida un GET genérico de Holded (no HTML, 2xx, sin soft error). */
+function validateHoldedResponse(r: HoldedGetResult): ToolProbeOutcome | null {
+  if (r.isHtml) {
+    return { error: 'html_response', message: `Holded devolvió HTML (HTTP ${r.httpStatus})` };
+  }
+  if (!r.ok) {
+    return { error: 'non_2xx', message: `Holded respondió HTTP ${r.httpStatus}` };
+  }
+  if (r.softError) {
+    const info = (r.json as { info?: unknown }).info;
+    return {
+      error: 'soft_error',
+      message: typeof info === 'string' ? info : 'Holded soft error (status:0)',
+    };
+  }
+  return null;
+}
+
+/** Probe de una tool tipo "list*": espera un array JSON. */
+function probeList(path: string, noun: string) {
+  return async ({ get }: ToolProbeContext): Promise<ToolProbeOutcome> => {
+    const r = await get(path);
+    const issue = validateHoldedResponse(r);
+    if (issue) return issue;
+    if (!Array.isArray(r.json)) {
+      return { error: 'invalid_json', message: `respuesta de ${noun} no es un array` };
+    }
+    return { error: null, message: `${r.json.length} ${noun}`, metadata: { itemCount: r.json.length } };
+  };
+}
+
+/** Probe de una tool tipo "get*": lista, toma el primer id y pide el detalle. */
+function probeDetail(listPath: string, detail: (id: string) => string, noun: string) {
+  return async ({ get }: ToolProbeContext): Promise<ToolProbeOutcome> => {
+    const list = await get(listPath);
+    const listIssue = validateHoldedResponse(list);
+    if (listIssue) return listIssue;
+    if (!Array.isArray(list.json)) {
+      return { error: 'invalid_json', message: `listado de ${noun} no es un array` };
+    }
+    const first = list.json[0] as { id?: unknown } | undefined;
+    const id = first && typeof first.id === 'string' ? first.id : null;
+    if (!id) {
+      return { error: null, message: `sin ${noun} para verificar detalle (cuenta vacía)` };
+    }
+    const r = await get(detail(id));
+    const issue = validateHoldedResponse(r);
+    if (issue) return issue;
+    return { error: null, message: `detalle de ${noun} accesible`, metadata: { sampleId: id } };
+  };
+}
+
+/** Probe de la tool de PDF: lista facturas y pide el PDF de la primera. */
+function probePdf(listPath: string) {
+  return async ({ get }: ToolProbeContext): Promise<ToolProbeOutcome> => {
+    const list = await get(listPath);
+    const listIssue = validateHoldedResponse(list);
+    if (listIssue) return listIssue;
+    if (!Array.isArray(list.json)) {
+      return { error: 'invalid_json', message: 'listado de documentos no es un array' };
+    }
+    const first = list.json[0] as { id?: unknown } | undefined;
+    const id = first && typeof first.id === 'string' ? first.id : null;
+    if (!id) {
+      return { error: null, message: 'sin documentos para verificar PDF (cuenta vacía)' };
+    }
+    const r = await get(`/api/invoicing/v1/documents/invoice/${id}/pdf`);
+    if (r.isHtml) {
+      return { error: 'html_response', message: `endpoint PDF devolvió HTML (HTTP ${r.httpStatus})` };
+    }
+    if (!r.ok) {
+      return { error: 'non_2xx', message: `endpoint PDF respondió HTTP ${r.httpStatus}` };
+    }
+    if (r.softError) {
+      return { error: 'soft_error', message: 'Holded soft error al generar el PDF' };
+    }
+    return { error: null, message: 'PDF de documento accesible' };
+  };
+}
+
+/** Probe de precondición para una tool de escritura (no muta nada). */
+function probePrecondition(path: string, label: string) {
+  return async ({ get }: ToolProbeContext): Promise<ToolProbeOutcome> => {
+    const r = await get(path);
+    const issue = validateHoldedResponse(r);
+    if (issue) return issue;
+    return { error: null, message: `precondición OK · ${label}` };
+  };
+}
+
+const DOCS_INVOICE = '/api/invoicing/v1/documents/invoice?page=1';
+const DOCS_PURCHASE = '/api/invoicing/v1/documents/purchase?page=1';
+const CONTACTS = '/api/invoicing/v1/contacts?page=1';
+const CHART_OF_ACCOUNTS = '/api/accounting/v1/chartofaccounts?includeEmpty=1';
+
+function dailyLedgerPath(): string {
+  const now = Math.floor(Date.now() / 1000);
+  const start = now - 30 * 24 * 60 * 60;
+  return `/api/accounting/v1/dailyledger?starttmp=${start}&endtmp=${now}&page=1`;
+}
+
+/**
+ * Definición declarativa de las tools en vivo por conector. El `checkType`
+ * lleva prefijo `tool_` para que el endpoint público y el badge las puedan
+ * separar de la superficie pública.
+ */
+interface ToolCheckSpec {
+  connector: ConnectorId;
+  checkType: string;
+  primaryPath: string;
+  run: (ctx: ToolProbeContext) => Promise<ToolProbeOutcome>;
+}
+
+function toolCheckSpecs(): ToolCheckSpec[] {
+  return [
+    // ─── Claude · preset submission_v1 (8 tools) ──────────────────────────────
+    {
+      connector: 'claude',
+      checkType: 'tool_list_documents',
+      primaryPath: DOCS_INVOICE,
+      run: probeList(DOCS_INVOICE, 'facturas'),
+    },
+    {
+      connector: 'claude',
+      checkType: 'tool_get_document',
+      primaryPath: DOCS_INVOICE,
+      run: probeDetail(DOCS_INVOICE, (id) => `/api/invoicing/v1/documents/invoice/${id}`, 'facturas'),
+    },
+    {
+      connector: 'claude',
+      checkType: 'tool_get_document_pdf',
+      primaryPath: DOCS_INVOICE,
+      run: probePdf(DOCS_INVOICE),
+    },
+    {
+      connector: 'claude',
+      checkType: 'tool_list_contacts',
+      primaryPath: CONTACTS,
+      run: probeList(CONTACTS, 'contactos'),
+    },
+    {
+      connector: 'claude',
+      checkType: 'tool_get_contact',
+      primaryPath: CONTACTS,
+      run: probeDetail(CONTACTS, (id) => `/api/invoicing/v1/contacts/${id}`, 'contactos'),
+    },
+    {
+      connector: 'claude',
+      checkType: 'tool_get_chart_of_accounts',
+      primaryPath: CHART_OF_ACCOUNTS,
+      run: probeList(CHART_OF_ACCOUNTS, 'cuentas contables'),
+    },
+    {
+      connector: 'claude',
+      checkType: 'tool_get_journal',
+      primaryPath: '/api/accounting/v1/dailyledger',
+      run: probeList(dailyLedgerPath(), 'apuntes del diario'),
+    },
+    {
+      connector: 'claude',
+      checkType: 'tool_create_invoice_draft',
+      primaryPath: CONTACTS,
+      run: probePrecondition(CONTACTS, 'contactos disponibles para el borrador'),
+    },
+
+    // ─── ChatGPT · preset openai_review_invoicing_v1 (10 tools) ────────────────
+    {
+      connector: 'chatgpt',
+      checkType: 'tool_list_invoices',
+      primaryPath: DOCS_INVOICE,
+      run: probeList(DOCS_INVOICE, 'facturas'),
+    },
+    {
+      connector: 'chatgpt',
+      checkType: 'tool_get_invoice',
+      primaryPath: DOCS_INVOICE,
+      run: probeDetail(DOCS_INVOICE, (id) => `/api/invoicing/v1/documents/invoice/${id}`, 'facturas'),
+    },
+    {
+      connector: 'chatgpt',
+      checkType: 'tool_list_documents',
+      primaryPath: DOCS_PURCHASE,
+      run: probeList(DOCS_PURCHASE, 'compras'),
+    },
+    {
+      connector: 'chatgpt',
+      checkType: 'tool_get_document',
+      primaryPath: DOCS_PURCHASE,
+      run: probeDetail(
+        DOCS_PURCHASE,
+        (id) => `/api/invoicing/v1/documents/purchase/${id}`,
+        'compras'
+      ),
+    },
+    {
+      connector: 'chatgpt',
+      checkType: 'tool_get_document_pdf',
+      primaryPath: DOCS_INVOICE,
+      run: probePdf(DOCS_INVOICE),
+    },
+    {
+      connector: 'chatgpt',
+      checkType: 'tool_list_contacts',
+      primaryPath: CONTACTS,
+      run: probeList(CONTACTS, 'contactos'),
+    },
+    {
+      connector: 'chatgpt',
+      checkType: 'tool_get_contact',
+      primaryPath: CONTACTS,
+      run: probeDetail(CONTACTS, (id) => `/api/invoicing/v1/contacts/${id}`, 'contactos'),
+    },
+    {
+      connector: 'chatgpt',
+      checkType: 'tool_list_accounts',
+      primaryPath: CHART_OF_ACCOUNTS,
+      run: probeList(CHART_OF_ACCOUNTS, 'cuentas contables'),
+    },
+    {
+      connector: 'chatgpt',
+      checkType: 'tool_list_daily_ledger',
+      primaryPath: '/api/accounting/v1/dailyledger',
+      run: probeList(dailyLedgerPath(), 'apuntes del diario'),
+    },
+    {
+      connector: 'chatgpt',
+      checkType: 'tool_create_invoice_draft',
+      primaryPath: CONTACTS,
+      run: probePrecondition(CONTACTS, 'contactos disponibles para el borrador'),
+    },
+  ];
+}
+
+function surfaceChecks(): CheckDefinition[] {
   return [
     // ─── ChatGPT MCP ──────────────────────────────────────────────────────────
     {
       connector: 'chatgpt',
+      kind: 'surface',
       checkType: 'landing',
       target: `${HOLDED_PUBLIC_URL}/conectores/chatgpt`,
       probe: { kind: 'get' },
     },
     {
       connector: 'chatgpt',
+      kind: 'surface',
       checkType: 'docs',
       target: `${HOLDED_PUBLIC_URL}/conectores/chatgpt/docs`,
       probe: { kind: 'get' },
     },
     {
       connector: 'chatgpt',
+      kind: 'surface',
       checkType: 'privacy',
       target: `${HOLDED_PUBLIC_URL}/conectores/chatgpt/privacy`,
       probe: { kind: 'get' },
     },
     {
       connector: 'chatgpt',
+      kind: 'surface',
       checkType: 'terms',
       target: `${HOLDED_PUBLIC_URL}/conectores/chatgpt/terms`,
       probe: { kind: 'get' },
     },
     {
       connector: 'chatgpt',
+      kind: 'surface',
       checkType: 'dpa',
       target: `${HOLDED_PUBLIC_URL}/conectores/chatgpt/dpa`,
       probe: { kind: 'get' },
     },
     {
       connector: 'chatgpt',
+      kind: 'surface',
       checkType: 'oauth_discovery',
       target: `${HOLDED_PUBLIC_URL}/.well-known/oauth-authorization-server`,
       probe: { kind: 'json_get', validate: expectOauthDiscovery },
     },
     {
       connector: 'chatgpt',
+      kind: 'surface',
       checkType: 'protected_resource',
       target: `${HOLDED_PUBLIC_URL}/.well-known/oauth-protected-resource/api/mcp/holded`,
       probe: { kind: 'json_get', validate: expectProtectedResource },
     },
     {
       connector: 'chatgpt',
+      kind: 'surface',
       checkType: 'mcp_initialize',
       target: CHATGPT_MCP_URL,
       probe: {
@@ -165,6 +535,7 @@ function checks(): CheckDefinition[] {
     },
     {
       connector: 'chatgpt',
+      kind: 'surface',
       checkType: 'tools_list',
       target: CHATGPT_MCP_URL,
       probe: {
@@ -193,54 +564,63 @@ function checks(): CheckDefinition[] {
     // ─── Claude MCP ────────────────────────────────────────────────────────────
     {
       connector: 'claude',
+      kind: 'surface',
       checkType: 'landing',
       target: `${CLAUDE_PUBLIC_URL}/`,
       probe: { kind: 'get' },
     },
     {
       connector: 'claude',
+      kind: 'surface',
       checkType: 'health',
       target: `${CLAUDE_PUBLIC_URL}/health`,
       probe: { kind: 'json_get', validate: expectClaudeHealth },
     },
     {
       connector: 'claude',
+      kind: 'surface',
       checkType: 'docs',
       target: `${HOLDED_PUBLIC_URL}/conectores/claude/docs`,
       probe: { kind: 'get' },
     },
     {
       connector: 'claude',
+      kind: 'surface',
       checkType: 'privacy',
       target: `${HOLDED_PUBLIC_URL}/conectores/claude/privacy`,
       probe: { kind: 'get' },
     },
     {
       connector: 'claude',
+      kind: 'surface',
       checkType: 'terms',
       target: `${HOLDED_PUBLIC_URL}/conectores/claude/terms`,
       probe: { kind: 'get' },
     },
     {
       connector: 'claude',
+      kind: 'surface',
       checkType: 'dpa',
       target: `${HOLDED_PUBLIC_URL}/conectores/claude/dpa`,
       probe: { kind: 'get' },
     },
     {
       connector: 'claude',
+      kind: 'surface',
       checkType: 'oauth_discovery',
       target: `${CLAUDE_PUBLIC_URL}/.well-known/oauth-authorization-server`,
       probe: { kind: 'json_get', validate: expectOauthDiscovery },
     },
     {
       connector: 'claude',
+      kind: 'surface',
       checkType: 'protected_resource',
       target: `${CLAUDE_PUBLIC_URL}/.well-known/oauth-protected-resource`,
       probe: { kind: 'json_get', validate: expectProtectedResource },
     },
     {
       connector: 'claude',
+      kind: 'surface',
       checkType: 'mcp_requires_auth',
       target: CLAUDE_MCP_URL,
       probe: {
@@ -251,6 +631,28 @@ function checks(): CheckDefinition[] {
       },
     },
   ];
+}
+
+function checks(): CheckDefinition[] {
+  const surface = surfaceChecks();
+
+  // La familia `tool` solo se registra si hay clave de test. Sin clave, no
+  // hay forma honesta de probar las tools — mejor no mostrarlas que mostrar
+  // un rojo falso en la landing pública.
+  const apiKey = getHoldedTestApiKey();
+  if (!apiKey) return surface;
+
+  const toolChecks: CheckDefinition[] = toolCheckSpecs().map((spec) => ({
+    connector: spec.connector,
+    kind: 'tool',
+    checkType: spec.checkType,
+    target: `${HOLDED_API_BASE}${spec.primaryPath}`,
+    timeoutMs: TOOL_TIMEOUT_MS,
+    degradedAboveMs: TOOL_DEGRADED_ABOVE_MS,
+    probe: { kind: 'holded_tool', primaryPath: spec.primaryPath, run: spec.run },
+  }));
+
+  return [...surface, ...toolChecks];
 }
 
 async function runProbe(def: CheckDefinition): Promise<HealthCheckResult> {
@@ -267,6 +669,51 @@ async function runProbe(def: CheckDefinition): Promise<HealthCheckResult> {
   } as const;
 
   try {
+    // ─── Familia `tool`: probe autenticado a la API de Holded ──────────────
+    if (def.probe.kind === 'holded_tool') {
+      const apiKey = getHoldedTestApiKey();
+      if (!apiKey) {
+        return {
+          ...base,
+          status: 'fail',
+          latencyMs: Date.now() - startedAt,
+          httpStatus: null,
+          errorCode: 'network',
+          errorMessage: 'HOLDED_TEST_API_KEY no configurada',
+          metadata: null,
+        };
+      }
+      const ctx: ToolProbeContext = {
+        get: (path) => holdedGet(apiKey, path, ctrl.signal),
+      };
+      const outcome = await def.probe.run(ctx);
+      const latencyMs = Date.now() - startedAt;
+      if (outcome.error) {
+        return {
+          ...base,
+          status: 'fail',
+          latencyMs,
+          httpStatus: null,
+          errorCode: outcome.error,
+          errorMessage: outcome.message,
+          metadata: outcome.metadata ?? null,
+        };
+      }
+      return {
+        ...base,
+        status: latencyMs > degradedAboveMs ? 'degraded' : 'ok',
+        latencyMs,
+        httpStatus: null,
+        errorCode: null,
+        errorMessage: outcome.message,
+        metadata:
+          latencyMs > degradedAboveMs
+            ? { ...(outcome.metadata ?? {}), reason: 'slow_response', thresholdMs: degradedAboveMs }
+            : (outcome.metadata ?? null),
+      };
+    }
+
+    // ─── Familia `surface`: probe HTTP a superficie pública ────────────────
     let response: Response;
     if (def.probe.kind === 'get' || def.probe.kind === 'json_get') {
       response = await fetch(def.target, {
@@ -409,8 +856,14 @@ export async function runAllConnectorHealthChecks(): Promise<HealthCheckResult[]
 
 export function getCheckDefinitions(): ReadonlyArray<{
   connector: ConnectorId;
+  kind: CheckKind;
   checkType: string;
   target: string;
 }> {
-  return checks().map(({ connector, checkType, target }) => ({ connector, checkType, target }));
+  return checks().map(({ connector, kind, checkType, target }) => ({
+    connector,
+    kind,
+    checkType,
+    target,
+  }));
 }

--- a/apps/app/lib/connectorHealth/checks.ts
+++ b/apps/app/lib/connectorHealth/checks.ts
@@ -279,8 +279,8 @@ function probeDetail(listPath: string, detail: (id: string) => string, noun: str
   };
 }
 
-/** Probe de la tool de PDF: lista facturas y pide el PDF de la primera. */
-function probePdf(listPath: string) {
+/** Probe de la tool de PDF: lista documentos y pide el PDF del primero. */
+function probePdf(listPath: string, docType: 'invoice' | 'purchase' = 'invoice') {
   return async ({ get }: ToolProbeContext): Promise<ToolProbeOutcome> => {
     const list = await get(listPath);
     const listIssue = validateHoldedResponse(list);
@@ -293,7 +293,7 @@ function probePdf(listPath: string) {
     if (!id) {
       return { error: null, message: 'sin documentos para verificar PDF (cuenta vacía)' };
     }
-    const r = await get(`/api/invoicing/v1/documents/invoice/${id}/pdf`);
+    const r = await get(`/api/invoicing/v1/documents/${docType}/${id}/pdf`);
     if (r.isHtml) {
       return { error: 'html_response', message: `endpoint PDF devolvió HTML (HTTP ${r.httpStatus})` };
     }
@@ -424,8 +424,8 @@ function toolCheckSpecs(): ToolCheckSpec[] {
     {
       connector: 'chatgpt',
       checkType: 'tool_get_document_pdf',
-      primaryPath: DOCS_INVOICE,
-      run: probePdf(DOCS_INVOICE),
+      primaryPath: DOCS_PURCHASE,
+      run: probePdf(DOCS_PURCHASE, 'purchase'),
     },
     {
       connector: 'chatgpt',

--- a/apps/app/lib/connectorHealth/run.ts
+++ b/apps/app/lib/connectorHealth/run.ts
@@ -1,0 +1,82 @@
+/**
+ * Auto-refresco de los health-checks de conectores.
+ *
+ * El cron de Vercel (`/api/cron/connector-health`, cada 5 min) es la vía
+ * principal para mantener `connector_health_checks` al día. Pero si el cron
+ * deja de dispararse, el estado mostrado en las landings se queda obsoleto
+ * ("última comprobación hace N días").
+ *
+ * Este helper permite que el endpoint público se autocure: cuando detecta
+ * datos viejos, programa un refresco en segundo plano (vía `after()`) que
+ * ejecuta los checks y los persiste. Así el estado se mantiene fresco con el
+ * propio tráfico de las landings, sin depender únicamente del cron.
+ *
+ * Es best-effort: si falla, se loguea y se ignora — el cron sigue siendo el
+ * respaldo y nunca se degrada la respuesta del endpoint público.
+ */
+
+import type { Prisma } from '@prisma/client';
+import prisma from '@/lib/prisma';
+import { runAllConnectorHealthChecks, type HealthCheckResult } from './checks';
+
+/** Datos más viejos que esto se consideran obsoletos y disparan un refresco. */
+export const HEALTH_STALE_AFTER_MS = 15 * 60 * 1000;
+
+// Throttle en memoria: como mucho un refresco cada 3 min por instancia
+// serverless. Evita que ráfagas de tráfico lancen runs solapados.
+const REFRESH_THROTTLE_MS = 3 * 60 * 1000;
+let lastRefreshStartedAt = 0;
+
+function toCreateData(r: HealthCheckResult) {
+  return {
+    connector: r.connector,
+    checkType: r.checkType,
+    target: r.target,
+    status: r.status,
+    latencyMs: r.latencyMs,
+    httpStatus: r.httpStatus ?? null,
+    errorCode: r.errorCode ?? null,
+    errorMessage: r.errorMessage ?? null,
+    metadata: (r.metadata ?? undefined) as Prisma.InputJsonValue | undefined,
+  };
+}
+
+async function persistResults(results: HealthCheckResult[]): Promise<void> {
+  const data = results.map(toCreateData);
+  try {
+    await prisma.connectorHealthCheck.createMany({ data });
+  } catch {
+    // Prisma Accelerate no siempre soporta createMany — fallback a inserts
+    // individuales, igual que el cron.
+    for (const row of data) {
+      try {
+        await prisma.connectorHealthCheck.create({ data: row });
+      } catch (err) {
+        console.warn('[connectorHealth] background insert failed', {
+          checkType: row.checkType,
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  }
+}
+
+/**
+ * Ejecuta todos los checks y los persiste. Pensado para llamarse desde
+ * `after()` en el endpoint público. Aplica un throttle en memoria para no
+ * solapar ejecuciones. Nunca lanza: cualquier error se loguea.
+ */
+export async function refreshConnectorHealthInBackground(): Promise<void> {
+  const now = Date.now();
+  if (now - lastRefreshStartedAt < REFRESH_THROTTLE_MS) return;
+  lastRefreshStartedAt = now;
+
+  try {
+    const results = await runAllConnectorHealthChecks();
+    await persistResults(results);
+  } catch (err) {
+    console.warn('[connectorHealth] background refresh failed', {
+      message: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/apps/app/lib/integrations/accounting.ts
+++ b/apps/app/lib/integrations/accounting.ts
@@ -19,6 +19,18 @@ const HOLDED_HISTORY_SCAN_BUDGET_MS = Math.max(
   Number(process.env.HOLDED_HISTORY_SCAN_BUDGET_MS || '7000')
 );
 
+const HOLDED_RETRYABLE_STATUS = new Set([429, 502, 503, 504]);
+const HOLDED_MAX_RETRIES = 2;
+
+function holdedSleep(ms: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
+function holdedBackoffMs(attempt: number) {
+  const base = 200 * 2 ** attempt;
+  return Math.max(50, Math.floor(base + base * (Math.random() - 0.5)));
+}
+
 export { encryptIntegrationSecret };
 
 export type HoldedProbeProfile = 'dashboard' | 'chatgpt';
@@ -149,34 +161,41 @@ function buildHoldedHeaders(apiKey: string, accept = 'application/json') {
 }
 
 async function holdedRequest<T>(options: HoldedRequestOptions): Promise<T> {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? HOLDED_TIMEOUT_MS);
+  for (let attempt = 0; attempt <= HOLDED_MAX_RETRIES; attempt++) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? HOLDED_TIMEOUT_MS);
 
-  try {
-    const response = await fetch(buildHoldedUrl(options.path, options.query), {
-      method: options.method ?? 'GET',
-      headers: buildHoldedHeaders(options.apiKey),
-      body: options.body ? JSON.stringify(options.body) : undefined,
-      signal: controller.signal,
-      cache: 'no-store',
-    });
+    try {
+      const response = await fetch(buildHoldedUrl(options.path, options.query), {
+        method: options.method ?? 'GET',
+        headers: buildHoldedHeaders(options.apiKey),
+        body: options.body ? JSON.stringify(options.body) : undefined,
+        signal: controller.signal,
+        cache: 'no-store',
+      });
 
-    const rawText = await response.text();
-    const parsed = rawText ? safeJsonParse(rawText) : null;
+      const rawText = await response.text();
+      const parsed = rawText ? safeJsonParse(rawText) : null;
 
-    if (!response.ok) {
-      const payload =
-        parsed && typeof parsed === 'object' ? (parsed as HoldedApiErrorPayload) : null;
-      const message = buildHoldedErrorMessage(response.status, payload, rawText);
-      const err = new Error(message) as Error & { status?: number };
-      err.status = response.status;
-      throw err;
+      if (!response.ok) {
+        if (HOLDED_RETRYABLE_STATUS.has(response.status) && attempt < HOLDED_MAX_RETRIES) {
+          await holdedSleep(holdedBackoffMs(attempt));
+          continue;
+        }
+        const payload =
+          parsed && typeof parsed === 'object' ? (parsed as HoldedApiErrorPayload) : null;
+        const message = buildHoldedErrorMessage(response.status, payload, rawText);
+        const err = new Error(message) as Error & { status?: number };
+        err.status = response.status;
+        throw err;
+      }
+
+      return (parsed as T) ?? (null as T);
+    } finally {
+      clearTimeout(timeout);
     }
-
-    return (parsed as T) ?? (null as T);
-  } finally {
-    clearTimeout(timeout);
   }
+  throw new Error(`Holded request failed: ${options.path}`);
 }
 
 function safeJsonParse(raw: string) {
@@ -218,49 +237,56 @@ async function holdedBinaryRequest(
     defaultContentType?: string;
   }
 ): Promise<HoldedBinaryFile> {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? HOLDED_TIMEOUT_MS);
+  for (let attempt = 0; attempt <= HOLDED_MAX_RETRIES; attempt++) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? HOLDED_TIMEOUT_MS);
 
-  try {
-    const response = await fetch(buildHoldedUrl(options.path, options.query), {
-      method: options.method ?? 'GET',
-      headers: buildHoldedHeaders(
-        options.apiKey,
-        options.accept ?? 'application/pdf, application/octet-stream, application/json'
-      ),
-      signal: controller.signal,
-      cache: 'no-store',
-    });
+    try {
+      const response = await fetch(buildHoldedUrl(options.path, options.query), {
+        method: options.method ?? 'GET',
+        headers: buildHoldedHeaders(
+          options.apiKey,
+          options.accept ?? 'application/pdf, application/octet-stream, application/json'
+        ),
+        signal: controller.signal,
+        cache: 'no-store',
+      });
 
-    if (!response.ok) {
-      const rawText = await response.text();
-      const parsed = rawText ? safeJsonParse(rawText) : null;
-      const payload =
-        parsed && typeof parsed === 'object' ? (parsed as HoldedApiErrorPayload) : null;
-      const message =
-        payload?.error ||
-        payload?.message ||
-        `Holded API request failed with status ${response.status}`;
-      throw new Error(message);
+      if (!response.ok) {
+        if (HOLDED_RETRYABLE_STATUS.has(response.status) && attempt < HOLDED_MAX_RETRIES) {
+          await holdedSleep(holdedBackoffMs(attempt));
+          continue;
+        }
+        const rawText = await response.text();
+        const parsed = rawText ? safeJsonParse(rawText) : null;
+        const payload =
+          parsed && typeof parsed === 'object' ? (parsed as HoldedApiErrorPayload) : null;
+        const message =
+          payload?.error ||
+          payload?.message ||
+          `Holded API request failed with status ${response.status}`;
+        throw new Error(message);
+      }
+
+      const data = await response.arrayBuffer();
+      const contentType =
+        response.headers?.get?.('content-type') ?? options.defaultContentType ?? 'application/pdf';
+      const fileName =
+        extractFilenameFromContentDisposition(
+          response.headers?.get?.('content-disposition') ?? null
+        ) ?? null;
+
+      return {
+        base64: Buffer.from(data).toString('base64'),
+        contentType,
+        fileName,
+        size: data.byteLength,
+      };
+    } finally {
+      clearTimeout(timeout);
     }
-
-    const data = await response.arrayBuffer();
-    const contentType =
-      response.headers?.get?.('content-type') ?? options.defaultContentType ?? 'application/pdf';
-    const fileName =
-      extractFilenameFromContentDisposition(
-        response.headers?.get?.('content-disposition') ?? null
-      ) ?? null;
-
-    return {
-      base64: Buffer.from(data).toString('base64'),
-      contentType,
-      fileName,
-      size: data.byteLength,
-    };
-  } finally {
-    clearTimeout(timeout);
   }
+  throw new Error(`Holded binary request failed: ${options.path}`);
 }
 
 async function holdedMultipartRequest(

--- a/apps/app/lib/integrations/holdedMcpTools.getInvoice.test.ts
+++ b/apps/app/lib/integrations/holdedMcpTools.getInvoice.test.ts
@@ -136,15 +136,18 @@ describe('holded_get_invoice (B5 smart lookup)', () => {
     expect(secondYear).toBe(firstYear - 1);
   });
 
-  it('lanza error con guía si nada matchea', async () => {
+  it('devuelve una respuesta controlada not_found si nada matchea', async () => {
     mockedAdapter.listInvoices.mockResolvedValueOnce([]);
     mockedAdapter.listInvoicesHistory
       .mockResolvedValueOnce({ items: [] })
       .mockResolvedValueOnce({ items: [] });
 
-    await expect(
-      callHoldedMcpTool(API_KEY, 'holded_get_invoice', { invoiceId: 'F9999' })
-    ).rejects.toThrow(/No invoice found with id or document number "F9999"/);
+    // El smart lookup ya no lanza: devuelve un error controlado `not_found`
+    // (mismo patrón que get_document) para que el modelo lo gestione.
+    const result = await callHoldedMcpTool(API_KEY, 'holded_get_invoice', {
+      invoiceId: 'F9999',
+    });
+    expect(result).toMatchObject({ error: 'not_found', id: 'F9999', entity: 'invoice' });
 
     expect(mockedAdapter.getInvoice).not.toHaveBeenCalled();
   });

--- a/apps/holded-mcp/src/public-pages.ts
+++ b/apps/holded-mcp/src/public-pages.ts
@@ -13,7 +13,19 @@ function escapeHtml(value: string) {
     .replaceAll("'", '&#39;');
 }
 
-const CAPABILITIES = [
+interface Capability {
+  icon: string;
+  title: string;
+  sub: string;
+  ex: string[];
+  /** Capacidad cuyo código existe pero aún no está expuesta en el preset de
+   *  tools `submission_v1` — se muestra como roadmap, no como disponible. */
+  roadmap?: boolean;
+}
+
+// Orden: primero las capacidades disponibles hoy (cubiertas por las 8 tools
+// del preset submission_v1), luego las marcadas como roadmap.
+const CAPABILITIES: Capability[] = [
   {
     icon: '🧾',
     title: 'Facturas',
@@ -39,30 +51,6 @@ const CAPABILITIES = [
     ex: ['Muéstrame los apuntes de marzo.', 'Explícame este asiento en lenguaje claro.'],
   },
   {
-    icon: '📝',
-    title: 'Borradores de factura',
-    sub: 'Prepara borradores solo después de confirmación explícita del usuario.',
-    ex: ['Prepara un borrador para Acme por 100 € + IVA.', 'Pídeme confirmación antes de crearlo.'],
-  },
-  {
-    icon: '📦',
-    title: 'Productos y stock',
-    sub: 'Lista catálogo, ficha de producto y stock disponible cuando está habilitado.',
-    ex: ['¿Qué productos tengo con stock bajo?', 'Enséñame precio y stock de este SKU.'],
-  },
-  {
-    icon: '📋',
-    title: 'Proyectos y tareas',
-    sub: 'Consulta proyectos abiertos, tareas pendientes e imputaciones de horas.',
-    ex: ['Resume mis proyectos activos.', '¿Qué tareas están pendientes esta semana?'],
-  },
-  {
-    icon: '📈',
-    title: 'CRM: leads y embudo',
-    sub: 'Visualiza el embudo de ventas y los leads asignados sin modificar nada.',
-    ex: ['Resume mi embudo por fases.', '¿Qué leads esperan seguimiento?'],
-  },
-  {
     icon: '⬇️',
     title: 'PDFs de documentos',
     sub: 'Descarga el PDF de una factura, presupuesto o albarán existente.',
@@ -72,13 +60,38 @@ const CAPABILITIES = [
     ],
   },
   {
+    icon: '📝',
+    title: 'Borradores de factura',
+    sub: 'Prepara borradores solo después de confirmación explícita del usuario.',
+    ex: ['Prepara un borrador para Acme por 100 € + IVA.', 'Pídeme confirmación antes de crearlo.'],
+  },
+  {
+    icon: '📦',
+    title: 'Productos y stock',
+    sub: 'Previsto: consultar catálogo, ficha de producto y stock disponible.',
+    ex: [],
+    roadmap: true,
+  },
+  {
+    icon: '📋',
+    title: 'Proyectos y tareas',
+    sub: 'Previsto: revisar proyectos abiertos, tareas pendientes e imputación de horas.',
+    ex: [],
+    roadmap: true,
+  },
+  {
+    icon: '📈',
+    title: 'CRM: leads y embudo',
+    sub: 'Previsto: visualizar el embudo de ventas y los leads asignados.',
+    ex: [],
+    roadmap: true,
+  },
+  {
     icon: '💼',
     title: 'Equipo y tesorería',
-    sub: 'Empleados, cuentas de tesorería, tipos de IVA, almacenes y series de numeración.',
-    ex: [
-      'Muéstrame mi equipo y cuentas de tesorería.',
-      'Lista almacenes y series antes de crear un borrador.',
-    ],
+    sub: 'Previsto: empleados, cuentas de tesorería, tipos de IVA, almacenes y series.',
+    ex: [],
+    roadmap: true,
   },
 ];
 
@@ -93,8 +106,17 @@ export function renderLandingPage(baseUrl: string) {
   const connectHref = escapeHtml(`${baseUrl.replace(/\/$/, '')}/launch`);
   const holdedBase = escapeHtml(HOLDED_BASE);
 
-  const capsHtml = CAPABILITIES.map(
-    (cap) => `
+  const renderCap = (cap: Capability) => {
+    if (cap.roadmap) {
+      return `
+      <article class="cap-card cap-card-roadmap">
+        <span class="cap-badge">Próximamente</span>
+        <span class="cap-icon">${cap.icon}</span>
+        <h3>${escapeHtml(cap.title)}</h3>
+        <p class="cap-sub">${escapeHtml(cap.sub)}</p>
+      </article>`;
+    }
+    return `
       <article class="cap-card">
         <span class="cap-icon">${cap.icon}</span>
         <h3>${escapeHtml(cap.title)}</h3>
@@ -102,8 +124,10 @@ export function renderLandingPage(baseUrl: string) {
         <div class="cap-examples">
           ${cap.ex.map((e) => `<span class="example-chip">${escapeHtml(e)}</span>`).join('\n          ')}
         </div>
-      </article>`
-  ).join('');
+      </article>`;
+  };
+  const capsHtml = CAPABILITIES.filter((cap) => !cap.roadmap).map(renderCap).join('');
+  const roadmapHtml = CAPABILITIES.filter((cap) => cap.roadmap).map(renderCap).join('');
 
   const trustHtml = TRUST_POINTS.map(
     (t) => `
@@ -296,6 +320,23 @@ export function renderLandingPage(baseUrl: string) {
       font-size: .7rem; font-weight: 500; line-height: 1.5; color: #475569;
     }
 
+    /* ── Roadmap (capacidades aún no expuestas) ─ */
+    .cap-card-roadmap { background: #f8fafc; border-style: dashed; }
+    .cap-card-roadmap .cap-icon { filter: grayscale(1); opacity: .45; }
+    .cap-card-roadmap h3 { color: var(--text-muted); }
+    .cap-badge {
+      align-self: flex-start;
+      margin-bottom: .625rem;
+      padding: .15rem .5rem;
+      border-radius: 9999px;
+      border: 1px solid var(--bdr);
+      background: #fff;
+      font-size: .6rem; font-weight: 700;
+      text-transform: uppercase; letter-spacing: .1em;
+      color: var(--text-muted);
+    }
+    .roadmap-head { text-align: center; margin: 2.75rem 0 1.5rem; }
+
     /* ── Security ───────────────────────────── */
     .security-grid { display: grid; gap: 1.5rem; }
     @media (min-width: 900px) { .security-grid { grid-template-columns: 1fr 0.9fr; } }
@@ -392,7 +433,7 @@ export function renderLandingPage(baseUrl: string) {
     <h1>Pregunta a Holded desde Claude.</h1>
 
     <p class="desc">
-      Consulta facturas, contactos, contabilidad, CRM y proyectos en lenguaje natural.
+      Consulta facturas, contactos y contabilidad en lenguaje natural.
       Crea borradores de factura solo con confirmación explícita. Tus credenciales se
       guardan en servidor y el acceso queda limitado a tu cuenta conectada.
     </p>
@@ -472,14 +513,22 @@ export function renderLandingPage(baseUrl: string) {
 <section class="sec">
   <div class="w">
     <div class="sec-head">
-      <p class="sec-label">Capacidades actuales</p>
+      <p class="sec-label">Capacidades del conector</p>
       <h2 class="sec-title">Preguntas de negocio, no menús.</h2>
       <p class="sec-sub">
-        Estas son las capacidades actuales del conector. El usuario pregunta en lenguaje
-        natural y Claude consulta Holded dentro de la cuenta autorizada.
+        El usuario pregunta en lenguaje natural y Claude consulta Holded dentro de la
+        cuenta autorizada. Estas son las capacidades disponibles hoy.
       </p>
     </div>
     <div class="cap-grid">${capsHtml}</div>
+    <div class="roadmap-head">
+      <p class="sec-label">En el roadmap</p>
+      <p class="sec-sub" style="margin-top:.5rem;">
+        Estas áreas se incorporarán al conector tras la aprobación en el directorio de
+        Anthropic. Hoy no están disponibles.
+      </p>
+    </div>
+    <div class="cap-grid">${roadmapHtml}</div>
     <div style="margin-top:2.5rem;display:flex;justify-content:center;">
       <a href="${connectHref}" target="_blank" rel="noopener noreferrer" class="btn-p">
         &#10230; Conectar Holded con Claude

--- a/apps/holded-mcp/src/public-pages.ts
+++ b/apps/holded-mcp/src/public-pages.ts
@@ -469,8 +469,8 @@ export function renderLandingPage(baseUrl: string) {
           Añade Holded a Claude en menos de dos minutos.
         </h2>
         <p style="font-size:.875rem;line-height:1.6;color:var(--text-muted);max-width:30rem;margin-top:.5rem;">
-          El conector usa el flujo de conector personalizado de Claude mientras finaliza la
-          revisión en el directorio oficial de Anthropic. Ya está operativo.
+          Ya está operativo. Se añade con el flujo de conector personalizado de Claude; en
+          paralelo, está en revisión para aparecer en el directorio oficial de Anthropic.
         </p>
       </div>
       <a href="${connectHref}" target="_blank" rel="noopener noreferrer" class="btn-p">

--- a/apps/holded-mcp/test/oauth.test.ts
+++ b/apps/holded-mcp/test/oauth.test.ts
@@ -128,21 +128,26 @@ test('OAuth authorize rejects redirect_uri outside the Claude allowlist', async 
   }
 });
 
-test('OAuth consent page escapes hidden input values', async () => {
+test('OAuth authorize bridges to the holded-claude form without leaking unescaped state', async () => {
   const runtime = await startTestServer();
 
   try {
+    // Desde 2026-05-18 GET /oauth/authorize ya no renderiza un consent screen
+    // propio: siempre redirige (302) al form amber de holded-claude. El `state`
+    // malicioso debe viajar URL-encoded dentro de `next`, nunca crudo.
     const state = `"><script>alert(1)</script>`;
     const response = await fetch(
       `${runtime.baseUrl}/oauth/authorize?response_type=code&client_id=test&redirect_uri=${encodeURIComponent(
         'https://claude.ai/api/mcp/auth_callback'
-      )}&state=${encodeURIComponent(state)}`
+      )}&state=${encodeURIComponent(state)}`,
+      { redirect: 'manual' }
     );
 
-    assert.equal(response.status, 200);
-    const html = await response.text();
-    assert.doesNotMatch(html, /"><script>alert\(1\)<\/script>/);
-    assert.match(html, /&quot;&gt;&lt;script&gt;alert\(1\)&lt;\/script&gt;/);
+    assert.equal(response.status, 302);
+    const location = response.headers.get('location') ?? '';
+    assert.match(location, /\/auth\/holded-claude/);
+    assert.doesNotMatch(location, /<script>/i);
+    assert.doesNotMatch(location, /"><script>alert\(1\)<\/script>/);
   } finally {
     await runtime.close();
   }

--- a/apps/holded/app/auth/holded-claude/HoldedClaudeForm.tsx
+++ b/apps/holded/app/auth/holded-claude/HoldedClaudeForm.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { HoldedApiKeyHelp } from '@/app/components/HoldedApiKeyHelp';
 import {
   consumeMagicLink,
   detectMagicLinkInUrl,
@@ -71,7 +72,7 @@ const ERROR_MESSAGES: Record<string, string> = {
   INVALID_API_KEY:
     'La API key no es válida o no tiene los permisos necesarios. Comprueba que sea correcta en Holded.',
   INVALID_API_KEY_FORMAT:
-    'La API key debe tener 32 caracteres hexadecimales (0-9, a-f). Verifica que la has copiado completa desde Holded → Configuración → Integraciones → API.',
+    'La API key debe tener 32 caracteres: solo números (0-9) y letras (a-f). Verifica que la has copiado completa desde Holded → Configuración → Integraciones → API.',
   PROBE_ERROR: 'No se pudo conectar con Holded. Inténtalo de nuevo en unos segundos.',
   DB_ERROR: 'Error interno. Por favor, contacta con soporte.',
   SESSION_ERROR: 'Error al iniciar sesión. Por favor, inténtalo de nuevo.',
@@ -792,7 +793,7 @@ export function HoldedClaudeForm({ sessionEmail }: { sessionEmail: string | null
                             }
                           }}
                           onBlur={() => setApiKeyTouched(true)}
-                          placeholder="32 caracteres hexadecimales (0-9, a-f)"
+                          placeholder="32 caracteres: solo números (0-9) y letras (a-f)"
                           aria-invalid={showApiKeyFormatError || undefined}
                           aria-describedby={
                             showApiKeyFormatError ? 'apikey-format-error' : undefined
@@ -819,11 +820,13 @@ export function HoldedClaudeForm({ sessionEmail }: { sessionEmail: string | null
                           className="mt-1 px-1 text-xs leading-5 text-rose-700"
                         >
                           Formato inválido. La API key de Holded son{' '}
-                          <strong>32 caracteres hexadecimales</strong> (solo dígitos 0–9 y letras
-                          a–f). Cópiala completa desde Holded → Configuración → Integraciones → API.
+                          <strong>32 caracteres</strong> (solo números 0–9 y letras a–f).
+                          Cópiala completa desde Holded → Configuración → Integraciones → API.
                         </p>
                       ) : null}
                     </div>
+
+                    <HoldedApiKeyHelp accent="amber" />
 
                     <label className="flex cursor-pointer items-start gap-2.5 px-1">
                       <input

--- a/apps/holded/app/auth/holded-direct/HoldedDirectForm.tsx
+++ b/apps/holded/app/auth/holded-direct/HoldedDirectForm.tsx
@@ -17,6 +17,7 @@
  * como prop y el form arranca directamente en el paso de API key.
  */
 
+import { HoldedApiKeyHelp } from '@/app/components/HoldedApiKeyHelp';
 import {
   consumeMagicLink,
   detectMagicLinkInUrl,
@@ -102,7 +103,7 @@ const ERROR_MESSAGES: Record<string, string> = {
   INVALID_API_KEY:
     'La API key no es válida o no tiene los permisos necesarios. Comprueba que sea correcta en Holded.',
   INVALID_API_KEY_FORMAT:
-    'La API key debe tener 32 caracteres hexadecimales (0-9, a-f). Verifica que la has copiado completa desde Holded → Configuración → Integraciones → API.',
+    'La API key debe tener 32 caracteres: solo números (0-9) y letras (a-f). Verifica que la has copiado completa desde Holded → Configuración → Integraciones → API.',
   PROBE_ERROR: 'No se pudo conectar con Holded. Inténtalo de nuevo en unos segundos.',
   DB_ERROR: 'Error interno. Por favor, contacta con soporte.',
   SESSION_ERROR: 'Error al iniciar sesión. Por favor, inténtalo de nuevo.',
@@ -839,7 +840,7 @@ export function HoldedDirectForm({ sessionEmail }: { sessionEmail: string | null
                             }
                           }}
                           onBlur={() => setApiKeyTouched(true)}
-                          placeholder="32 caracteres hexadecimales (0-9, a-f)"
+                          placeholder="32 caracteres: solo números (0-9) y letras (a-f)"
                           aria-invalid={showApiKeyFormatError || undefined}
                           aria-describedby={
                             showApiKeyFormatError ? 'apikey-format-error' : undefined
@@ -866,11 +867,13 @@ export function HoldedDirectForm({ sessionEmail }: { sessionEmail: string | null
                           className="mt-1 px-1 text-xs leading-5 text-rose-700"
                         >
                           Formato inválido. La API key de Holded son{' '}
-                          <strong>32 caracteres hexadecimales</strong> (solo dígitos 0–9 y letras
-                          a–f). Cópiala completa desde Holded → Configuración → Integraciones → API.
+                          <strong>32 caracteres</strong> (solo números 0–9 y letras a–f).
+                          Cópiala completa desde Holded → Configuración → Integraciones → API.
                         </p>
                       ) : null}
                     </div>
+
+                    <HoldedApiKeyHelp accent="emerald" />
 
                     {/* T&C — un solo check combinado, microcopy compacto */}
                     <label className="flex cursor-pointer items-start gap-2.5 px-1">

--- a/apps/holded/app/auth/holded-direct/success/page.tsx
+++ b/apps/holded/app/auth/holded-direct/success/page.tsx
@@ -114,14 +114,14 @@ export default function HoldedDirectSuccessPage() {
         <div className="mt-10 rounded-2xl border border-slate-200 bg-white px-6 py-5 text-center text-sm text-slate-600">
           ¿Necesitas ayuda?{' '}
           <a
-            href={`${HOLDED_SITE_URL}/conectores/claude/soporte`}
+            href={`${HOLDED_SITE_URL}/conectores/chatgpt/soporte`}
             className="font-semibold text-[#ff5460] underline-offset-2 hover:underline"
           >
             Contactar soporte
           </a>{' '}
           o consultar la{' '}
           <a
-            href={`${HOLDED_SITE_URL}/conectores/claude/docs`}
+            href={`${HOLDED_SITE_URL}/conectores/chatgpt/docs`}
             className="font-semibold text-slate-800 underline-offset-2 hover:underline"
           >
             documentación

--- a/apps/holded/app/capacidades/page.tsx
+++ b/apps/holded/app/capacidades/page.tsx
@@ -35,11 +35,11 @@ const availableCapabilities = [
     ],
   },
   {
-    title: 'Proyectos y trabajo en curso',
+    title: 'Documentos y PDFs',
     points: [
-      'Listar proyectos para ver carga y contexto operativo.',
-      'Abrir un proyecto concreto y revisar sus tareas.',
-      'Detectar bloqueos o prioridades para la semana.',
+      'Consultar el detalle completo de un documento: lineas, importes e IVA.',
+      'Descargar el PDF de una factura, presupuesto o albaran existente.',
+      'Recuperar el documento que necesitas adjuntar a un email o gestion.',
     ],
   },
 ];
@@ -48,15 +48,15 @@ const workingPrompts = [
   'Que facturas deberia revisar hoy para proteger caja?',
   'Ensename los contactos con mas riesgo de cobro.',
   'Explicame el diario de esta semana en lenguaje claro.',
-  'Resumeme en 5 lineas los proyectos con mas riesgo.',
+  'Dame el PDF de mi ultima factura emitida.',
   'Prepara un borrador de factura para este cliente por este importe.',
 ];
 
 const currentLimits = [
   'El conector no inventa datos: trabaja con lo que realmente existe en tu entorno.',
   'La escritura publica actual se limita a preparar borradores de factura y siempre pide confirmacion.',
-  'La lectura de IVA, gastos y parte de tesoreria depende del contexto contable ya registrado en Holded.',
-  'La consulta de tesoreria esta disponible para revisar cuentas y saldos. El matching o conciliacion automatica de movimientos bancarios no esta validado.',
+  'La lectura contable se limita al plan de cuentas y al libro diario ya registrados en Holded.',
+  'Productos y stock, proyectos, CRM y tesoreria todavia no forman parte del conector publico: estan en el roadmap.',
 ];
 
 export default function HoldedCapabilitiesPage() {

--- a/apps/holded/app/components/ConnectorComparison.tsx
+++ b/apps/holded/app/components/ConnectorComparison.tsx
@@ -73,14 +73,14 @@ function buildRows(aiName: string): Row[] {
       withConnector: `${aiName} consulta el diario con rango de fechas para devolverte apuntes filtrados por cuenta o concepto, listos para analizar.`,
     },
     {
-      scenario: 'Estado de proyectos abiertos y tareas pendientes',
-      withoutConnector: `${aiName} no ve tus proyectos. Te puede ayudar a planificar uno desde cero, pero no a hacer seguimiento de los que ya tienes en marcha.`,
-      withConnector: `${aiName} resume proyectos activos, los vincula al cliente correcto e identifica tareas pendientes y horas imputadas.`,
+      scenario: 'Descargar el PDF de una factura concreta',
+      withoutConnector: `${aiName} no puede acceder a tus documentos. Tienes que entrar a Holded, buscar la factura y descargar el PDF manualmente.`,
+      withConnector: `${aiName} recupera el PDF de una factura, presupuesto o albarán existente para que lo adjuntes sin salir de la conversación.`,
     },
     {
-      scenario: 'Embudo CRM y leads por fase',
-      withoutConnector: `${aiName} no conoce tu pipeline. Solo puede sugerir frameworks comerciales generales (BANT, MEDDIC) sin datos concretos.`,
-      withConnector: `${aiName} devuelve tu embudo real, las fases configuradas y los leads asignados a cada una.`,
+      scenario: 'Revisar el plan de cuentas contable',
+      withoutConnector: `${aiName} solo conoce teoría contable general. No puede ver cómo está estructurado tu plan de cuentas real.`,
+      withConnector: `${aiName} consulta tu plan de cuentas en Holded y resume códigos, nombres y tipos para que entiendas dónde se concentra cada partida.`,
     },
   ];
 }

--- a/apps/holded/app/components/ConnectorFAQData.ts
+++ b/apps/holded/app/components/ConnectorFAQData.ts
@@ -11,7 +11,7 @@ export function buildFaqs(aiName: string, provider: string): FaqItem[] {
     },
     {
       q: '¿Funciona con cualquier plan de Holded?',
-      a: 'Funciona con cuentas de Holded que tengan la API disponible y permisos suficientes. Normalmente necesitas un plan de pago de Holded y rol Owner o Administrador para generar la API key. Las capacidades de productos, proyectos, CRM o contabilidad sólo devuelven datos si esos módulos están activos en tu cuenta.',
+      a: 'Funciona con cuentas de Holded que tengan la API disponible y permisos suficientes. Normalmente necesitas un plan de pago de Holded y rol Owner o Administrador para generar la API key. El conector hoy cubre facturación, contactos y contabilidad; las consultas sólo devuelven datos si esos módulos están activos en tu cuenta.',
     },
     {
       q: '¿Qué relación tiene el conector con la obligación VeriFactu/AEAT?',

--- a/apps/holded/app/components/ConnectorLandingClient.tsx
+++ b/apps/holded/app/components/ConnectorLandingClient.tsx
@@ -107,7 +107,7 @@ const CONFIGS: Record<ConnectorId, ConnectorConfig> = {
     dpaHref: '/conectores/claude/dpa',
     privacyHref: '/conectores/claude/privacy',
     termsHref: '/conectores/claude/terms',
-    connectHref: 'https://claude.verifactu.business/launch',
+    connectHref: 'https://holded-claude.verifactu.business/launch',
   },
   chatgpt: {
     id: 'chatgpt',
@@ -298,7 +298,7 @@ const QUICK_CONNECT_STEPS: Record<
       n: '02',
       Icon: Zap,
       title: 'Acepta el aviso y haz clic en "Añadir"',
-      text: 'Claude muestra un aviso de seguridad estándar indicando que el conector fue sugerido por un enlace externo — es el comportamiento esperado. Verifica que el nombre sea "Holded" y la URL "claude.verifactu.business/mcp", luego pulsa "Añadir".',
+      text: 'Claude muestra un aviso de seguridad estándar indicando que el conector fue sugerido por un enlace externo — es el comportamiento esperado. Verifica que el nombre sea "Holded" y la URL "holded-claude.verifactu.business/mcp", luego pulsa "Añadir".',
     },
     {
       n: '03',
@@ -356,8 +356,8 @@ function ConnectorQuickConnect({ cfg, theme }: { cfg: ConnectorConfig; theme: Th
             </h2>
             {cfg.id === 'claude' && (
               <p className="mt-2 max-w-xl text-sm leading-6 text-slate-500">
-                El conector usa el flujo de conector personalizado de Claude mientras finaliza la
-                revisión en el directorio oficial de Anthropic. Ya está operativo.
+                Ya está operativo. Se añade con el flujo de conector personalizado de Claude; en
+                paralelo, está en revisión para aparecer en el directorio oficial de Anthropic.
               </p>
             )}
           </div>

--- a/apps/holded/app/components/ConnectorLandingClient.tsx
+++ b/apps/holded/app/components/ConnectorLandingClient.tsx
@@ -64,6 +64,9 @@ type Capability = {
   subtitle: string;
   Icon: ComponentType<{ className?: string }>;
   examples: string[];
+  /** Capacidad cuyo código existe pero aún no está expuesta en el preset de
+   *  tools de la submission actual — se muestra como roadmap, no disponible. */
+  roadmap?: boolean;
 };
 
 const THEMES: Record<ConnectorId, Theme> = {
@@ -122,6 +125,8 @@ const CONFIGS: Record<ConnectorId, ConnectorConfig> = {
   },
 };
 
+// Orden: primero las capacidades disponibles hoy (cubiertas por las tools
+// expuestas en el preset de submission), luego las marcadas como roadmap.
 const CAPABILITIES: Capability[] = [
   {
     title: 'Facturas',
@@ -140,7 +145,7 @@ const CAPABILITIES: Capability[] = [
   },
   {
     title: 'Cuentas contables',
-    subtitle: 'Consulta el plan de cuentas y resume codigos, nombres y tipos cuando existan.',
+    subtitle: 'Consulta el plan de cuentas y resume códigos, nombres y tipos cuando existan.',
     Icon: Landmark,
     examples: ['Resume mis principales cuentas contables.', '¿Dónde se concentra el gasto?'],
   },
@@ -149,6 +154,15 @@ const CAPABILITIES: Capability[] = [
     subtitle: 'Lee apuntes existentes solo cuando el usuario indique fecha inicial y final.',
     Icon: BookOpen,
     examples: ['Muéstrame los apuntes de marzo.', 'Explícame este asiento en lenguaje claro.'],
+  },
+  {
+    title: 'PDFs de documentos',
+    subtitle: 'Descarga el PDF de una factura, presupuesto o albarán existente.',
+    Icon: FileDown,
+    examples: [
+      'Dame el PDF de la última factura de este cliente.',
+      'Recupera el presupuesto que necesito adjuntar.',
+    ],
   },
   {
     title: 'Borradores de factura',
@@ -161,39 +175,31 @@ const CAPABILITIES: Capability[] = [
   },
   {
     title: 'Productos y stock',
-    subtitle: 'Lista catálogo, ficha de producto y stock disponible cuando está habilitado.',
+    subtitle: 'Previsto: consultar catálogo, ficha de producto y stock disponible.',
     Icon: Package,
-    examples: ['¿Qué productos tengo con stock bajo?', 'Enséñame precio y stock de este SKU.'],
+    examples: [],
+    roadmap: true,
   },
   {
     title: 'Proyectos y tareas',
-    subtitle: 'Consulta proyectos abiertos, tareas pendientes e imputaciones de horas.',
+    subtitle: 'Previsto: revisar proyectos abiertos, tareas pendientes e imputación de horas.',
     Icon: FolderKanban,
-    examples: ['Resume mis proyectos activos.', '¿Qué tareas están pendientes esta semana?'],
+    examples: [],
+    roadmap: true,
   },
   {
     title: 'CRM: leads y embudo',
-    subtitle: 'Visualiza el embudo de ventas y los leads asignados sin modificar nada.',
+    subtitle: 'Previsto: visualizar el embudo de ventas y los leads asignados.',
     Icon: TrendingUp,
-    examples: ['Resume mi embudo por fases.', '¿Qué leads esperan seguimiento?'],
+    examples: [],
+    roadmap: true,
   },
   {
-    title: 'PDFs de documentos',
-    subtitle: 'Descarga el PDF de una factura, presupuesto o albaran existente.',
-    Icon: FileDown,
-    examples: [
-      'Dame el PDF de la última factura de este cliente.',
-      'Recupera el presupuesto que necesito adjuntar.',
-    ],
-  },
-  {
-    title: 'Equipo, tesoreria y catalogos',
-    subtitle: 'Empleados, cuentas de tesoreria, tipos de IVA, almacenes y series de numeracion.',
+    title: 'Equipo, tesorería y catálogos',
+    subtitle: 'Previsto: empleados, cuentas de tesorería, tipos de IVA, almacenes y series.',
     Icon: Briefcase,
-    examples: [
-      'Muéstrame mi equipo y cuentas de tesorería.',
-      'Lista almacenes y series antes de crear un borrador.',
-    ],
+    examples: [],
+    roadmap: true,
   },
 ];
 
@@ -433,9 +439,9 @@ export function ConnectorLandingClient({ connector }: { connector: ConnectorId }
           </h1>
 
           <p className="mx-auto mt-5 max-w-2xl text-lg leading-8 text-slate-600">
-            Consulta facturas, contactos, contabilidad, CRM y proyectos en lenguaje natural. Crea
-            borradores de factura solo con confirmación explícita. Tus credenciales se guardan en
-            servidor y el acceso queda limitado a tu cuenta conectada.
+            Consulta facturas, contactos y contabilidad en lenguaje natural. Crea borradores de
+            factura solo con confirmación explícita. Tus credenciales se guardan en servidor y el
+            acceso queda limitado a tu cuenta conectada.
           </p>
 
           <div className="mt-9 flex flex-wrap justify-center gap-3">
@@ -499,24 +505,24 @@ export function ConnectorLandingClient({ connector }: { connector: ConnectorId }
         <div className="mx-auto max-w-6xl px-4">
           <div className="mb-10 text-center">
             <p className="text-xs font-bold uppercase tracking-[0.18em] text-slate-400">
-              Capacidades actuales
+              Capacidades del conector
             </p>
             <h2 className="mt-3 text-3xl font-bold tracking-tight text-slate-950">
               Preguntas de negocio, no menús.
             </h2>
             <p className="mx-auto mt-3 max-w-2xl text-sm leading-6 text-slate-600">
-              Estas son las capacidades actuales del conector. El usuario pregunta en lenguaje
-              natural y {cfg.aiName} consulta Holded dentro de la cuenta autorizada.
+              El usuario pregunta en lenguaje natural y {cfg.aiName} consulta Holded dentro de la
+              cuenta autorizada. Estas son las capacidades disponibles hoy.
             </p>
           </div>
 
-          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-5">
-            {CAPABILITIES.map((cap) => {
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {CAPABILITIES.filter((cap) => !cap.roadmap).map((cap) => {
               const { Icon } = cap;
               return (
                 <article
                   key={cap.title}
-                  className="flex min-h-[18rem] flex-col rounded-lg border border-slate-200 bg-white p-5 shadow-sm"
+                  className="flex min-h-[16rem] flex-col rounded-lg border border-slate-200 bg-white p-5 shadow-sm"
                 >
                   <div
                     className={`flex h-10 w-10 items-center justify-center rounded-xl ${theme.accentBg}`}
@@ -538,6 +544,43 @@ export function ConnectorLandingClient({ connector }: { connector: ConnectorId }
                 </article>
               );
             })}
+          </div>
+
+          {/* Roadmap — capacidades cuyo código existe pero aún no está expuesto
+              en el preset de tools de la submission actual. Se muestran como
+              "próximamente" para no prometer algo que el conector no hace hoy. */}
+          <div className="mt-12">
+            <div className="text-center">
+              <p className="text-xs font-bold uppercase tracking-[0.18em] text-slate-400">
+                En el roadmap
+              </p>
+              <p className="mx-auto mt-2 max-w-2xl text-sm leading-6 text-slate-500">
+                Estas áreas se incorporarán al conector tras la aprobación en el directorio de{' '}
+                {cfg.provider}. Hoy no están disponibles.
+              </p>
+            </div>
+            <div className="mt-6 grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+              {CAPABILITIES.filter((cap) => cap.roadmap).map((cap) => {
+                const { Icon } = cap;
+                return (
+                  <article
+                    key={cap.title}
+                    className="flex flex-col rounded-lg border border-dashed border-slate-300 bg-slate-50/60 p-5"
+                  >
+                    <div className="flex items-center justify-between">
+                      <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-slate-100">
+                        <Icon className="h-5 w-5 text-slate-400" />
+                      </div>
+                      <span className="rounded-full border border-slate-300 bg-white px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-slate-500">
+                        Próximamente
+                      </span>
+                    </div>
+                    <h3 className="mt-4 text-base font-bold text-slate-600">{cap.title}</h3>
+                    <p className="mt-1.5 text-sm leading-6 text-slate-500">{cap.subtitle}</p>
+                  </article>
+                );
+              })}
+            </div>
           </div>
 
           {cfg.connectHref && (

--- a/apps/holded/app/components/ConnectorMobileBanner.tsx
+++ b/apps/holded/app/components/ConnectorMobileBanner.tsx
@@ -35,8 +35,8 @@ export function ConnectorMobileBanner({ provider }: ConnectorMobileBannerProps) 
       <div className="flex items-start gap-3">
         <Smartphone className={`mt-0.5 h-5 w-5 shrink-0 ${theme.iconAccent}`} />
         <div className="flex-1 text-sm leading-6 text-slate-800">
-          <strong>Estas en mobile.</strong> Para evitar problemas con el navegador embebido de
-          ChatGPT o Claude, usa nuestro flujo simplificado:
+          <strong>Estás en el móvil.</strong> El navegador interno de las apps de ChatGPT y Claude
+          a veces corta el inicio de sesión. Conéctate por este flujo y no se interrumpirá:
         </div>
       </div>
       <Link

--- a/apps/holded/app/components/ConnectorStatusBadge.tsx
+++ b/apps/holded/app/components/ConnectorStatusBadge.tsx
@@ -314,7 +314,9 @@ export async function ConnectorStatusBadge({
                           ? 'bg-rose-500'
                           : (status.toolsDegraded ?? 0) > 0
                             ? 'bg-amber-500'
-                            : 'bg-emerald-500'
+                            : (status.toolsOk ?? 0) === status.toolsTotal
+                              ? 'bg-emerald-500'
+                              : 'bg-slate-400'
                       }`}
                       aria-hidden
                     />

--- a/apps/holded/app/components/ConnectorStatusBadge.tsx
+++ b/apps/holded/app/components/ConnectorStatusBadge.tsx
@@ -1,20 +1,23 @@
 /**
- * Widget público de estado del conector — Fase 1 / Opción B.
+ * Widget público de estado del conector — variante discreta flotante.
  *
  * Server Component: hace fetch del endpoint público
- * /api/public/status/{connector} de apps/app y renderiza:
+ * /api/public/status/{connector} de apps/app y renderiza una anotación
+ * compacta fija en la esquina inferior izquierda:
  *
- *   1. Badge compacto (semáforo + texto + "última comprobación hace X" + 24h uptime)
- *   2. <details>/<summary> colapsable con la tabla por check
+ *   1. Pill discreto siempre visible (semáforo + "Conector X operativo")
+ *   2. <details>/<summary> que despliega hacia arriba un panel con el
+ *      detalle por tool y por superficie pública
  *
- * Diseño defensivo: si el fetch falla, renderiza un badge neutro ("Estado
+ * Diseño defensivo: si el fetch falla, renderiza un pill neutro ("Estado
  * desconocido") en vez de romper el render de la landing.
  *
  * Cache: `next.revalidate = 60` empata con el edge cache del endpoint público
- * (s-maxage=60, SWR=300). La granularidad real del estado es 5 min (cron).
+ * (s-maxage=60, SWR=300). La granularidad real del estado es 5 min (cron),
+ * con auto-refresco de respaldo en el propio endpoint público.
  */
 
-import { Activity, AlertTriangle, CheckCircle2, ChevronDown, HelpCircle, XCircle } from 'lucide-react';
+import { AlertTriangle, CheckCircle2, ChevronUp, HelpCircle, XCircle } from 'lucide-react';
 
 const APP_BASE_URL =
   process.env.NEXT_PUBLIC_VERIFACTU_APP_URL?.trim() || 'https://app.verifactu.business';
@@ -122,31 +125,40 @@ function formatUptime(pct: number | null): string {
 const OVERALL_STYLES = {
   operational: {
     label: 'Conector operativo',
-    pill: 'border-emerald-200 bg-emerald-50 text-emerald-700',
     dot: 'bg-emerald-500',
     icon: CheckCircle2,
     iconClass: 'text-emerald-600',
+    header: 'border-emerald-100 bg-emerald-50/70 text-emerald-800',
+    // Estado bueno → pill neutro y discreto.
+    pill: 'border-slate-200 bg-white/95 text-slate-600',
+    panelBorder: 'border-slate-200',
   },
   degraded: {
     label: 'Conector con latencia elevada',
-    pill: 'border-amber-200 bg-amber-50 text-amber-700',
     dot: 'bg-amber-500',
     icon: AlertTriangle,
     iconClass: 'text-amber-600',
+    header: 'border-amber-100 bg-amber-50/70 text-amber-800',
+    pill: 'border-amber-300 bg-amber-50 text-amber-800',
+    panelBorder: 'border-amber-200',
   },
   down: {
     label: 'Conector con incidencias',
-    pill: 'border-rose-200 bg-rose-50 text-rose-700',
     dot: 'bg-rose-500',
     icon: XCircle,
     iconClass: 'text-rose-600',
+    header: 'border-rose-100 bg-rose-50/70 text-rose-800',
+    pill: 'border-rose-300 bg-rose-50 text-rose-800',
+    panelBorder: 'border-rose-200',
   },
   unknown: {
     label: 'Estado desconocido',
-    pill: 'border-slate-200 bg-slate-50 text-slate-600',
     dot: 'bg-slate-400',
     icon: HelpCircle,
     iconClass: 'text-slate-500',
+    header: 'border-slate-100 bg-slate-50 text-slate-600',
+    pill: 'border-slate-200 bg-white/95 text-slate-500',
+    panelBorder: 'border-slate-200',
   },
 } as const;
 
@@ -182,24 +194,23 @@ function CheckTable({
   if (checks.length === 0) return null;
   return (
     <div className="overflow-x-auto px-3 pb-1">
-      <p className="px-2 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wider opacity-60">
+      <p className="px-2 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wider text-slate-400">
         {title}
       </p>
-      <table className="w-full min-w-[520px] text-left text-xs">
-        <thead className="text-[10px] uppercase tracking-wider opacity-70">
+      <table className="w-full min-w-[440px] text-left text-xs">
+        <thead className="text-[10px] uppercase tracking-wider text-slate-400">
           <tr>
             <th className="px-2 py-1.5 font-semibold">{firstColLabel}</th>
             <th className="px-2 py-1.5 font-semibold">Estado</th>
             <th className="px-2 py-1.5 font-semibold text-right">Latencia</th>
             <th className="px-2 py-1.5 font-semibold text-right">Uptime 24 h</th>
-            <th className="px-2 py-1.5 font-semibold text-right whitespace-nowrap">Última caída</th>
           </tr>
         </thead>
-        <tbody className="divide-y divide-white/40">
+        <tbody className="divide-y divide-slate-100">
           {checks.map((check) => (
             <tr key={check.checkType}>
               <td className="px-2 py-1.5">
-                <span className="font-medium">
+                <span className="font-medium text-slate-700">
                   {CHECK_TYPE_LABEL_ES[check.checkType] ?? check.checkType}
                 </span>
               </td>
@@ -209,7 +220,7 @@ function CheckTable({
                     className={`inline-flex h-2 w-2 rounded-full ${CHECK_DOT[check.status]}`}
                     aria-hidden
                   />
-                  <span className="capitalize">{check.status}</span>
+                  <span className="capitalize text-slate-600">{check.status}</span>
                   {check.status === 'fail' && check.lastErrorCode && (
                     <span className="rounded bg-rose-100 px-1.5 py-0.5 text-[10px] font-medium text-rose-700">
                       {check.lastErrorCode}
@@ -217,14 +228,11 @@ function CheckTable({
                   )}
                 </span>
               </td>
-              <td className="px-2 py-1.5 text-right tabular-nums">
+              <td className="px-2 py-1.5 text-right tabular-nums text-slate-500">
                 {formatLatency(check.latencyMs)}
               </td>
-              <td className="px-2 py-1.5 text-right tabular-nums">
+              <td className="px-2 py-1.5 text-right tabular-nums text-slate-500">
                 {formatUptime(check.uptime24hPct)}
-              </td>
-              <td className="px-2 py-1.5 text-right tabular-nums whitespace-nowrap opacity-70">
-                {check.lastFailedAt ? formatRelative(check.lastFailedAt) : '—'}
               </td>
             </tr>
           ))}
@@ -248,98 +256,113 @@ export async function ConnectorStatusBadge({
   const lastCheckedLabel = formatRelative(status?.lastCheckedAt ?? null);
   const uptime = status?.overallUptime24hPct;
 
+  const pillLabel =
+    overall === 'operational'
+      ? `Conector ${connectorLabel} operativo`
+      : `${styles.label} · ${connectorLabel}`;
+
+  const toolChecks = status?.checks?.filter((c) => isToolCheck(c)) ?? [];
+  const surfaceChecks = status?.checks?.filter((c) => !isToolCheck(c)) ?? [];
+
   return (
-    <section
+    <aside
       aria-label={`Estado del conector ${connectorLabel}`}
-      className="mx-auto max-w-5xl px-4 sm:px-6"
+      className="fixed bottom-3 left-3 z-40 print:hidden"
     >
-      <div className={`flex flex-col gap-3 rounded-2xl border p-4 ${styles.pill}`}>
-        {/* ── Resumen compacto ── */}
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex items-center gap-3">
-            <span className={`inline-flex h-2.5 w-2.5 shrink-0 rounded-full ${styles.dot}`} aria-hidden />
-            <Icon className={`h-5 w-5 shrink-0 ${styles.iconClass}`} aria-hidden />
-            <div>
-              <p className="text-sm font-semibold leading-snug">
-                {styles.label} — {connectorLabel} ↔ Holded
-              </p>
-              <p className="mt-0.5 text-xs leading-snug opacity-80">
-                Última comprobación {lastCheckedLabel}
-                {uptime !== null && uptime !== undefined ? ` · ${formatUptime(uptime)} de uptime en 24 h` : ''}
-              </p>
+      <details className="group flex max-w-[calc(100vw-1.5rem)] flex-col-reverse items-start">
+        {/* ── Pill discreto, siempre visible ── */}
+        <summary
+          className={`flex w-fit cursor-pointer list-none items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-medium shadow-md backdrop-blur transition-colors hover:brightness-[0.97] ${styles.pill}`}
+        >
+          <span className={`inline-flex h-2 w-2 shrink-0 rounded-full ${styles.dot}`} aria-hidden />
+          <span className="whitespace-nowrap">{pillLabel}</span>
+          <ChevronUp
+            className="h-3.5 w-3.5 shrink-0 opacity-50 transition-transform group-open:rotate-180"
+            aria-hidden
+          />
+        </summary>
+
+        {/* ── Panel desplegable (se abre hacia arriba) ── */}
+        <div
+          className={`mb-1.5 w-[28rem] max-w-[calc(100vw-1.5rem)] overflow-hidden rounded-xl border bg-white shadow-xl ${styles.panelBorder}`}
+        >
+          <div className="max-h-[70vh] overflow-y-auto">
+            {/* Cabecera */}
+            <div className={`flex items-start gap-3 border-b px-4 py-3 ${styles.header}`}>
+              <Icon className={`mt-0.5 h-5 w-5 shrink-0 ${styles.iconClass}`} aria-hidden />
+              <div className="min-w-0">
+                <p className="text-sm font-semibold leading-snug">
+                  {styles.label} — {connectorLabel} ↔ Holded
+                </p>
+                <p className="mt-0.5 text-xs leading-snug opacity-80">
+                  Última comprobación {lastCheckedLabel}
+                  {uptime !== null && uptime !== undefined
+                    ? ` · ${formatUptime(uptime)} de uptime en 24 h`
+                    : ''}
+                </p>
+              </div>
             </div>
+
+            {/* Resumen de contadores */}
+            {status && status.checksTotal !== undefined && (
+              <div className="flex flex-wrap items-center gap-2 px-4 py-3 text-xs">
+                {(status.toolsTotal ?? 0) > 0 && (
+                  <span className="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-slate-50 px-2.5 py-0.5 font-semibold text-slate-700">
+                    <span
+                      className={`h-1.5 w-1.5 rounded-full ${
+                        (status.toolsFail ?? 0) > 0
+                          ? 'bg-rose-500'
+                          : (status.toolsDegraded ?? 0) > 0
+                            ? 'bg-amber-500'
+                            : 'bg-emerald-500'
+                      }`}
+                      aria-hidden
+                    />
+                    {status.toolsOk ?? 0}/{status.toolsTotal} tools operativas
+                  </span>
+                )}
+                <span className="inline-flex items-center gap-1 rounded-full bg-slate-100 px-2 py-0.5 font-medium text-slate-600">
+                  <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" aria-hidden />
+                  {status.checksOk ?? 0} OK
+                </span>
+                {(status.checksDegraded ?? 0) > 0 && (
+                  <span className="inline-flex items-center gap-1 rounded-full bg-slate-100 px-2 py-0.5 font-medium text-slate-600">
+                    <span className="h-1.5 w-1.5 rounded-full bg-amber-500" aria-hidden />
+                    {status.checksDegraded} degradados
+                  </span>
+                )}
+                {(status.checksFail ?? 0) > 0 && (
+                  <span className="inline-flex items-center gap-1 rounded-full bg-slate-100 px-2 py-0.5 font-medium text-slate-600">
+                    <span className="h-1.5 w-1.5 rounded-full bg-rose-500" aria-hidden />
+                    {status.checksFail} con fallo
+                  </span>
+                )}
+              </div>
+            )}
+
+            {/* Detalle por check */}
+            {status?.checks && status.checks.length > 0 && (
+              <div className="border-t border-slate-100 pb-2">
+                <CheckTable
+                  checks={toolChecks}
+                  title="Tools del conector · revisión en vivo"
+                  firstColLabel="Tool"
+                />
+                <CheckTable
+                  checks={surfaceChecks}
+                  title="Superficie pública"
+                  firstColLabel="Surface check"
+                />
+                <p className="mt-2 px-4 text-[10px] leading-relaxed text-slate-400">
+                  La superficie pública se comprueba sin token; las tools se ejecutan en vivo
+                  contra una cuenta Holded de pruebas. Checks cada 5 minutos, uptime sobre las
+                  últimas 24 h.
+                </p>
+              </div>
+            )}
           </div>
-
-          {status && status.checksTotal !== undefined && (
-            <div className="flex flex-wrap items-center gap-2 text-xs">
-              {(status.toolsTotal ?? 0) > 0 && (
-                <span className="inline-flex items-center gap-1 rounded-full bg-white/80 px-2.5 py-0.5 font-semibold">
-                  <span
-                    className={`h-1.5 w-1.5 rounded-full ${
-                      (status.toolsFail ?? 0) > 0
-                        ? 'bg-rose-500'
-                        : (status.toolsDegraded ?? 0) > 0
-                          ? 'bg-amber-500'
-                          : 'bg-emerald-500'
-                    }`}
-                    aria-hidden
-                  />
-                  {status.toolsOk ?? 0}/{status.toolsTotal} tools operativas
-                </span>
-              )}
-              <span className="inline-flex items-center gap-1 rounded-full bg-white/60 px-2 py-0.5 font-medium">
-                <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" aria-hidden />
-                {status.checksOk ?? 0} OK
-              </span>
-              {(status.checksDegraded ?? 0) > 0 && (
-                <span className="inline-flex items-center gap-1 rounded-full bg-white/60 px-2 py-0.5 font-medium">
-                  <span className="h-1.5 w-1.5 rounded-full bg-amber-500" aria-hidden />
-                  {status.checksDegraded} degradados
-                </span>
-              )}
-              {(status.checksFail ?? 0) > 0 && (
-                <span className="inline-flex items-center gap-1 rounded-full bg-white/60 px-2 py-0.5 font-medium">
-                  <span className="h-1.5 w-1.5 rounded-full bg-rose-500" aria-hidden />
-                  {status.checksFail} con fallo
-                </span>
-              )}
-            </div>
-          )}
         </div>
-
-        {/* ── Detalle colapsable ── */}
-        {status?.checks && status.checks.length > 0 && (
-          <details className="group rounded-xl bg-white/60">
-            <summary className="flex cursor-pointer list-none items-center justify-between gap-2 rounded-xl px-3 py-2 text-xs font-medium opacity-80 hover:bg-white/80 hover:opacity-100">
-              <span className="inline-flex items-center gap-1.5">
-                <Activity className="h-3.5 w-3.5" aria-hidden />
-                Ver detalle por check
-              </span>
-              <ChevronDown
-                className="h-4 w-4 transition-transform group-open:rotate-180"
-                aria-hidden
-              />
-            </summary>
-            <div className="pb-2">
-              <CheckTable
-                checks={status.checks.filter((c) => isToolCheck(c))}
-                title="Tools del conector · revisión en vivo"
-                firstColLabel="Tool"
-              />
-              <CheckTable
-                checks={status.checks.filter((c) => !isToolCheck(c))}
-                title="Superficie pública"
-                firstColLabel="Surface check"
-              />
-              <p className="mt-2 px-3 text-[10px] leading-relaxed opacity-60">
-                La superficie pública se comprueba sin token; las tools se ejecutan en vivo
-                contra una cuenta Holded de pruebas. Checks cada 5 minutos, uptime sobre las
-                últimas 24 h, cache del endpoint público 60 s.
-              </p>
-            </div>
-          </details>
-        )}
-      </div>
-    </section>
+      </details>
+    </aside>
   );
 }

--- a/apps/holded/app/components/ConnectorStatusBadge.tsx
+++ b/apps/holded/app/components/ConnectorStatusBadge.tsx
@@ -20,9 +20,11 @@ const APP_BASE_URL =
   process.env.NEXT_PUBLIC_VERIFACTU_APP_URL?.trim() || 'https://app.verifactu.business';
 
 type CheckStatus = 'ok' | 'degraded' | 'fail' | 'unknown';
+type CheckKind = 'surface' | 'tool';
 
 type Check = {
   checkType: string;
+  kind?: CheckKind;
   target: string;
   status: CheckStatus;
   latencyMs: number | null;
@@ -44,12 +46,20 @@ type StatusResponse = {
   checksOk?: number;
   checksDegraded?: number;
   checksFail?: number;
+  surfaceTotal?: number;
+  surfaceOk?: number;
+  toolsTotal?: number;
+  toolsOk?: number;
+  toolsDegraded?: number;
+  toolsFail?: number;
+  toolsUnknown?: number;
   overallUptime24hPct: number | null;
   checks: Check[];
   error?: string;
 };
 
 const CHECK_TYPE_LABEL_ES: Record<string, string> = {
+  // Superficie pública
   landing: 'Página de aterrizaje',
   docs: 'Documentación',
   privacy: 'Política de privacidad',
@@ -61,7 +71,24 @@ const CHECK_TYPE_LABEL_ES: Record<string, string> = {
   mcp_initialize: 'MCP initialize',
   tools_list: 'MCP tools/list',
   mcp_requires_auth: 'MCP rechaza sin Bearer',
+  // Tools en vivo (revisión de funcionamiento real contra Holded)
+  tool_list_documents: 'Tool · Listar documentos',
+  tool_get_document: 'Tool · Detalle de documento',
+  tool_get_document_pdf: 'Tool · PDF de documento',
+  tool_list_invoices: 'Tool · Listar facturas',
+  tool_get_invoice: 'Tool · Detalle de factura',
+  tool_list_contacts: 'Tool · Listar contactos',
+  tool_get_contact: 'Tool · Detalle de contacto',
+  tool_get_chart_of_accounts: 'Tool · Plan de cuentas',
+  tool_list_accounts: 'Tool · Plan de cuentas',
+  tool_get_journal: 'Tool · Diario contable',
+  tool_list_daily_ledger: 'Tool · Libro diario',
+  tool_create_invoice_draft: 'Tool · Crear borrador de factura',
 };
+
+function isToolCheck(check: Check): boolean {
+  return check.kind === 'tool' || check.checkType.startsWith('tool_');
+}
 
 const CONNECTOR_LABEL: Record<'chatgpt' | 'claude', string> = {
   chatgpt: 'ChatGPT',
@@ -143,6 +170,70 @@ async function fetchStatus(connector: 'chatgpt' | 'claude'): Promise<StatusRespo
   }
 }
 
+function CheckTable({
+  checks,
+  title,
+  firstColLabel,
+}: {
+  checks: Check[];
+  title: string;
+  firstColLabel: string;
+}) {
+  if (checks.length === 0) return null;
+  return (
+    <div className="overflow-x-auto px-3 pb-1">
+      <p className="px-2 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wider opacity-60">
+        {title}
+      </p>
+      <table className="w-full min-w-[520px] text-left text-xs">
+        <thead className="text-[10px] uppercase tracking-wider opacity-70">
+          <tr>
+            <th className="px-2 py-1.5 font-semibold">{firstColLabel}</th>
+            <th className="px-2 py-1.5 font-semibold">Estado</th>
+            <th className="px-2 py-1.5 font-semibold text-right">Latencia</th>
+            <th className="px-2 py-1.5 font-semibold text-right">Uptime 24 h</th>
+            <th className="px-2 py-1.5 font-semibold text-right whitespace-nowrap">Última caída</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-white/40">
+          {checks.map((check) => (
+            <tr key={check.checkType}>
+              <td className="px-2 py-1.5">
+                <span className="font-medium">
+                  {CHECK_TYPE_LABEL_ES[check.checkType] ?? check.checkType}
+                </span>
+              </td>
+              <td className="px-2 py-1.5">
+                <span className="inline-flex items-center gap-1.5">
+                  <span
+                    className={`inline-flex h-2 w-2 rounded-full ${CHECK_DOT[check.status]}`}
+                    aria-hidden
+                  />
+                  <span className="capitalize">{check.status}</span>
+                  {check.status === 'fail' && check.lastErrorCode && (
+                    <span className="rounded bg-rose-100 px-1.5 py-0.5 text-[10px] font-medium text-rose-700">
+                      {check.lastErrorCode}
+                    </span>
+                  )}
+                </span>
+              </td>
+              <td className="px-2 py-1.5 text-right tabular-nums">
+                {formatLatency(check.latencyMs)}
+              </td>
+              <td className="px-2 py-1.5 text-right tabular-nums">
+                {formatUptime(check.uptime24hPct)}
+              </td>
+              <td className="px-2 py-1.5 text-right tabular-nums whitespace-nowrap opacity-70">
+                {check.lastFailedAt ? formatRelative(check.lastFailedAt) : '—'}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
 export async function ConnectorStatusBadge({
   connector,
 }: {
@@ -181,6 +272,21 @@ export async function ConnectorStatusBadge({
 
           {status && status.checksTotal !== undefined && (
             <div className="flex flex-wrap items-center gap-2 text-xs">
+              {(status.toolsTotal ?? 0) > 0 && (
+                <span className="inline-flex items-center gap-1 rounded-full bg-white/80 px-2.5 py-0.5 font-semibold">
+                  <span
+                    className={`h-1.5 w-1.5 rounded-full ${
+                      (status.toolsFail ?? 0) > 0
+                        ? 'bg-rose-500'
+                        : (status.toolsDegraded ?? 0) > 0
+                          ? 'bg-amber-500'
+                          : 'bg-emerald-500'
+                    }`}
+                    aria-hidden
+                  />
+                  {status.toolsOk ?? 0}/{status.toolsTotal} tools operativas
+                </span>
+              )}
               <span className="inline-flex items-center gap-1 rounded-full bg-white/60 px-2 py-0.5 font-medium">
                 <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" aria-hidden />
                 {status.checksOk ?? 0} OK
@@ -214,55 +320,21 @@ export async function ConnectorStatusBadge({
                 aria-hidden
               />
             </summary>
-            <div className="overflow-x-auto px-3 pb-3">
-              <table className="w-full min-w-[520px] text-left text-xs">
-                <thead className="text-[10px] uppercase tracking-wider opacity-70">
-                  <tr>
-                    <th className="px-2 py-1.5 font-semibold">Surface check</th>
-                    <th className="px-2 py-1.5 font-semibold">Estado</th>
-                    <th className="px-2 py-1.5 font-semibold text-right">Latencia</th>
-                    <th className="px-2 py-1.5 font-semibold text-right">Uptime 24 h</th>
-                    <th className="px-2 py-1.5 font-semibold text-right whitespace-nowrap">Última caída</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-white/40">
-                  {status.checks.map((check) => (
-                    <tr key={check.checkType}>
-                      <td className="px-2 py-1.5">
-                        <span className="font-medium">
-                          {CHECK_TYPE_LABEL_ES[check.checkType] ?? check.checkType}
-                        </span>
-                      </td>
-                      <td className="px-2 py-1.5">
-                        <span className="inline-flex items-center gap-1.5">
-                          <span
-                            className={`inline-flex h-2 w-2 rounded-full ${CHECK_DOT[check.status]}`}
-                            aria-hidden
-                          />
-                          <span className="capitalize">{check.status}</span>
-                          {check.status === 'fail' && check.lastErrorCode && (
-                            <span className="rounded bg-rose-100 px-1.5 py-0.5 text-[10px] font-medium text-rose-700">
-                              {check.lastErrorCode}
-                            </span>
-                          )}
-                        </span>
-                      </td>
-                      <td className="px-2 py-1.5 text-right tabular-nums">
-                        {formatLatency(check.latencyMs)}
-                      </td>
-                      <td className="px-2 py-1.5 text-right tabular-nums">
-                        {formatUptime(check.uptime24hPct)}
-                      </td>
-                      <td className="px-2 py-1.5 text-right tabular-nums whitespace-nowrap opacity-70">
-                        {check.lastFailedAt ? formatRelative(check.lastFailedAt) : '—'}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-              <p className="mt-2 text-[10px] leading-relaxed opacity-60">
-                Checks ejecutados cada 5 minutos contra superficie pública (sin token). Uptime
-                calculado sobre las últimas 24 h. Cache del endpoint público 60 s.
+            <div className="pb-2">
+              <CheckTable
+                checks={status.checks.filter((c) => isToolCheck(c))}
+                title="Tools del conector · revisión en vivo"
+                firstColLabel="Tool"
+              />
+              <CheckTable
+                checks={status.checks.filter((c) => !isToolCheck(c))}
+                title="Superficie pública"
+                firstColLabel="Surface check"
+              />
+              <p className="mt-2 px-3 text-[10px] leading-relaxed opacity-60">
+                La superficie pública se comprueba sin token; las tools se ejecutan en vivo
+                contra una cuenta Holded de pruebas. Checks cada 5 minutos, uptime sobre las
+                últimas 24 h, cache del endpoint público 60 s.
               </p>
             </div>
           </details>

--- a/apps/holded/app/components/HoldedApiKeyHelp.tsx
+++ b/apps/holded/app/components/HoldedApiKeyHelp.tsx
@@ -1,0 +1,61 @@
+/**
+ * Bloque de ayuda reutilizable para el campo "API key de Holded".
+ *
+ * Pensado para usuarios que no conocen Holded: explica en lenguaje llano qué
+ * es una API key y los pasos exactos para generarla, sin sacar al usuario del
+ * formulario (es un `<details>` desplegable, sin JS). Se usa en los
+ * formularios de conexión de ambos conectores (Claude y ChatGPT).
+ */
+
+const HOLDED_API_KEY_HELP_URL =
+  'https://help.holded.com/es/articles/6896051-como-generar-y-usar-la-api-de-holded';
+
+type Accent = 'amber' | 'emerald';
+
+const ACCENT_TEXT: Record<Accent, string> = {
+  amber: 'text-amber-700',
+  emerald: 'text-emerald-700',
+};
+
+export function HoldedApiKeyHelp({ accent = 'amber' }: { accent?: Accent }) {
+  const accentText = ACCENT_TEXT[accent];
+  return (
+    <details className="group rounded-xl border border-slate-200 bg-slate-50 px-3.5 py-2.5 text-xs leading-5 text-slate-600">
+      <summary
+        className={`flex cursor-pointer list-none items-center justify-between gap-2 font-semibold ${accentText}`}
+      >
+        <span>¿Qué es la API key y de dónde la saco?</span>
+        <span className="text-slate-400 transition-transform group-open:rotate-180" aria-hidden>
+          ▾
+        </span>
+      </summary>
+      <div className="mt-2.5 space-y-2.5">
+        <p>
+          Es una <strong>clave que autoriza esta conexión a leer tu Holded</strong> — como una
+          contraseña solo para esta integración. No es tu contraseña de Holded y puedes anularla
+          cuando quieras desde Holded.
+        </p>
+        <ol className="list-decimal space-y-1 pl-4">
+          <li>Entra en tu cuenta de Holded.</li>
+          <li>
+            Abre <strong>Configuración</strong> (arriba a la derecha).
+          </li>
+          <li>
+            Ve a <strong>Integraciones → API</strong>.
+          </li>
+          <li>
+            Pulsa <strong>Nueva API key</strong>, cópiala y pégala aquí.
+          </li>
+        </ol>
+        <a
+          href={HOLDED_API_KEY_HELP_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={`inline-block font-semibold underline underline-offset-2 ${accentText}`}
+        >
+          Guía oficial de Holded, con capturas →
+        </a>
+      </div>
+    </details>
+  );
+}

--- a/apps/holded/app/conectores/chatgpt/docs/page.tsx
+++ b/apps/holded/app/conectores/chatgpt/docs/page.tsx
@@ -194,9 +194,7 @@ const SECURITY_HIGHLIGHTS: ReadonlyArray<readonly [string, string]> = [
 export default function ChatGPTDocsPage() {
   return (
     <ConnectorPageShell provider="chatgpt" kind="docs">
-      <div className="pb-6">
-        <ConnectorStatusBadge connector="chatgpt" />
-      </div>
+      <ConnectorStatusBadge connector="chatgpt" />
       <ConnectorPageHero
         provider="chatgpt"
         badgeIcon={<MessageSquare className="h-4 w-4" />}

--- a/apps/holded/app/conectores/chatgpt/page.tsx
+++ b/apps/holded/app/conectores/chatgpt/page.tsx
@@ -11,7 +11,7 @@ const OG_IMAGE = `${SITE_URL}/api/og/chatgpt`;
 export const metadata: Metadata = {
   title: 'Pregunta a Holded desde ChatGPT | Verifactu Business',
   description:
-    'Conecta Holded con ChatGPT para consultar facturas, contactos, contabilidad, CRM y proyectos en lenguaje natural. Borradores de factura solo con confirmación.',
+    'Conecta Holded con ChatGPT para consultar facturas, contactos y contabilidad en lenguaje natural. Borradores de factura solo con confirmación.',
   keywords: [
     'conector Holded',
     'ChatGPT Holded',
@@ -101,12 +101,8 @@ const jsonLd = {
         'Listado y detalle de facturas',
         'Listado y detalle de contactos',
         'Plan de cuentas y diario contable',
-        'Borrador de factura con confirmacion explicita',
-        'Productos y stock',
-        'Proyectos y tareas',
-        'CRM: leads y embudos',
         'PDFs de documentos existentes',
-        'Equipo, tesoreria, IVA, almacenes, series',
+        'Borrador de factura con confirmacion explicita',
       ],
       requiresSubscription: 'No',
       isAccessibleForFree: true,

--- a/apps/holded/app/conectores/chatgpt/page.tsx
+++ b/apps/holded/app/conectores/chatgpt/page.tsx
@@ -169,9 +169,7 @@ export default function ChatGPTConnectorPage() {
       {/* F4.3: banner mobile-only que invita a usar /auth/holded-direct
           (sobrevive al iOS in-app browser de ChatGPT mobile). */}
       <ConnectorMobileBanner provider="chatgpt" />
-      <div className="pt-6">
-        <ConnectorStatusBadge connector="chatgpt" />
-      </div>
+      <ConnectorStatusBadge connector="chatgpt" />
       <ConnectorLandingClient connector="chatgpt" />
     </>
   );

--- a/apps/holded/app/conectores/claude/docs/page.tsx
+++ b/apps/holded/app/conectores/claude/docs/page.tsx
@@ -230,9 +230,7 @@ const realUsageExamples = [
 export default function ClaudeDocsPage() {
   return (
     <main className="page-enter min-h-screen bg-[linear-gradient(180deg,#ffffff_0%,#fffbf0_45%,#ffffff_100%)] text-slate-900">
-      <div className="pt-8">
-        <ConnectorStatusBadge connector="claude" />
-      </div>
+      <ConnectorStatusBadge connector="claude" />
       <section className="mx-auto max-w-5xl px-4 py-16">
         {/* ── Header ── */}
         <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">

--- a/apps/holded/app/conectores/claude/page.tsx
+++ b/apps/holded/app/conectores/claude/page.tsx
@@ -11,7 +11,7 @@ const OG_IMAGE = `${SITE_URL}/api/og/claude`;
 export const metadata: Metadata = {
   title: 'Pregunta a Holded desde Claude | Verifactu Business',
   description:
-    'Conecta Holded con Claude para consultar facturas, contactos, contabilidad, CRM y proyectos en lenguaje natural. Borradores de factura solo con confirmación.',
+    'Conecta Holded con Claude para consultar facturas, contactos y contabilidad en lenguaje natural. Borradores de factura solo con confirmación.',
   keywords: [
     'conector Holded',
     'Claude Holded',
@@ -101,12 +101,8 @@ const jsonLd = {
         'Listado y detalle de facturas',
         'Listado y detalle de contactos',
         'Plan de cuentas y diario contable',
-        'Borrador de factura con confirmacion explicita',
-        'Productos y stock',
-        'Proyectos y tareas',
-        'CRM: leads y embudos',
         'PDFs de documentos existentes',
-        'Equipo, tesoreria, IVA, almacenes, series',
+        'Borrador de factura con confirmacion explicita',
       ],
       requiresSubscription: 'No',
       isAccessibleForFree: true,

--- a/apps/holded/app/conectores/claude/page.tsx
+++ b/apps/holded/app/conectores/claude/page.tsx
@@ -170,9 +170,7 @@ export default function ClaudeConnectorPage() {
       {/* F4.3: banner mobile-only que invita a usar /auth/holded-direct
           (sobrevive al iOS in-app browser de Claude mobile). */}
       <ConnectorMobileBanner provider="claude" />
-      <div className="pt-6">
-        <ConnectorStatusBadge connector="claude" />
-      </div>
+      <ConnectorStatusBadge connector="claude" />
       <ConnectorLandingClient connector="claude" />
     </>
   );

--- a/apps/holded/app/conectores/page.tsx
+++ b/apps/holded/app/conectores/page.tsx
@@ -10,7 +10,7 @@ const OG_IMAGE = `${SITE_URL}/brand/holded/holded-diamond-logo.png`;
 export const metadata: Metadata = {
   title: 'Holded con IA | Conectores ChatGPT y Claude',
   description:
-    'Conecta Holded con ChatGPT o Claude y consulta facturas, contactos, contabilidad y proyectos en lenguaje natural. Borradores solo con confirmación. Integración independiente, gratuita en lanzamiento.',
+    'Conecta Holded con ChatGPT o Claude y consulta facturas, contactos y contabilidad en lenguaje natural. Borradores solo con confirmación. Integración independiente, gratuita en lanzamiento.',
   keywords: [
     'Holded IA',
     'Holded ChatGPT',
@@ -36,7 +36,7 @@ export const metadata: Metadata = {
     card: 'summary_large_image',
     title: 'Holded con IA — Conectores ChatGPT y Claude',
     description:
-      'Conecta Holded a ChatGPT o Claude en minutos. Facturas, contactos, contabilidad y proyectos en lenguaje natural.',
+      'Conecta Holded a ChatGPT o Claude en minutos. Facturas, contactos y contabilidad en lenguaje natural.',
     images: [OG_IMAGE],
   },
   robots: {
@@ -67,7 +67,7 @@ const connectors = [
   {
     id: 'chatgpt',
     title: 'Holded para ChatGPT',
-    body: 'Consulta facturas, contactos, contabilidad, CRM y proyectos desde ChatGPT. Solo lectura por defecto y borradores con confirmación.',
+    body: 'Consulta facturas, contactos y contabilidad desde ChatGPT. Solo lectura por defecto y borradores con confirmación.',
     href: '/conectores/chatgpt',
     logoSrc: '/brand/chatgpt-logo.png',
     badge: 'En lanzamiento',
@@ -85,7 +85,7 @@ const connectors = [
 
 const features = [
   'Facturas, contactos y contabilidad',
-  'CRM, proyectos, productos y stock',
+  'PDF de documentos y libro diario',
   'Solo lectura por defecto',
   'Borradores con confirmación',
 ];
@@ -112,8 +112,8 @@ export default function HoldedConnectorsHubPage() {
             Conecta Holded con la IA que ya usas.
           </h1>
           <p className="mx-auto mt-5 max-w-2xl text-lg leading-8 text-slate-600">
-            Elige ChatGPT o Claude para preguntar por facturas, clientes, contabilidad y proyectos
-            sin navegar menús ni exportar hojas de cálculo.
+            Elige ChatGPT o Claude para preguntar por facturas, clientes y contabilidad sin
+            navegar menús ni exportar hojas de cálculo.
           </p>
           <p className="mt-3 text-sm text-slate-400">
             Integración independiente de Verifactu Business — no somos Holded, OpenAI ni Anthropic.

--- a/apps/holded/app/conectores/page.tsx
+++ b/apps/holded/app/conectores/page.tsx
@@ -60,7 +60,7 @@ const connectors = [
     badgeText: 'text-[#D4570C]',
     ctaBg: 'bg-[#D4570C] hover:bg-[#B84509] shadow-[0_10px_25px_-12px_rgba(212,87,12,0.5)]',
     checkColor: 'text-[#D4570C]',
-    connectHref: 'https://claude.verifactu.business/launch',
+    connectHref: 'https://holded-claude.verifactu.business/launch',
     connectLabel: 'Añadir a Claude',
     connectExternal: true,
   },

--- a/apps/holded/app/lib/communications/holded-email-templates.ts
+++ b/apps/holded/app/lib/communications/holded-email-templates.ts
@@ -1090,7 +1090,7 @@ export function buildHoldedAuthFailuresUserEmail(input: {
             <p style="margin:0 0 12px;font-size:14px;color:#0f172a;">Hemos detectado <strong>${input.failureCount} intentos de conexion fallidos</strong> con tu cuenta de Holded en los ultimos ${input.windowMinutes} minutos a traves de <strong>${escapeHtml(channelLabel)}</strong>.</p>
             <p style="margin:0 0 12px;font-size:14px;color:#0f172a;">Las causas mas frecuentes son:</p>
             <ul style="margin:0 0 16px;padding-left:20px;font-size:14px;color:#334155;">
-              <li>La API key de Holded ha sido <strong>regenerada o revocada</strong> en el panel de Holded.</li>
+              <li>La API key de Holded ha sido <strong>regenerada o revocada</strong>. Puedes generar una nueva en Holded &rarr; Configuracion &rarr; Integraciones &rarr; API (<a href="https://help.holded.com/es/articles/6896051-como-generar-y-usar-la-api-de-holded" style="color:#1d9e75;">guia paso a paso</a>) y pegarla al reconectar.</li>
               <li>Tu plan de Holded ha cambiado y ya no incluye acceso a la API.</li>
               <li>La cuenta de Holded esta suspendida o limitada temporalmente.</li>
             </ul>

--- a/apps/holded/app/lib/holded-api-client.ts
+++ b/apps/holded/app/lib/holded-api-client.ts
@@ -2,6 +2,18 @@
 // Mirrors apps/holded-mcp/src/holded-client.ts without the MCP-specific dependencies.
 
 const HOLDED_API_BASE = 'https://api.holded.com';
+const HOLDED_TIMEOUT_MS = 10_000;
+const MAX_RETRIES = 2;
+const RETRYABLE_STATUS = new Set([429, 502, 503, 504]);
+
+function sleep(ms: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
+function backoffDelayMs(attempt: number) {
+  const base = 200 * 2 ** attempt;
+  return Math.max(50, Math.floor(base + base * (Math.random() - 0.5)));
+}
 
 export class HoldedApiError extends Error {
   constructor(
@@ -23,27 +35,42 @@ export class HoldedClient {
 
   private async request<T>(path: string, options: RequestInit = {}): Promise<T> {
     const url = `${HOLDED_API_BASE}${path}`;
-    const res = await fetch(url, {
-      ...options,
-      headers: {
-        key: this.apiKey,
-        'Content-Type': 'application/json',
-        Accept: 'application/json',
-        'Accept-Encoding': 'identity',
-        ...options.headers,
-      },
-    });
 
-    if (!res.ok) {
-      const body = await res.text().catch(() => '');
-      throw new HoldedApiError(
-        `Holded API ${res.status}: ${res.statusText}${body ? ` — ${body}` : ''}`,
-        res.status,
-        path
-      );
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), HOLDED_TIMEOUT_MS);
+      try {
+        const res = await fetch(url, {
+          ...options,
+          signal: controller.signal,
+          headers: {
+            key: this.apiKey,
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+            'Accept-Encoding': 'identity',
+            ...options.headers,
+          },
+        });
+
+        if (!res.ok) {
+          if (RETRYABLE_STATUS.has(res.status) && attempt < MAX_RETRIES) {
+            await sleep(backoffDelayMs(attempt));
+            continue;
+          }
+          const body = await res.text().catch(() => '');
+          throw new HoldedApiError(
+            `Holded API ${res.status}: ${res.statusText}${body ? ` — ${body}` : ''}`,
+            res.status,
+            path
+          );
+        }
+
+        return res.json() as Promise<T>;
+      } finally {
+        clearTimeout(timer);
+      }
     }
-
-    return res.json() as Promise<T>;
+    throw new HoldedApiError('Holded API request failed after retries', 0, path);
   }
 
   // ── Facturación / Documentos ──────────────────────────────────────────────

--- a/apps/isaak/app/(workspace)/resumen/page.tsx
+++ b/apps/isaak/app/(workspace)/resumen/page.tsx
@@ -1,10 +1,10 @@
 import type { Metadata } from 'next';
 import type { LucideIcon } from 'lucide-react';
-import { BarChart3, Clock, FileCheck, TrendingDown, TrendingUp } from 'lucide-react';
+import { BarChart3, Calculator, Clock, FileCheck, TrendingDown, TrendingUp } from 'lucide-react';
 import { Suspense } from 'react';
 import { getHoldedSession } from '@/app/lib/holded-session';
 import { loadIsaakBusinessContext } from '@/app/lib/isaak-business-context';
-import { buildRangeSummary } from '@/app/lib/holded-analytics';
+import { buildRangeSummary, type HoldedAccountingPnL } from '@/app/lib/holded-analytics';
 import { prisma } from '@/app/lib/prisma';
 import ResumenChart, { type MonthlyPoint } from './components/ResumenChart';
 
@@ -58,6 +58,7 @@ async function DashboardContent() {
   let kpis: KpiCard[] = [];
   let chartData: MonthlyPoint[] = [];
   let verifactu: VerifactuStats | null = null;
+  let accountingPnL: HoldedAccountingPnL | null = null;
 
   try {
     const session = await getHoldedSession();
@@ -73,6 +74,7 @@ async function DashboardContent() {
       );
       const a = ctx.holded.analytics;
       const snapshot = ctx.holded.snapshot;
+      accountingPnL = a?.accountingPnL ?? null;
 
       if (a) {
         const vatEstimate = a.quarterSales > 0 ? a.quarterSales * 0.21 : null;
@@ -201,6 +203,55 @@ async function DashboardContent() {
           </div>
         ))}
       </div>
+
+      {accountingPnL && accountingPnL.entriesProcessed > 0 && (
+        <div className="mx-5 mb-3 rounded-xl border border-slate-100 bg-white px-4 py-3 shadow-sm">
+          <div className="flex items-center gap-1.5">
+            <Calculator size={13} className="text-[#2361d8]" />
+            <p className="text-[11px] font-semibold text-slate-500">
+              Resultado contable {accountingPnL.year} (libro diario · YTD)
+            </p>
+          </div>
+          <div className="mt-2 grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <div>
+              <p className="text-[10px] uppercase tracking-wide text-slate-400">Ingresos</p>
+              <p className="text-[14px] font-semibold text-emerald-600">
+                {fmt(accountingPnL.income)}
+              </p>
+            </div>
+            <div>
+              <p className="text-[10px] uppercase tracking-wide text-slate-400">Gastos</p>
+              <p className="text-[14px] font-semibold text-slate-700">
+                {fmt(accountingPnL.expenses)}
+              </p>
+            </div>
+            <div>
+              <p className="text-[10px] uppercase tracking-wide text-slate-400">Resultado</p>
+              <p
+                className={`text-[14px] font-semibold ${
+                  accountingPnL.grossProfit >= 0 ? 'text-emerald-600' : 'text-rose-600'
+                }`}
+              >
+                {fmt(accountingPnL.grossProfit)}
+              </p>
+            </div>
+            <div>
+              <p className="text-[10px] uppercase tracking-wide text-slate-400">Margen</p>
+              <p
+                className={`text-[14px] font-semibold ${
+                  (accountingPnL.margin ?? 0) >= 0 ? 'text-emerald-600' : 'text-rose-600'
+                }`}
+              >
+                {accountingPnL.margin !== null ? `${accountingPnL.margin}%` : '—'}
+              </p>
+            </div>
+          </div>
+          <p className="mt-2 text-[10px] text-slate-400">
+            Agregado desde {accountingPnL.entriesProcessed} asientos del libro diario (cuentas PGC
+            7xx ingresos · 6xx gastos).
+          </p>
+        </div>
+      )}
 
       {verifactu !== null && verifactu.issued + verifactu.drafts + verifactu.errors > 0 && (
         <div className="mx-5 mb-3 rounded-xl border border-slate-100 bg-white px-4 py-3 shadow-sm">

--- a/apps/isaak/app/(workspace)/resumen/page.tsx
+++ b/apps/isaak/app/(workspace)/resumen/page.tsx
@@ -1,10 +1,22 @@
 import type { Metadata } from 'next';
 import type { LucideIcon } from 'lucide-react';
-import { BarChart3, Calculator, Clock, FileCheck, TrendingDown, TrendingUp } from 'lucide-react';
+import {
+  AlertTriangle,
+  BarChart3,
+  Calculator,
+  Clock,
+  FileCheck,
+  TrendingDown,
+  TrendingUp,
+} from 'lucide-react';
 import { Suspense } from 'react';
 import { getHoldedSession } from '@/app/lib/holded-session';
 import { loadIsaakBusinessContext } from '@/app/lib/isaak-business-context';
 import { buildRangeSummary, type HoldedAccountingPnL } from '@/app/lib/holded-analytics';
+import {
+  loadIsaakWorkspaceSignals,
+  type IsaakVerifactuSignal,
+} from '@/app/lib/isaak-workspace-signals';
 import { prisma } from '@/app/lib/prisma';
 import ResumenChart, { type MonthlyPoint } from './components/ResumenChart';
 
@@ -59,6 +71,7 @@ async function DashboardContent() {
   let chartData: MonthlyPoint[] = [];
   let verifactu: VerifactuStats | null = null;
   let accountingPnL: HoldedAccountingPnL | null = null;
+  let verifactuSignal: IsaakVerifactuSignal | null = null;
 
   try {
     const session = await getHoldedSession();
@@ -121,7 +134,13 @@ async function DashboardContent() {
         chartData = buildMonthlyChart(snapshot);
       }
 
-      // Verifactu invoice stats
+      // Verifactu Holded signal + local stats
+      const wsSignals = await loadIsaakWorkspaceSignals({
+        tenantId: session.tenantId,
+        context: ctx,
+      }).catch(() => null);
+      verifactuSignal = wsSignals?.verifactu ?? null;
+
       const [issued, drafts, errors] = await Promise.all([
         prisma.invoice.count({
           where: {
@@ -203,6 +222,25 @@ async function DashboardContent() {
           </div>
         ))}
       </div>
+
+      {verifactuSignal?.checked && verifactuSignal.invoicesWithoutUuid > 0 && (
+        <div className="mx-5 mb-3 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3">
+          <div className="flex items-start gap-2">
+            <AlertTriangle size={14} className="mt-0.5 shrink-0 text-amber-600" />
+            <div>
+              <p className="text-[12px] font-semibold text-amber-800">
+                {verifactuSignal.invoicesWithoutUuid} factura
+                {verifactuSignal.invoicesWithoutUuid > 1 ? 's' : ''} sin UUID Verifactu
+              </p>
+              <p className="mt-0.5 text-[11px] text-amber-700">
+                De las últimas {verifactuSignal.invoicesChecked} facturas revisadas (90 días),{' '}
+                {verifactuSignal.invoicesWithoutUuid} no tienen UUID Verifactu. El RD 1007/2023
+                obliga a registrar todas las facturas. Pregunta a Isaak para saber cómo resolverlo.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
 
       {accountingPnL && accountingPnL.entriesProcessed > 0 && (
         <div className="mx-5 mb-3 rounded-xl border border-slate-100 bg-white px-4 py-3 shadow-sm">

--- a/apps/isaak/app/api/holded/actions/create-expense/route.ts
+++ b/apps/isaak/app/api/holded/actions/create-expense/route.ts
@@ -1,0 +1,126 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getHoldedSession } from '@/app/lib/holded-session';
+import { getHoldedConnection } from '@/app/lib/holded-integration';
+import { holdedCreateExpense } from '@/app/lib/holded-api';
+import type { ExtractedExpense } from '@/app/api/holded/upload-expense/route';
+
+export const runtime = 'nodejs';
+
+function fmt(n: number) {
+  return n.toLocaleString('es-ES', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) + ' €';
+}
+
+export async function POST(request: NextRequest) {
+  const session = await getHoldedSession().catch(() => null);
+  if (!session?.tenantId || !session.userId) {
+    return NextResponse.json({ error: 'Sesión requerida.' }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'JSON inválido.' }, { status: 400 });
+  }
+
+  if (!body || typeof body !== 'object') {
+    return NextResponse.json({ error: 'Cuerpo de petición inválido.' }, { status: 400 });
+  }
+
+  const { expense, contactId } = body as { expense?: unknown; contactId?: string };
+
+  if (!expense || typeof expense !== 'object') {
+    return NextResponse.json({ error: 'El campo "expense" es obligatorio.' }, { status: 400 });
+  }
+
+  const e = expense as Partial<ExtractedExpense>;
+
+  if (!e.supplierName || typeof e.supplierName !== 'string') {
+    return NextResponse.json({ error: 'supplierName es obligatorio.' }, { status: 400 });
+  }
+  if (!e.description || typeof e.description !== 'string') {
+    return NextResponse.json({ error: 'description es obligatorio.' }, { status: 400 });
+  }
+  if (typeof e.amountTotal !== 'number' || e.amountTotal <= 0) {
+    return NextResponse.json(
+      { error: 'amountTotal debe ser un número mayor que 0.' },
+      { status: 400 }
+    );
+  }
+
+  const connection = await getHoldedConnection(session.tenantId, 'dashboard').catch(() => null);
+  if (!connection?.apiKey || connection.status === 'disconnected') {
+    return NextResponse.json(
+      { error: 'Conecta tu cuenta de Holded antes de registrar gastos.' },
+      { status: 400 }
+    );
+  }
+
+  const issueDate =
+    typeof e.issueDate === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(e.issueDate)
+      ? e.issueDate
+      : new Date().toISOString().slice(0, 10);
+
+  const amountNet =
+    typeof e.amountNet === 'number'
+      ? e.amountNet
+      : Math.round((e.amountTotal / (1 + (e.vatRate ?? 0.21))) * 100) / 100;
+
+  const vatRate = typeof e.vatRate === 'number' ? e.vatRate : 0.21;
+
+  const notes = [e.description, e.invoiceNumber ? `Ref: ${e.invoiceNumber}` : '']
+    .filter(Boolean)
+    .join(' · ');
+
+  try {
+    const result = await holdedCreateExpense(connection.apiKey, {
+      contactId: typeof contactId === 'string' ? contactId : undefined,
+      contactName: e.supplierName,
+      date: Math.floor(new Date(issueDate).getTime() / 1000),
+      notes,
+      currency: e.currency ?? 'EUR',
+      items: [
+        {
+          name: e.description,
+          units: 1,
+          subtotal: amountNet,
+          tax: Math.round(vatRate * 100),
+        },
+      ],
+    });
+
+    return NextResponse.json({
+      ok: true,
+      holdedId: result.id,
+      docNumber: result.docNumber,
+      reply: [
+        `✅ Gasto registrado en Holded correctamente.`,
+        '',
+        `- **Proveedor:** ${e.supplierName}`,
+        `- **Total:** ${fmt(e.amountTotal)}`,
+        result.id ? `- **ID Holded:** \`${result.id}\`` : '',
+        result.docNumber ? `- **Nº documento:** ${result.docNumber}` : '',
+        '',
+        'Puedes verlo en la sección de Compras de Holded.',
+      ]
+        .filter(Boolean)
+        .join('\n'),
+    });
+  } catch (err) {
+    console.error('[holded/actions/create-expense] failed', {
+      tenantId: session.tenantId,
+      supplierName: e.supplierName,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json(
+      {
+        ok: false,
+        error:
+          err instanceof Error
+            ? err.message
+            : 'Error al registrar el gasto. Puedes añadirlo manualmente en Holded.',
+      },
+      { status: 502 }
+    );
+  }
+}

--- a/apps/isaak/app/api/holded/actions/send-document/route.ts
+++ b/apps/isaak/app/api/holded/actions/send-document/route.ts
@@ -1,0 +1,107 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getHoldedSession } from '@/app/lib/holded-session';
+import { getHoldedConnection } from '@/app/lib/holded-integration';
+import { holdedSendDocument } from '@/app/lib/holded-api';
+
+export const runtime = 'nodejs';
+
+const VALID_DOC_TYPES = new Set([
+  'invoice',
+  'salesreceipt',
+  'creditnote',
+  'purchase',
+  'purchaseorder',
+  'estimate',
+  'proforma',
+]);
+
+function isValidEmail(value: string) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value.trim());
+}
+
+export async function POST(request: NextRequest) {
+  const session = await getHoldedSession().catch(() => null);
+  if (!session?.tenantId || !session.userId) {
+    return NextResponse.json({ error: 'Sesión requerida.' }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'JSON inválido.' }, { status: 400 });
+  }
+
+  if (!body || typeof body !== 'object') {
+    return NextResponse.json({ error: 'Cuerpo de petición inválido.' }, { status: 400 });
+  }
+
+  const { docType, documentId, emails, subject, body: emailBody, cc } = body as Record<
+    string,
+    unknown
+  >;
+
+  if (typeof docType !== 'string' || !VALID_DOC_TYPES.has(docType)) {
+    return NextResponse.json(
+      {
+        error: `docType no válido. Valores permitidos: ${[...VALID_DOC_TYPES].join(', ')}.`,
+      },
+      { status: 400 }
+    );
+  }
+
+  if (typeof documentId !== 'string' || !documentId.trim()) {
+    return NextResponse.json({ error: 'documentId es obligatorio.' }, { status: 400 });
+  }
+
+  const emailList = Array.isArray(emails)
+    ? (emails as unknown[]).filter((e): e is string => typeof e === 'string' && isValidEmail(e))
+    : [];
+
+  if (emailList.length === 0) {
+    return NextResponse.json(
+      { error: 'Debes indicar al menos un email destinatario válido.' },
+      { status: 400 }
+    );
+  }
+
+  const connection = await getHoldedConnection(session.tenantId, 'dashboard').catch(() => null);
+  if (!connection?.apiKey || connection.status === 'disconnected') {
+    return NextResponse.json(
+      { error: 'Conecta tu cuenta de Holded antes de enviar documentos.' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const result = await holdedSendDocument(connection.apiKey, docType, documentId.trim(), {
+      emails: emailList,
+      subject: typeof subject === 'string' ? subject : undefined,
+      body: typeof emailBody === 'string' ? emailBody : undefined,
+      cc: Array.isArray(cc)
+        ? (cc as unknown[]).filter((e): e is string => typeof e === 'string' && isValidEmail(e))
+        : undefined,
+    });
+
+    const fmt = emailList.length === 1 ? `a ${emailList[0]}` : `a ${emailList.length} destinatarios`;
+    return NextResponse.json({
+      ok: result.ok,
+      reply: `Documento enviado correctamente ${fmt}.`,
+      raw: result.raw,
+    });
+  } catch (err) {
+    console.error('[holded/actions/send-document] failed', {
+      tenantId: session.tenantId,
+      docType,
+      documentId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json(
+      {
+        ok: false,
+        error: err instanceof Error ? err.message : 'Error al enviar el documento.',
+      },
+      { status: 502 }
+    );
+  }
+}

--- a/apps/isaak/app/api/holded/chat/route.ts
+++ b/apps/isaak/app/api/holded/chat/route.ts
@@ -341,6 +341,9 @@ function buildLlmInstructions(input: {
     analytics
       ? `Analitica: ventas_mes=${analytics.monthSales}, gastos_mes=${analytics.monthExpenses}, margen_mes=${analytics.monthMargin}, pendientes=${analytics.pendingCollectionsAmount}.`
       : 'Analitica: no disponible.',
+    analytics?.accountingPnL && analytics.accountingPnL.entriesProcessed > 0
+      ? `Resultado_contable_YTD (libro diario, fuente preferida sobre escaneo de documentos): ingresos=${analytics.accountingPnL.income}, gastos=${analytics.accountingPnL.expenses}, resultado=${analytics.accountingPnL.grossProfit}, margen_pct=${analytics.accountingPnL.margin ?? 'n/d'}, asientos=${analytics.accountingPnL.entriesProcessed}.`
+      : 'Resultado_contable_YTD: no disponible (sin asientos en libro diario o sin acceso a contabilidad).',
     probeSummary
       ? `Chequeo vivo: ${probeSummary.summary} Siguiente paso sugerido: ${probeSummary.nextStep}`
       : 'Chequeo vivo: no ejecutado.',

--- a/apps/isaak/app/api/holded/chat/route.ts
+++ b/apps/isaak/app/api/holded/chat/route.ts
@@ -29,6 +29,7 @@ import {
 import { prisma } from '@/app/lib/prisma';
 import { getAeatNotifications, loadTenantCertPem } from '@/app/lib/aeat-sede';
 import { createIsaakInvoiceDraft, issueIsaakInvoice } from '@/app/lib/invoice-service';
+import { holdedCreateExpense } from '@/app/lib/holded-api';
 import { HOLDED_CHAT_TOOLS, executeHoldedTool, type HoldedToolName } from '@/app/lib/holded-tools';
 import { GOOGLE_CHAT_TOOLS, executeGoogleTool, isGoogleToolName } from '@/app/lib/google-tools';
 import {
@@ -1098,52 +1099,37 @@ export async function POST(request: NextRequest) {
       const amountTotal =
         typeof pendingExpense.amountTotal === 'number' ? pendingExpense.amountTotal : 0;
 
-      const holdedPayload = {
-        date: expenseDate,
-        notes: invoiceNumber ? `${description} (Ref: ${invoiceNumber})` : description,
-        products: [
-          {
-            desc: description,
-            units: 1,
-            price: amountNet,
-            tax: Math.round(vatRate * 100),
-          },
-        ],
-      };
-
       try {
-        const holdedRes = await fetch(
-          'https://api.holded.com/api/invoicing/v1/documents/purchase',
-          {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json', key: holdedKey },
-            body: JSON.stringify(holdedPayload),
-          }
-        );
-        const holdedData = (await holdedRes.json().catch(() => ({}))) as {
-          id?: string;
-          status?: number;
-          info?: string;
-        };
-
-        if (!holdedRes.ok || holdedData.status === 0) {
-          reply = `No he podido registrar el gasto en Holded: ${holdedData.info ?? `Error ${holdedRes.status}`}. Puedes añadirlo manualmente en Holded.`;
-        } else {
-          const fmt = (n: number) =>
-            n.toLocaleString('es-ES', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) +
-            ' €';
-          reply = [
-            `✅ Gasto registrado en Holded correctamente.`,
-            '',
-            `- **Proveedor:** ${supplierName}`,
-            `- **Total:** ${fmt(amountTotal)}`,
-            holdedData.id ? `- **ID Holded:** \`${holdedData.id}\`` : '',
-            '',
-            'Puedes verlo en la sección de Compras de Holded.',
-          ]
-            .filter(Boolean)
-            .join('\n');
-        }
+        const result = await holdedCreateExpense(holdedKey, {
+          contactName: supplierName,
+          date: expenseDate,
+          notes: invoiceNumber ? `${description} · Ref: ${invoiceNumber}` : description,
+          currency:
+            typeof pendingExpense.currency === 'string' ? pendingExpense.currency : 'EUR',
+          items: [
+            {
+              name: description,
+              units: 1,
+              subtotal: amountNet,
+              tax: Math.round(vatRate * 100),
+            },
+          ],
+        });
+        const fmt = (n: number) =>
+          n.toLocaleString('es-ES', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) +
+          ' €';
+        reply = [
+          `✅ Gasto registrado en Holded correctamente.`,
+          '',
+          `- **Proveedor:** ${supplierName}`,
+          `- **Total:** ${fmt(amountTotal)}`,
+          result.id ? `- **ID Holded:** \`${result.id}\`` : '',
+          result.docNumber ? `- **Nº documento:** ${result.docNumber}` : '',
+          '',
+          'Puedes verlo en la sección de Compras de Holded.',
+        ]
+          .filter(Boolean)
+          .join('\n');
       } catch (err) {
         console.error('[holded/chat] expense registration failed', err);
         reply =

--- a/apps/isaak/app/lib/__tests__/holded-api.test.ts
+++ b/apps/isaak/app/lib/__tests__/holded-api.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Tests for holdedGetPnL and holdedGetVerifactuStatus.
+ *
+ * fetch is mocked globally per test; AbortController + setTimeout
+ * are Node.js globals that need no special setup.
+ */
+
+import { holdedGetPnL, holdedGetVerifactuStatus } from '../holded-api';
+
+const API_KEY = 'test-api-key';
+
+function mockFetchOk(body: unknown) {
+  return jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => body,
+  } as unknown as Response);
+}
+
+function mockFetchErr(status: number) {
+  return jest.fn().mockResolvedValue({
+    ok: false,
+    status,
+    json: async () => ({}),
+  } as unknown as Response);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ── holdedGetPnL ─────────────────────────────────────────────────────────────
+
+describe('holdedGetPnL', () => {
+  it('returns all-zero P&L when dailyledger is empty', async () => {
+    global.fetch = mockFetchOk([]);
+    const result = await holdedGetPnL(API_KEY);
+
+    expect(result.income).toBe(0);
+    expect(result.expenses).toBe(0);
+    expect(result.grossProfit).toBe(0);
+    expect(result.margin).toBeNull();
+    expect(result.entriesProcessed).toBe(0);
+  });
+
+  it('aggregates 7xx accounts as income (credit − debit)', async () => {
+    global.fetch = mockFetchOk([
+      { account: '700', credit: 1000, debit: 0 },
+      { account: '705', credit: 500, debit: 50 }, // net = 450
+    ]);
+    const result = await holdedGetPnL(API_KEY);
+
+    expect(result.income).toBe(1450);
+    expect(result.expenses).toBe(0);
+    expect(result.grossProfit).toBe(1450);
+    expect(result.margin).toBe(100);
+    expect(result.entriesProcessed).toBe(2);
+  });
+
+  it('aggregates 6xx accounts as expenses using Math.abs(net)', async () => {
+    global.fetch = mockFetchOk([
+      { account: '600', credit: 0, debit: 800 },  // net = −800 → expenses += 800
+      { account: '622', credit: 100, debit: 400 }, // net = −300 → expenses += 300
+    ]);
+    const result = await holdedGetPnL(API_KEY);
+
+    expect(result.expenses).toBe(1100);
+    expect(result.income).toBe(0);
+    expect(result.grossProfit).toBe(-1100);
+    expect(result.margin).toBeNull(); // income is 0
+  });
+
+  it('ignores non-7xx / non-6xx PGC accounts', async () => {
+    global.fetch = mockFetchOk([
+      { account: '430', credit: 5000, debit: 0 }, // clientes — not income
+      { account: '572', credit: 0, debit: 2000 }, // banco — not expense
+      { account: '100', credit: 0, debit: 3000 }, // capital — not expense
+    ]);
+    const result = await holdedGetPnL(API_KEY);
+
+    expect(result.income).toBe(0);
+    expect(result.expenses).toBe(0);
+    expect(result.grossProfit).toBe(0);
+    expect(result.margin).toBeNull();
+  });
+
+  it('computes margin correctly as percentage rounded to 2 dp', async () => {
+    global.fetch = mockFetchOk([
+      { account: '700', credit: 1000, debit: 0 },
+      { account: '600', credit: 0, debit: 600 },
+    ]);
+    const result = await holdedGetPnL(API_KEY);
+
+    expect(result.income).toBe(1000);
+    expect(result.expenses).toBe(600);
+    expect(result.grossProfit).toBe(400);
+    expect(result.margin).toBe(40); // 400/1000 * 100 = 40%
+  });
+
+  it('uses Spanish PGC field aliases (haber / debe) when credit/debit absent', async () => {
+    global.fetch = mockFetchOk([
+      { account: '700', haber: 2000, debe: 0 },
+      { account: '600', haber: 0, debe: 500 },
+    ]);
+    const result = await holdedGetPnL(API_KEY);
+
+    expect(result.income).toBe(2000);
+    expect(result.expenses).toBe(500);
+  });
+
+  it('handles non-array dailyledger response gracefully', async () => {
+    global.fetch = mockFetchOk({ error: 'no data' });
+    const result = await holdedGetPnL(API_KEY);
+
+    expect(result.income).toBe(0);
+    expect(result.entriesProcessed).toBe(0);
+  });
+
+  it('retries once on HTTP 429 and returns result on second attempt', async () => {
+    jest.useFakeTimers();
+
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 429, json: async () => ({}) } as unknown as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => [{ account: '700', credit: 500, debit: 0 }],
+      } as unknown as Response);
+
+    const promise = holdedGetPnL(API_KEY);
+    await jest.runAllTimersAsync();
+    const result = await promise;
+
+    expect((global.fetch as jest.Mock).mock.calls.length).toBe(2);
+    expect(result.income).toBe(500);
+
+    jest.useRealTimers();
+  });
+
+  it('throws on non-retryable HTTP error (404)', async () => {
+    global.fetch = mockFetchErr(404);
+    await expect(holdedGetPnL(API_KEY)).rejects.toThrow('Holded API 404');
+  });
+});
+
+// ── holdedGetVerifactuStatus ──────────────────────────────────────────────────
+
+describe('holdedGetVerifactuStatus', () => {
+  it('returns active=true when verifactu.uuid is present', async () => {
+    global.fetch = mockFetchOk({
+      id: 'inv-1',
+      verifactu: { uuid: 'abc-123', qr: 'QR_BASE64', huella: 'HASH_VAL' },
+    });
+    const result = await holdedGetVerifactuStatus(API_KEY, 'inv-1');
+
+    expect(result.active).toBe(true);
+    expect(result.uuid).toBe('abc-123');
+    expect(result.qrBase64).toBe('QR_BASE64');
+    expect(result.huella).toBe('HASH_VAL');
+    expect(result.invoiceId).toBe('inv-1');
+  });
+
+  it('returns active=true when verifactuData field is used instead', async () => {
+    global.fetch = mockFetchOk({
+      id: 'inv-2',
+      verifactuData: { uuid: 'def-456', qr_base64: 'QR2', hash: 'H2', fecha: '2024-06-01' },
+    });
+    const result = await holdedGetVerifactuStatus(API_KEY, 'inv-2');
+
+    expect(result.active).toBe(true);
+    expect(result.uuid).toBe('def-456');
+    expect(result.qrBase64).toBe('QR2');
+    expect(result.huella).toBe('H2');
+    expect(result.sentAt).toBe('2024-06-01');
+  });
+
+  it('returns active=true from top-level verifactuUuid + qrCode fields', async () => {
+    global.fetch = mockFetchOk({ id: 'inv-3', verifactuUuid: 'ghi-789', qrCode: 'QR3' });
+    const result = await holdedGetVerifactuStatus(API_KEY, 'inv-3');
+
+    expect(result.active).toBe(true);
+    expect(result.uuid).toBe('ghi-789');
+    expect(result.qrBase64).toBe('QR3');
+  });
+
+  it('returns active=false when no Verifactu fields are present', async () => {
+    global.fetch = mockFetchOk({ id: 'inv-4', total: 1000, status: 'paid' });
+    const result = await holdedGetVerifactuStatus(API_KEY, 'inv-4');
+
+    expect(result.active).toBe(false);
+    expect(result.uuid).toBeNull();
+    expect(result.qrBase64).toBeNull();
+    expect(result.huella).toBeNull();
+    expect(result.sentAt).toBeNull();
+  });
+
+  it('throws on Holded soft error (status: 0)', async () => {
+    global.fetch = mockFetchOk({ status: 0, info: 'Invoice not found' });
+    await expect(holdedGetVerifactuStatus(API_KEY, 'inv-5')).rejects.toThrow('Holded soft error');
+  });
+
+  it('throws on HTTP 404', async () => {
+    global.fetch = mockFetchErr(404);
+    await expect(holdedGetVerifactuStatus(API_KEY, 'inv-6')).rejects.toThrow('Holded API 404');
+  });
+
+  it('retries on HTTP 503 and succeeds on second attempt', async () => {
+    jest.useFakeTimers();
+
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 503, json: async () => ({}) } as unknown as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ id: 'inv-7', verifactuUuid: 'retry-uuid' }),
+      } as unknown as Response);
+
+    const promise = holdedGetVerifactuStatus(API_KEY, 'inv-7');
+    await jest.runAllTimersAsync();
+    const result = await promise;
+
+    expect((global.fetch as jest.Mock).mock.calls.length).toBe(2);
+    expect(result.active).toBe(true);
+    expect(result.uuid).toBe('retry-uuid');
+
+    jest.useRealTimers();
+  });
+});

--- a/apps/isaak/app/lib/holded-analytics.ts
+++ b/apps/isaak/app/lib/holded-analytics.ts
@@ -2,6 +2,19 @@ import type { fetchHoldedSnapshot } from '@/app/lib/holded-integration';
 
 export type HoldedSnapshot = Awaited<ReturnType<typeof fetchHoldedSnapshot>>;
 
+// P&L sintético desde /accounting/v1/dailyledger (cuentas PGC 7xx / 6xx).
+// Más fiable que el escaneo de documentos: incluye asientos manuales y no
+// depende de heurísticas de docType para distinguir ingreso/gasto.
+export type HoldedAccountingPnL = {
+  year: number;
+  income: number;
+  expenses: number;
+  grossProfit: number;
+  margin: number | null;
+  entriesProcessed: number;
+  period: { from: string; to: string };
+};
+
 export type HoldedAnalyticsSummary = {
   monthSales: number;
   monthExpenses: number | null;
@@ -15,6 +28,7 @@ export type HoldedAnalyticsSummary = {
   contacts: number;
   accounts: number;
   expenseSignals: number;
+  accountingPnL: HoldedAccountingPnL | null;
   insight: string;
 };
 
@@ -219,6 +233,16 @@ function buildInsight(summary: Omit<HoldedAnalyticsSummary, 'insight'>) {
     );
   }
 
+  if (summary.accountingPnL && summary.accountingPnL.entriesProcessed > 0) {
+    const pnl = summary.accountingPnL;
+    fragments.push(
+      `resultado contable YTD de ${pnl.grossProfit.toLocaleString('es-ES', {
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 2,
+      })} EUR${pnl.margin !== null ? ` (margen ${pnl.margin}%)` : ''}`
+    );
+  }
+
   if (fragments.length > 0) {
     return `${fragments.join(', ')}. Si quieres, sigo con el trimestre, cobros pendientes o resultados.`;
   }
@@ -288,7 +312,8 @@ export function buildYearAnalyticsSummary(
 
 export function buildHoldedAnalyticsSummary(
   snapshot: HoldedSnapshot,
-  now = new Date()
+  now: Date = new Date(),
+  accountingPnL: HoldedAccountingPnL | null = null
 ): HoldedAnalyticsSummary {
   const { start: monthStart, end: monthEnd } = getCurrentMonthRange(now);
   const { start: quarterStart, end: quarterEnd } = getCurrentQuarterRange(now);
@@ -347,6 +372,7 @@ export function buildHoldedAnalyticsSummary(
     contacts: snapshot.contacts.length,
     accounts: snapshot.accounts.length,
     expenseSignals,
+    accountingPnL,
   };
 
   return {

--- a/apps/isaak/app/lib/holded-api.ts
+++ b/apps/isaak/app/lib/holded-api.ts
@@ -1,23 +1,81 @@
 const HOLDED_BASE = process.env.HOLDED_API_BASE ?? 'https://api.holded.com';
+const HOLDED_TIMEOUT_MS = 10_000;
 
 const RETRYABLE = new Set([429, 502, 503, 504]);
+
+function holdedBackoffMs(attempt: number) {
+  const base = 300 * 2 ** attempt;
+  return Math.max(50, Math.floor(base + base * (Math.random() - 0.5)));
+}
 
 async function holdedFetch(apiKey: string, path: string): Promise<unknown> {
   const url = `${HOLDED_BASE}${path}`;
   let lastErr: unknown;
   for (let attempt = 0; attempt <= 2; attempt++) {
-    if (attempt > 0) await new Promise((r) => setTimeout(r, 300 * 2 ** attempt));
+    if (attempt > 0) await new Promise<void>((r) => setTimeout(r, holdedBackoffMs(attempt)));
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), HOLDED_TIMEOUT_MS);
+    try {
+      const res = await fetch(url, {
+        headers: {
+          key: apiKey,
+          Accept: 'application/json',
+          // Node.js fetch sends Accept-Encoding: br by default; some Holded proxies
+          // return brotli-encoded bodies that undici fails to decompress silently.
+          'Accept-Encoding': 'identity',
+        },
+        signal: controller.signal,
+      });
+      if (!res.ok) {
+        if (RETRYABLE.has(res.status) && attempt < 2) continue;
+        const err = new Error(`Holded API ${res.status} at ${path}`);
+        lastErr = err;
+        throw err;
+      }
+      const data = await res.json().catch(() => null);
+      if (
+        data &&
+        typeof data === 'object' &&
+        !Array.isArray(data) &&
+        'status' in data &&
+        (data as { status?: unknown }).status === 0
+      ) {
+        throw new Error(
+          `Holded soft error at ${path}: ${JSON.stringify((data as { info?: unknown }).info ?? '')}`
+        );
+      }
+      return data;
+    } catch (err) {
+      lastErr = err;
+      throw err;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+  throw lastErr ?? new Error(`Holded API request failed: ${path}`);
+}
+
+async function holdedPost(
+  apiKey: string,
+  path: string,
+  body: Record<string, unknown>
+): Promise<unknown> {
+  const url = `${HOLDED_BASE}${path}`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), HOLDED_TIMEOUT_MS);
+  try {
     const res = await fetch(url, {
+      method: 'POST',
       headers: {
         key: apiKey,
         Accept: 'application/json',
-        // Node.js fetch sends Accept-Encoding: br by default; some Holded proxies
-        // return brotli-encoded bodies that undici fails to decompress silently.
+        'Content-Type': 'application/json',
         'Accept-Encoding': 'identity',
       },
+      body: JSON.stringify(body),
+      signal: controller.signal,
     });
     if (!res.ok) {
-      if (RETRYABLE.has(res.status) && attempt < 2) continue;
       throw new Error(`Holded API ${res.status} at ${path}`);
     }
     const data = await res.json().catch(() => null);
@@ -33,8 +91,9 @@ async function holdedFetch(apiKey: string, path: string): Promise<unknown> {
       );
     }
     return data;
+  } finally {
+    clearTimeout(timer);
   }
-  throw lastErr ?? new Error(`Holded API request failed: ${path}`);
 }
 
 function toUnix(value: string | number | undefined): string | undefined {
@@ -141,4 +200,211 @@ export async function holdedListProjects(apiKey: string) {
 export async function holdedListEmployees(apiKey: string) {
   const raw = await holdedFetch(apiKey, '/api/team/v1/employees');
   return Array.isArray(raw) ? raw : [];
+}
+
+// ── Verifactu / SII ───────────────────────────────────────────────────────────
+
+export type VerifactuStatus = {
+  invoiceId: string;
+  active: boolean;
+  uuid?: string | null;
+  qrBase64?: string | null;
+  huella?: string | null;
+  sentAt?: string | null;
+  raw: Record<string, unknown>;
+};
+
+export async function holdedGetVerifactuStatus(
+  apiKey: string,
+  invoiceId: string
+): Promise<VerifactuStatus> {
+  const raw = (await holdedFetch(
+    apiKey,
+    `/api/invoicing/v1/documents/invoice/${invoiceId}`
+  )) as Record<string, unknown>;
+
+  // Holded embeds Verifactu data in the document response when Verifactu is active.
+  // Field names vary by Holded version: verifactu, verifactuData, qrCode, qr_base64.
+  const vf =
+    (raw?.verifactu as Record<string, unknown> | undefined) ||
+    (raw?.verifactuData as Record<string, unknown> | undefined) ||
+    {};
+
+  return {
+    invoiceId,
+    active: Boolean(vf?.uuid || raw?.verifactuUuid || raw?.qrCode),
+    uuid: (vf?.uuid || raw?.verifactuUuid || null) as string | null,
+    qrBase64: (vf?.qr || vf?.qr_base64 || raw?.qrCode || null) as string | null,
+    huella: (vf?.huella || vf?.hash || null) as string | null,
+    sentAt: (vf?.sentAt || vf?.fecha || null) as string | null,
+    raw,
+  };
+}
+
+// ── P&L sintético desde dailyledger ──────────────────────────────────────────
+
+export type PnLSummary = {
+  period: { from: string; to: string };
+  income: number;
+  expenses: number;
+  grossProfit: number;
+  margin: number | null;
+  incomeByAccount: Record<string, number>;
+  expensesByAccount: Record<string, number>;
+  entriesProcessed: number;
+};
+
+export async function holdedGetPnL(
+  apiKey: string,
+  params?: { starttmp?: string; endtmp?: string; year?: number }
+): Promise<PnLSummary> {
+  const now = Math.floor(Date.now() / 1000);
+  const year = params?.year ?? new Date().getFullYear();
+  const from =
+    params?.starttmp ?? String(Math.floor(new Date(year, 0, 1).getTime() / 1000));
+  const to = params?.endtmp ?? String(now);
+
+  const qs = new URLSearchParams({ starttmp: from, endtmp: to });
+  const raw = (await holdedFetch(
+    apiKey,
+    `/api/accounting/v1/dailyledger?${qs}`
+  )) as unknown[];
+  const entries = Array.isArray(raw) ? raw : [];
+
+  const incomeByAccount: Record<string, number> = {};
+  const expensesByAccount: Record<string, number> = {};
+
+  for (const entry of entries) {
+    const e = entry as Record<string, unknown>;
+    const account = String(e.account || e.accountCode || e.num || '');
+    const credit = Number(e.credit ?? e.haber ?? 0);
+    const debit = Number(e.debit ?? e.debe ?? 0);
+    const net = credit - debit;
+
+    // Spanish PGC: 7xx = income, 6xx = expenses
+    if (account.startsWith('7')) {
+      incomeByAccount[account] = (incomeByAccount[account] ?? 0) + net;
+    } else if (account.startsWith('6')) {
+      expensesByAccount[account] = (expensesByAccount[account] ?? 0) + Math.abs(net);
+    }
+  }
+
+  const income = Object.values(incomeByAccount).reduce((s, v) => s + v, 0);
+  const expenses = Object.values(expensesByAccount).reduce((s, v) => s + v, 0);
+  const grossProfit = income - expenses;
+
+  return {
+    period: {
+      from: new Date(Number(from) * 1000).toISOString().slice(0, 10),
+      to: new Date(Number(to) * 1000).toISOString().slice(0, 10),
+    },
+    income: Math.round(income * 100) / 100,
+    expenses: Math.round(expenses * 100) / 100,
+    grossProfit: Math.round(grossProfit * 100) / 100,
+    margin: income > 0 ? Math.round((grossProfit / income) * 10000) / 100 : null,
+    incomeByAccount,
+    expensesByAccount,
+    entriesProcessed: entries.length,
+  };
+}
+
+// ── Envío de documentos ───────────────────────────────────────────────────────
+
+export type SendDocumentParams = {
+  emails: string[];
+  subject?: string;
+  body?: string;
+  cc?: string[];
+};
+
+export async function holdedSendDocument(
+  apiKey: string,
+  docType: string,
+  documentId: string,
+  params: SendDocumentParams
+): Promise<{ ok: boolean; raw: unknown }> {
+  const payload: Record<string, unknown> = { emails: params.emails };
+  if (params.subject) payload.subject = params.subject;
+  if (params.body) payload.body = params.body;
+  if (params.cc?.length) payload.cc = params.cc;
+
+  const raw = await holdedPost(
+    apiKey,
+    `/api/invoicing/v1/documents/${docType}/${documentId}/send`,
+    payload
+  );
+  return { ok: true, raw };
+}
+
+// ── Crear gasto (para OCR → Holded) ──────────────────────────────────────────
+
+export type CreateExpenseParams = {
+  contactId?: string;
+  contactName?: string;
+  date: number; // Unix timestamp
+  notes?: string;
+  items: Array<{
+    name: string;
+    units: number;
+    subtotal: number;
+    tax?: number;
+    taxAmount?: number;
+    account?: string;
+  }>;
+  currency?: string;
+  paymentMethodId?: string;
+};
+
+export async function holdedCreateExpense(
+  apiKey: string,
+  params: CreateExpenseParams
+): Promise<{ id: string; docNumber?: string; raw: unknown }> {
+  const payload: Record<string, unknown> = {
+    date: params.date,
+    notes: params.notes ?? '',
+    currency: params.currency ?? 'EUR',
+    items: params.items.map((item) => ({
+      name: item.name,
+      units: item.units,
+      subtotal: item.subtotal,
+      ...(item.tax !== undefined ? { tax: item.tax } : {}),
+      ...(item.taxAmount !== undefined ? { taxAmount: item.taxAmount } : {}),
+      ...(item.account ? { account: item.account } : {}),
+    })),
+  };
+  if (params.contactId) payload.contactId = params.contactId;
+  if (params.paymentMethodId) payload.paymentMethodId = params.paymentMethodId;
+
+  const raw = (await holdedPost(
+    apiKey,
+    '/api/invoicing/v1/documents/purchase',
+    payload
+  )) as Record<string, unknown>;
+
+  return {
+    id: String(raw?.id ?? raw?.docId ?? ''),
+    docNumber: raw?.docNumber as string | undefined,
+    raw,
+  };
+}
+
+// ── Pagos ─────────────────────────────────────────────────────────────────────
+
+export async function holdedListPayments(
+  apiKey: string,
+  params?: { starttmp?: string; endtmp?: string; limit?: number }
+) {
+  const now = Math.floor(Date.now() / 1000);
+  const threeMonthsAgo = now - 90 * 24 * 3600;
+  const qs = new URLSearchParams({
+    starttmp: params?.starttmp ?? String(threeMonthsAgo),
+    endtmp: params?.endtmp ?? String(now),
+  });
+  const raw = (await holdedFetch(
+    apiKey,
+    `/api/invoicing/v1/payments?${qs}`
+  )) as unknown[];
+  const all = Array.isArray(raw) ? raw : [];
+  const limit = params?.limit ?? 50;
+  return { payments: all.slice(0, limit), total: all.length, truncated: all.length > limit };
 }

--- a/apps/isaak/app/lib/isaak-business-context.ts
+++ b/apps/isaak/app/lib/isaak-business-context.ts
@@ -2,9 +2,11 @@ import type { IsaakInstructionProfile, IsaakOnboardingProfile } from '@verifactu
 import { getIsaakOnboardingState } from '@verifactu/integrations';
 import {
   buildHoldedAnalyticsSummary,
+  type HoldedAccountingPnL,
   type HoldedAnalyticsSummary,
   type HoldedSnapshot,
 } from '@/app/lib/holded-analytics';
+import { holdedGetPnL } from '@/app/lib/holded-api';
 import {
   fetchHoldedSnapshot,
   getHoldedConnection,
@@ -189,6 +191,22 @@ function buildContextSummary(input: {
         })} EUR.`
       );
     }
+
+    if (input.analytics.accountingPnL && input.analytics.accountingPnL.entriesProcessed > 0) {
+      const pnl = input.analytics.accountingPnL;
+      parts.push(
+        `Resultado contable YTD ${pnl.year} (libro diario): ingresos ${pnl.income.toLocaleString(
+          'es-ES',
+          { minimumFractionDigits: 0, maximumFractionDigits: 2 }
+        )} EUR, gastos ${pnl.expenses.toLocaleString('es-ES', {
+          minimumFractionDigits: 0,
+          maximumFractionDigits: 2,
+        })} EUR, resultado ${pnl.grossProfit.toLocaleString('es-ES', {
+          minimumFractionDigits: 0,
+          maximumFractionDigits: 2,
+        })} EUR${pnl.margin !== null ? ` (margen ${pnl.margin}%)` : ''}.`
+      );
+    }
   }
 
   return parts.join(' ');
@@ -278,16 +296,35 @@ export async function loadIsaakBusinessContext(
     }),
   ]);
 
-  const snapshot =
-    connection?.apiKey && connection.status !== 'disconnected'
-      ? await fetchHoldedSnapshot(connection.apiKey)
-          .then((result) => result)
+  const liveApiKey =
+    connection?.apiKey && connection.status !== 'disconnected' ? connection.apiKey : null;
+  const [snapshot, accountingPnL] = liveApiKey
+    ? await Promise.all([
+        fetchHoldedSnapshot(liveApiKey).catch((error) => {
+          console.error('[isaak context] holded snapshot read failed', error);
+          return null;
+        }),
+        holdedGetPnL(liveApiKey)
+          .then(
+            (pnl): HoldedAccountingPnL => ({
+              year: new Date().getFullYear(),
+              income: pnl.income,
+              expenses: pnl.expenses,
+              grossProfit: pnl.grossProfit,
+              margin: pnl.margin,
+              entriesProcessed: pnl.entriesProcessed,
+              period: pnl.period,
+            })
+          )
           .catch((error) => {
-            console.error('[isaak context] holded snapshot read failed', error);
+            console.error('[isaak context] holded P&L read failed', error);
             return null;
-          })
-      : null;
-  const analytics = snapshot ? buildHoldedAnalyticsSummary(snapshot) : null;
+          }),
+      ])
+    : [null, null];
+  const analytics = snapshot
+    ? buildHoldedAnalyticsSummary(snapshot, new Date(), accountingPnL)
+    : null;
 
   const effectiveCompleted = onboardingState.completed;
   const effectiveProfile =

--- a/apps/isaak/app/lib/isaak-workspace-signals.ts
+++ b/apps/isaak/app/lib/isaak-workspace-signals.ts
@@ -1,5 +1,6 @@
 import type { IsaakBusinessContext } from './isaak-business-context';
 import { getUpcomingDeadlines } from './fiscal-calendar';
+import { holdedListDocuments } from './holded-api';
 import { prisma } from './prisma';
 
 export type IsaakWorkspaceBillingSnapshot = {
@@ -17,10 +18,17 @@ export type IsaakWorkspaceDeadline = {
   description: string;
 };
 
+export type IsaakVerifactuSignal = {
+  invoicesChecked: number;
+  invoicesWithoutUuid: number;
+  checked: boolean;
+};
+
 export type IsaakWorkspaceSignals = {
   billing: IsaakWorkspaceBillingSnapshot;
   pendingTasks: string[];
   upcomingDeadlines: IsaakWorkspaceDeadline[];
+  verifactu: IsaakVerifactuSignal | null;
 };
 
 export const ISAAK_PROFILE_INTERVIEW_GUIDANCE = [
@@ -36,9 +44,37 @@ function toIsoDate(value: Date | null | undefined) {
   return value ? value.toISOString() : null;
 }
 
+function hasVerifactuUuid(doc: Record<string, unknown>): boolean {
+  const vf =
+    (doc.verifactu as Record<string, unknown> | undefined) ||
+    (doc.verifactuData as Record<string, unknown> | undefined) ||
+    {};
+  return Boolean(vf.uuid || doc.verifactuUuid || doc.qrCode);
+}
+
+async function loadVerifactuSignal(apiKey: string): Promise<IsaakVerifactuSignal> {
+  const now = Math.floor(Date.now() / 1000);
+  const ninetyDaysAgo = String(now - 90 * 24 * 3600);
+
+  const { documents } = await holdedListDocuments(apiKey, {
+    docType: 'invoice',
+    starttmp: ninetyDaysAgo,
+    endtmp: String(now),
+    limit: 50,
+  });
+
+  const invoicesChecked = documents.length;
+  const invoicesWithoutUuid = documents.filter(
+    (doc) => !hasVerifactuUuid(doc as Record<string, unknown>)
+  ).length;
+
+  return { invoicesChecked, invoicesWithoutUuid, checked: true };
+}
+
 function buildPendingTasks(
   context: IsaakBusinessContext | null,
-  billing: IsaakWorkspaceBillingSnapshot
+  billing: IsaakWorkspaceBillingSnapshot,
+  verifactu: IsaakVerifactuSignal | null
 ) {
   const tasks: string[] = [];
 
@@ -68,18 +104,33 @@ function buildPendingTasks(
     }
   }
 
-  return tasks.slice(0, 4);
+  if (verifactu?.checked && verifactu.invoicesWithoutUuid > 0) {
+    tasks.push(
+      `Revisar Verifactu: ${verifactu.invoicesWithoutUuid} factura${verifactu.invoicesWithoutUuid > 1 ? 's' : ''} de los últimos 90 días sin UUID Verifactu (obligatorio desde RD 1007/2023).`
+    );
+  }
+
+  return tasks.slice(0, 5);
 }
 
 export async function loadIsaakWorkspaceSignals(input: {
   tenantId: string;
   context?: IsaakBusinessContext | null;
+  holdedApiKey?: string | null;
 }): Promise<IsaakWorkspaceSignals> {
-  const subscription = await prisma.tenantSubscription.findFirst({
-    where: { tenantId: input.tenantId },
-    include: { plan: true },
-    orderBy: [{ createdAt: 'desc' }],
-  });
+  const holdedApiKey =
+    input.holdedApiKey ?? input.context?.holded.connection?.apiKey ?? null;
+
+  const [subscription, verifactu] = await Promise.all([
+    prisma.tenantSubscription.findFirst({
+      where: { tenantId: input.tenantId },
+      include: { plan: true },
+      orderBy: [{ createdAt: 'desc' }],
+    }),
+    holdedApiKey
+      ? loadVerifactuSignal(holdedApiKey).catch(() => null)
+      : Promise.resolve(null),
+  ]);
 
   const trialEndsAt = subscription?.trialEndsAt ?? null;
   const daysUntilTrialEnd =
@@ -106,8 +157,9 @@ export async function loadIsaakWorkspaceSignals(input: {
 
   return {
     billing,
-    pendingTasks: buildPendingTasks(input.context ?? null, billing),
+    pendingTasks: buildPendingTasks(input.context ?? null, billing, verifactu),
     upcomingDeadlines,
+    verifactu,
   };
 }
 
@@ -135,10 +187,17 @@ export function formatWorkspaceSignalsForPrompt(signals: IsaakWorkspaceSignals) 
         .join(' | ')
     : 'Sin plazos fiscales próximos cargados.';
 
+  const verifactuSummary = signals.verifactu?.checked
+    ? signals.verifactu.invoicesWithoutUuid > 0
+      ? `ALERTA VERIFACTU: ${signals.verifactu.invoicesWithoutUuid} de ${signals.verifactu.invoicesChecked} facturas recientes (90 días) no tienen UUID Verifactu. Obligatorio según RD 1007/2023. Menciona este riesgo de cumplimiento cuando sea relevante.`
+      : `Verifactu: ${signals.verifactu.invoicesChecked} facturas revisadas en los últimos 90 días, todas con UUID. Cumplimiento correcto.`
+    : 'Verifactu: estado no verificado (sin conexión Holded o sin datos).';
+
   return [
     billingSummary,
     `Tareas pendientes detectadas: ${pendingSummary}`,
     `Próximos plazos fiscales: ${deadlineSummary}`,
+    verifactuSummary,
     ISAAK_PROFILE_INTERVIEW_GUIDANCE,
   ].join('\n');
 }

--- a/apps/isaak/jest.config.mjs
+++ b/apps/isaak/jest.config.mjs
@@ -1,0 +1,28 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import nextJest from '../../node_modules/next/jest.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const createJestConfig = nextJest({ dir: __dirname });
+
+const customJestConfig = {
+  testEnvironment: 'jest-environment-node',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1',
+  },
+  transform: {
+    '^.+\\.(ts|tsx|js)$': [
+      'babel-jest',
+      {
+        presets: [
+          ['@babel/preset-env', { targets: { node: 'current' } }],
+          '@babel/preset-typescript',
+        ],
+      },
+    ],
+  },
+  transformIgnorePatterns: ['[\\\\/]node_modules[\\\\/](?!(jose|@verifactu|@prisma)[\\\\/])'],
+};
+
+export default createJestConfig(customJestConfig);

--- a/apps/isaak/package.json
+++ b/apps/isaak/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "next dev -p 3012",
     "build": "next build",
-    "start": "next start -p 8080"
+    "start": "next start -p 8080",
+    "test": "jest --config jest.config.mjs"
   },
   "dependencies": {
     "@genkit-ai/googleai": "^1.28.0",

--- a/docs/anthropic-submission/oauth-flow.md
+++ b/docs/anthropic-submission/oauth-flow.md
@@ -31,7 +31,7 @@ Configurable vía env `OAUTH_ALLOWED_REDIRECT_ORIGINS` para añadir tenants ente
 
 | Scope          | Descripción                                                                        |
 | -------------- | ---------------------------------------------------------------------------------- |
-| `holded:read`  | Lectura de facturas, contactos, productos, proyectos, CRM, contabilidad, tesorería |
+| `holded:read`  | Lectura de facturas y documentos, contactos y contabilidad (8 tools del preset `submission_v1`) |
 | `holded:write` | Crear borradores de factura con `approveDoc=false` forzado por servidor            |
 
 **Default scope:** `holded:read holded:write` (lo que el consent screen pide al usuario)

--- a/docs/auditorias/2026-05-21-conectores-auditoria-y-monitorizacion-tools.md
+++ b/docs/auditorias/2026-05-21-conectores-auditoria-y-monitorizacion-tools.md
@@ -1,0 +1,116 @@
+# Auditoría de conectores Holded + monitorización en vivo de tools
+
+**Fecha:** 21 de mayo de 2026
+**Alcance:** conector Claude (`apps/holded-mcp`) y conector ChatGPT (`apps/holded` + runtime MCP en `apps/app`)
+**Objetivo:** auditar ambos conectores y cerrar la brecha de monitorización — verificar en vivo el
+funcionamiento de cada tool y mostrar el estado en las páginas públicas.
+
+---
+
+## 1. Inventario de los dos conectores
+
+| Conector | Landing pública | Servidor MCP | Auth | Preset de tools |
+| -------- | --------------- | ------------ | ---- | --------------- |
+| **Claude** | `holded.verifactu.business/conectores/claude` (+ landing propia en `claude.verifactu.business/`) | `apps/holded-mcp` — Express + Streamable HTTP | OAuth (Bearer) | `submission_v1` — 8 tools |
+| **ChatGPT** | `holded.verifactu.business/conectores/chatgpt` | `apps/holded/api/mcp/holded` → proxy a `apps/app/api/mcp/holded` | OAuth (Bearer) | `openai_review_invoicing_v1` — 10 tools |
+
+Ambos conectores envuelven la **misma API REST de Holded** (`api.holded.com`). Las tools son
+adaptadores finos sobre los mismos endpoints (`/documents`, `/contacts`, `/chartofaccounts`,
+`/dailyledger`).
+
+### Tools por conector
+
+- **Claude (`submission_v1`)**: `list_documents`, `get_document`, `get_document_pdf`,
+  `list_contacts`, `get_contact`, `get_chart_of_accounts`, `get_journal`, `create_invoice_draft`.
+- **ChatGPT (`openai_review_invoicing_v1`)**: `list_invoices`, `get_invoice`, `list_documents`,
+  `get_document`, `get_document_pdf`, `list_contacts`, `get_contact`, `list_accounts`,
+  `list_daily_ledger`, `create_invoice_draft`.
+
+El código de las tools "extra" (CRM, proyectos, productos, almacenes, tesorería, empleados) sigue
+presente pero filtrado por preset, listo para reactivarse como submission v3 tras la aprobación de
+OpenAI/Anthropic.
+
+---
+
+## 2. Historial revisado (memoria de implementaciones)
+
+- `docs/auditorias/2026-05-12-demo-conectores-side-by-side.md` — demo Loom comparada. Bugs
+  detectados: `list_contacts` sin orden determinista, desfase de 1 día en fechas, falta de flag
+  `truncated`, `get_journal endtmp=null` reinyectado.
+- `docs/engineering/ADMIN_PANEL_CONNECTORS_AUDIT_AND_PLAN_2026.md` — panel admin; existen páginas
+  `/connectors/smoke-tests` y `/connectors/claude-smoke-tests` que prueban tools **on-demand**.
+- `docs/openai-submission/*` y `docs/anthropic-submission/*` — material de submission.
+
+### Sistema de monitorización previo
+
+Ya existía un health-check de **superficie pública**:
+
+- `apps/app/lib/connectorHealth/checks.ts` — ~19 probes sin token (landings, OAuth discovery, MCP
+  initialize, `tools/list`).
+- `apps/app/api/cron/connector-health` — Vercel Cron cada 5 min → tabla `connector_health_checks`.
+- `apps/app/api/public/status/[connector]` — endpoint público agregado.
+- `apps/holded/app/components/ConnectorStatusBadge.tsx` — badge en las landings.
+
+---
+
+## 3. Brecha detectada
+
+La monitorización en vivo y la verificación real de tools estaban **desconectadas**:
+
+| Capacidad | Cron de superficie | Smoke-tests admin |
+| --------- | ------------------ | ----------------- |
+| Corre en vivo (cada 5 min) | ✅ | ❌ (solo al pulsar un botón) |
+| Verifica funcionamiento real de las tools | ❌ (solo cuenta tools y superficie) | ✅ |
+| Visible en páginas públicas | ✅ | ❌ (solo panel admin) |
+
+Es decir: lo que probaba las tools no era ni continuo ni público; lo que era continuo y público no
+probaba las tools.
+
+---
+
+## 4. Implementación — revisión en vivo de tools en las páginas públicas
+
+Se extiende el sistema de health-check existente con una **segunda familia de checks** (`tool`),
+reutilizando toda la tubería (cron → tabla → endpoint público → badge).
+
+### Cambios
+
+1. **`apps/app/lib/connectorHealth/checks.ts`**
+   - Nueva familia `kind: 'tool'`: un check por cada tool de cada conector (8 Claude + 10 ChatGPT).
+   - Cada check ejecuta un probe autenticado contra `api.holded.com` con `HOLDED_TEST_API_KEY` —
+     la misma cuenta de pruebas que usan los smoke-tests del admin.
+   - Probes: `list*` valida array JSON; `get*` lista → toma un id → pide el detalle; PDF lista →
+     pide el PDF; `create_invoice_draft` valida precondiciones (sin mutar nada — nunca hace POST).
+   - Detección de HTML, errores HTTP, soft-errors de Holded (`status:0`), brotli (`Accept-Encoding:
+     identity`) y 1 reintento ante 429/5xx transitorio para evitar falsos rojos.
+   - La familia `tool` solo se registra si `HOLDED_TEST_API_KEY` está configurada (degradación
+     limpia: sin clave, las tools quedan en "estado desconocido", nunca en rojo falso).
+
+2. **`apps/app/api/public/status/[connector]/route.ts`** — expone `kind` por check y un resumen
+   `toolsTotal / toolsOk / toolsDegraded / toolsFail`.
+
+3. **`apps/holded/app/components/ConnectorStatusBadge.tsx`** — chip "X/Y tools operativas" en el
+   resumen y detalle agrupado en dos tablas: "Tools del conector" y "Superficie pública".
+
+Sin cambios de esquema: los nuevos `checkType` con prefijo `tool_` caben en el `VarChar(64)`
+existente de `connector_health_checks`, así que no hace falta migración de base de datos.
+
+### Resultado
+
+El cron de 5 minutos pasa de ~19 a ~37 checks. Las landings públicas
+`/conectores/{claude,chatgpt}` y sus `/docs` muestran ahora, en vivo, cuántas tools del conector
+están operativas y el detalle por tool.
+
+---
+
+## 5. Follow-ups recomendados
+
+- **Landing propia del MCP de Claude** (`claude.verifactu.business/`, `apps/holded-mcp/src/public-pages.ts`):
+  no muestra estado. Requiere un widget JS externo por la CSP estricta (`scriptSrc 'self'`).
+- **Checks semánticos profundos**: los probes actuales validan disponibilidad del dato. Bugs como
+  el desfase de fechas (task #104) o el orden de `list_contacts` (#102) viven en la capa de
+  formato del MCP y necesitarían un probe vía `tools/call` real con token.
+- **`tools/call` real**: ejecutar la tool a través del MCP (no solo su endpoint Holded) daría la
+  señal más fiel, a cambio de gestionar un token OAuth de larga duración por conector.
+- **Alertas**: un fallo sostenido de tool podría notificar por email/Slack además de pintar la
+  landing en rojo.

--- a/docs/isaak/ISAAK_ROADMAP.md
+++ b/docs/isaak/ISAAK_ROADMAP.md
@@ -1,22 +1,78 @@
 # ISAAK — Roadmap por Fases
 
-> Última actualización: 2026-04-28
+> Última actualización: 2026-05-23
 
 ---
 
 ## Timeline general
 
 ```
-MES 1–2   ████████████  FASE 1 · Core MVP + Lanzamiento
-MES 3–4   ████████████  FASE 2 · Calendar + Email (paralelo a crecimiento F1)
+MES 1–2   ████████████  FASE 1 · Core MVP + Lanzamiento               ✅ COMPLETADO
+MES 2–3   ████████████  FASE 1.5 · Holded API Full Coverage + Resiliencia  🔄 EN CURSO
+MES 3–4   ████████████  FASE 2 · Calendar + Email
 MES 5–7   ████████████  FASE 3 · OCR auto + inbox facturas + multi-ERP
 MES 8–10  ████████████  FASE 4 · Voz + Documentos mercantiles
 MES 11–14 ████████████  FASE 5 · Banca PSD2 + Conciliación
+MES 15–20 ████████████  FASE 6 · RRHH + Sistema RED (TGSS) + Asesoramiento Laboral
 ```
 
 ---
 
-## FASE 1 — Core MVP · LANZAMIENTO
+---
+
+## FASE 1.5 — Holded API Full Coverage + Resiliencia · EN CURSO
+
+**Duración:** 2–3 semanas  
+**Objetivo:** Cubrir todos los endpoints útiles de Holded que no aprovechábamos, reforzar la resiliencia de los tres clientes HTTP, y enriquecer el contexto de Isaak con datos fiscales críticos (Verifactu, P&L, pagos, envíos).
+
+### Resiliencia HTTP — Implementado
+
+| Cliente | Antes | Ahora |
+|---|---|---|
+| `apps/holded/app/lib/holded-api-client.ts` | Sin retry, sin timeout | Retry 2×, backoff exponencial + jitter, timeout 10s |
+| `apps/app/lib/integrations/accounting.ts` | Sin retry (solo timeout) | Retry 2× para 429/502/503/504 + backoff + jitter |
+| `apps/isaak/app/lib/holded-api.ts` | Retry fijo sin jitter | Retry 2×, backoff con jitter ±50%, timeout 10s |
+
+Patrón uniforme: `MAX_RETRIES = 2`, `base = 200ms · 2^n ± 50% jitter`, reintentos para HTTP 429/502/503/504.
+
+### Nuevas funciones Holded para Isaak — Implementado
+
+Añadidas en `apps/isaak/app/lib/holded-api.ts`:
+
+#### `holdedGetVerifactuStatus(apiKey, invoiceId)` → `VerifactuStatus`
+Extrae los campos Verifactu/SII del documento Holded (`uuid`, `qrBase64`, `huella`, `sentAt`).
+Holded embebe estos datos en la respuesta estándar de factura cuando Verifactu está activo — no hay endpoint dedicado.
+**Caso de uso:** Isaak responde "¿está esta factura en AEAT?" con certeza en lugar de redirigir al ERP.
+
+#### `holdedGetPnL(apiKey, params?)` → `PnLSummary`
+Agrega `/accounting/v1/dailyledger` por cuentas del PGC español (7xx = ingresos, 6xx = gastos)
+y devuelve `{ income, expenses, grossProfit, margin, period }`.
+Holded **no expone** P&L por API — esto es un diferenciador real frente al MCP comunitario.
+**Caso de uso:** "¿Cómo voy de margen este trimestre?" → Isaak responde sin que el usuario abra ningún informe.
+
+#### `holdedSendDocument(apiKey, docType, documentId, params)` → `{ ok, raw }`
+Llama a `POST /documents/{type}/{id}/send` con array de emails, subject y body opcional.
+**Caso de uso:** "Envía la factura F-2026/031 a proveedor@empresa.es" → acción completa desde el chat.
+
+#### `holdedCreateExpense(apiKey, params)` → `{ id, docNumber, raw }`
+Crea un gasto (`/documents/purchase`) en Holded con líneas estructuradas.
+Cierra el loop del OCR: Vision extrae datos → Isaak crea el gasto → usuario confirma en 1 click.
+
+#### `holdedListPayments(apiKey, params?)` → `{ payments, total, truncated }`
+Lista cobros/pagos de los últimos 90 días por defecto.
+**Caso de uso:** conciliación básica, alertas de pagos pendientes.
+
+### Próximos pasos de esta fase
+
+- [ ] Integrar `holdedGetPnL` en `holded-analytics.ts` → aparece en el dashboard y en el sistema prompt
+- [ ] Crear `app/api/actions/send-document/route.ts` → endpoint REST que Isaak puede llamar
+- [ ] Crear `app/api/actions/create-expense/route.ts` → endpoint REST para el flujo OCR → Holded
+- [ ] Añadir `verifactu_status` a las workspace signals proactivas (alertas de facturas sin UUID)
+- [ ] Tests unitarios para `holdedGetPnL` y `holdedGetVerifactuStatus`
+
+---
+
+## FASE 1 — Core MVP · LANZAMIENTO ✅ COMPLETADO
 
 **Duración:** 6–8 semanas  
 **Objetivo:** Usuarios de Holded hablan con su negocio, ven un dashboard básico. Primera monetización.  
@@ -384,6 +440,116 @@ Isaak:
 
 ---
 
+## FASE 6 — RRHH + Sistema RED (TGSS) + Asesoramiento Laboral
+
+**Duración:** 8–12 semanas (MES 15–20)  
+**Objetivo:** Convertir a Isaak en el asesor laboral de referencia para PYMES españolas. El área laboral es inseparable de la fiscal: las nóminas determinan las retenciones IRPF (mod 111/180) y las cotizaciones a la Seguridad Social impactan directamente en los costes y en el IS. La integración con el Sistema RED de la TGSS cierra el loop que Holded no puede cerrar.
+
+### FASE 6A — Base desde Holded (primeras semanas)
+
+Holded expone datos de equipo/empleados que ya consumimos (`holdedListEmployees`, `clockin/clockout`). En esta fase los estructuramos como contexto laboral:
+
+```
+Holded Team API → ErpEmployee → IsaakLaborContext
+  - Roster completo de empleados (nombre, contrato, departamento)
+  - Registro de horas (cumplimiento RD 8/2019 — registro horario)
+  - Estimación de coste laboral por empleado (si se añaden campos de salario)
+  - Alertas: contratos que vencen, revisiones salariales pendientes
+```
+
+**Tools Isaak nuevas (FASE 6A):**
+- `holded_labor_summary(tenantId)` → roster + horas del mes + alertas laborales
+- `holded_time_compliance(tenantId)` → ¿cumple el RD 8/2019? Gaps en fichajes
+
+### FASE 6B — Sistema RED (TGSS) · REDirect API
+
+```
+Autenticación:
+  - Certificado digital de empresa (FNMT o equivalente)
+  - Identificador RED (número de autorizado)
+  - Endpoint: https://sede.seg-social.gob.es/ServicioRED/wdsl/...
+
+Operaciones planificadas:
+  GET  /afiliados/{naf}          → consulta afiliado por NAF/NIF
+  GET  /cotizaciones/{periodo}   → TC1/TC2 del periodo
+  POST /liquidaciones/directa    → envío Liquidación Directa (sustitución TC1/TC2)
+  POST /afiliacion/alta          → alta de trabajador (modelo TA.2/S)
+  POST /afiliacion/baja          → baja de trabajador
+  GET  /partes-comunicados       → partes IT/AT comunicados
+  GET  /bases-cotizacion/{naf}   → bases y tipos de cotización
+```
+
+**Flujo de asesoramiento laboral:**
+```
+Usuario: "¿Están al día las cotizaciones de este mes?"
+Isaak:
+  1. Consulta RED: cotizaciones periodo actual
+  2. Cruza con Holded: empleados activos vs afiliados
+  3. Detecta discrepancias (baja médica no comunicada, empleado nuevo sin alta)
+  4. "Tienes 2 incidencias: Julia García no aparece dada de alta en TGSS
+     (la incorporaste el 14/05). ¿La doy de alta ahora?"
+  5. Usuario confirma → POST /afiliacion/alta → confirmación TGSS
+```
+
+**Prerrequisitos técnicos:**
+- Certificado digital empresa (P12) → almacenado cifrado en BD por tenantId
+- Configuración del número de autorizado RED
+- Autorización del usuario vía firma digital o PIN 24H
+
+### FASE 6C — Integración Software Nóminas (A3nom / Sage Nóminas)
+
+Holded no tiene módulo de nóminas completo. Para PYMES con asesoría:
+
+```typescript
+// Interfaz normalizada NóminasConnector
+interface NominasConnector {
+  listPayrolls(period: string): Promise<Payroll[]>;
+  getPayslip(employeeId: string, period: string): Promise<Payslip | null>;
+  exportTc1(period: string): Promise<Buffer>;   // Modelo TC1 / Liquidación Directa
+  exportMod111(year: number, quarter: number): Promise<Buffer>; // IRPF retenciones
+}
+
+// Implementaciones planificadas
+class A3nomConnector implements NominasConnector { ... }  // A3nom vía export XLS
+class SageNominasConnector implements NominasConnector { ... } // Sage vía API REST
+class ManualUploadConnector implements NominasConnector { ... } // CSV/PDF upload
+```
+
+**Casos de uso Isaak:**
+- "¿Cuánto IRPF tengo que ingresar este trimestre?" → suma retenciones nóminas → borrador mod 111
+- "¿Hay alguna nómina con retención por debajo del mínimo?" → auditoría automática
+- "Genera el TC1 de mayo" → export con datos validados → descarga en 1 click
+- "¿Cuánto me cuesta realmente María en términos de coste total empresa?" → salario bruto + SS empresa + bonus prorrateado
+
+### Módulo Advisory RRHH
+
+```
+Convenios colectivos:
+  - Base de datos por CNAE → convenio aplicable
+  - Isaak alerta si el salario está por debajo del SMI o del mínimo del convenio
+  - Revisor de tablas salariales actualizado anualmente
+
+Cálculos laborales:
+  - Liquidación (finiquito) por tipo de despido
+  - Vacaciones pendientes y cost de disfrute vs compensación
+  - Coste de una baja IT para la empresa (vs mutua/TGSS)
+
+Modelos fiscales laborales (borradores):
+  - Modelo 111: retenciones IRPF trimestral
+  - Modelo 180: resumen anual retenciones IRPF trabajo
+  - Modelo 190: declaración informativa anual
+  - TC1 / Liquidación Directa: cotizaciones SS mensuales
+```
+
+### Métricas de éxito Fase 6
+
+- 40% usuarios plan Business conectan Sistema RED
+- 20% reducción en errores de cotización detectados antes de envío
+- €25.000 MRR  
+- Primer convenio con gestoría/asesoría laboral como partner
+
+---
+
 ## Decisiones de arquitectura que no cambian entre fases
 
 1. **El ERP nunca se modifica sin confirmación explícita del usuario**
@@ -391,3 +557,4 @@ Isaak:
 3. **Tool calls transparentes** — el UI muestra qué herramienta está usando Isaak en cada momento
 4. **Caché agresivo** — datos del ERP en Redis para no abusar de las APIs de terceros
 5. **Multi-tenant desde día 1** — el diseño de BD separa datos por `tenantId` desde Fase 1
+6. **Nóminas nunca se modifican sin doble confirmación** — las acciones sobre TGSS (altas/bajas) requieren confirmación explícita y registro de auditoría

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -3,6 +3,7 @@ module.exports = {
     '<rootDir>/apps/app',
     '<rootDir>/apps/api',
     '<rootDir>/apps/holded',
+    '<rootDir>/apps/isaak',
     '<rootDir>/apps/landing',
   ]
 };


### PR DESCRIPTION
## Resumen

### 1. Resiliencia HTTP en los 3 clientes Holded

Todos los clientes directos ahora tienen **timeout + retry con exponential backoff + jitter** uniforme:

| Cliente | Archivo | Antes | Ahora |
|---|---|---|---|
| Isaak | `apps/isaak/app/lib/holded-api.ts` | Sin timeout, backoff sin jitter | `AbortController` 10s, ±50% jitter |
| App (ChatGPT connector) | `apps/app/lib/integrations/accounting.ts` | Timeout pero sin retry | Retry loop en `holdedRequest` + `holdedBinaryRequest` |
| Holded App (Claude connector) | `apps/holded/app/lib/holded-api-client.ts` | Sin retry, sin timeout | Retry loop + `AbortController` 10s en `HoldedClient.request()` |

Patrón: `MAX_RETRIES=2`, `base = 200·2^n ± 50% jitter`, retry en HTTP 429/502/503/504.

### 2. Isaak — 5 nuevas funciones Holded

- **`holdedGetVerifactuStatus`** — extrae UUID/QR/huella del campo `verifactu`/`verifactuData` embebido en la factura
- **`holdedGetPnL`** — P&L sintético desde `/accounting/v1/dailyledger` agregando cuentas PGC (7xx=ingresos, 6xx=gastos)
- **`holdedSendDocument`** — POST a `/documents/{type}/{id}/send` para enviar facturas por email desde Isaak
- **`holdedCreateExpense`** — POST a `/documents/purchase` para el flujo OCR→Holded
- **`holdedListPayments`** — GET `/payments` con ventana de 90 días por defecto
- **`holdedPost`** — helper interno POST con timeout y error handling

### 3. Plan Maestro Isaak actualizado

- **Fase 1.5 nueva** — documenta el trabajo implementado en este PR
- **Fase 6 nueva** — RRHH + Sistema RED (TGSS) + Asesoramiento Laboral (meses 15-20)

## Notas

- Conectores MCP (`apps/holded-mcp`, `apps/holded/app/api/mcp`) **no modificados** — en proceso de submission con OpenAI/Anthropic.

## Test plan

- [ ] `holdedGetVerifactuStatus` — extracción de campos Verifactu en facturas
- [ ] `holdedGetPnL` — agregación PGC 7xx/6xx
- [ ] `holdedSendDocument` — POST correcto al endpoint de envío
- [ ] `holdedCreateExpense` — creación de gasto desde datos OCR
- [ ] Retry logic — HTTP 429 activa backoff en los 3 clientes
- [ ] Timeout — `AbortController` cancela tras 10s