### PR TITLE
feat(isaak): 4 nuevas tools de chat — Verifactu status, P&L dinámico, pagos, envío de documentos

### DIFF
--- a/apps/isaak/app/api/holded/chat/route.ts
+++ b/apps/isaak/app/api/holded/chat/route.ts
@@ -355,6 +355,8 @@ function buildLlmInstructions(input: {
       : 'Si desconoces el régimen fiscal, pregunta si es autónomo o sociedad antes de dar cifras concretas de impuestos.',
     'Si el usuario te pide un resumen, usa cifras concretas, concluye que significa para el negocio y remata con una recomendacion accionable.',
     'Si el usuario pide diagnostico, nombra al menos facturas, contactos y contabilidad aunque alguno falle.',
+    'Herramientas disponibles: puedes usar holded_get_verifactu_status para verificar si una factura tiene UUID Verifactu; holded_get_pnl para obtener el resultado contable actualizado del año; holded_list_payments para ver cobros y pagos; holded_send_document para enviar documentos por email (SIEMPRE pide confirmación explícita antes de enviar).',
+    'Para holded_send_document: muestra primero un resumen claro (destinatario, documento, asunto) y espera que el usuario responda "sí", "confirmar" o similar antes de ejecutar la tool con confirmed=true.',
     input.workspaceSignalsBlock
       ? `Estado del workspace:\n${input.workspaceSignalsBlock}`
       : 'Estado del workspace: no disponible.',

--- a/apps/isaak/app/lib/holded-tools.ts
+++ b/apps/isaak/app/lib/holded-tools.ts
@@ -3,15 +3,19 @@ import {
   holdedGetContact,
   holdedGetDocument,
   holdedGetJournal,
+  holdedGetPnL,
+  holdedGetVerifactuStatus,
   holdedListContacts,
   holdedListDocuments,
   holdedListEmployees,
+  holdedListPayments,
   holdedListProducts,
   holdedListProjects,
   holdedListTreasuryAccounts,
+  holdedSendDocument,
 } from './holded-api';
 
-// Anthropic tool definitions for Isaak chat — 10 read tools
+// Anthropic tool definitions for Isaak chat — 14 tools (10 lectura + 4 nuevas)
 export const HOLDED_CHAT_TOOLS = [
   {
     name: 'holded_list_documents',
@@ -131,6 +135,103 @@ export const HOLDED_CHAT_TOOLS = [
     description: 'Lista los empleados del equipo en Holded.',
     input_schema: { type: 'object', properties: {} },
   },
+  {
+    name: 'holded_get_verifactu_status',
+    description:
+      'Consulta el estado Verifactu de una factura de venta concreta: si tiene UUID registrado en la AEAT, el QR y la huella (hash). Úsalo cuando el usuario pregunte si una factura específica está registrada en Verifactu o si cumple con el RD 1007/2023.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        invoiceId: {
+          type: 'string',
+          description: 'ID de la factura en Holded.',
+        },
+      },
+      required: ['invoiceId'],
+    },
+  },
+  {
+    name: 'holded_get_pnl',
+    description:
+      'Calcula el P&L contable del año (o rango indicado) desde el libro diario de Holded, agregando cuentas PGC 7xx (ingresos) y 6xx (gastos). Más fiable que el escaneo de documentos porque incluye asientos manuales. Úsalo cuando el usuario pregunte por beneficio, margen, resultado contable o PyG.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        year: {
+          type: 'number',
+          description: 'Año a consultar. Por defecto el año actual.',
+        },
+        starttmp: {
+          type: 'string',
+          description: 'Fecha inicio ISO 8601 o Unix (alternativa a year).',
+        },
+        endtmp: {
+          type: 'string',
+          description: 'Fecha fin ISO 8601 o Unix (alternativa a year).',
+        },
+      },
+    },
+  },
+  {
+    name: 'holded_list_payments',
+    description:
+      'Lista los pagos registrados en Holded (cobros y pagos). Úsalo para responder preguntas sobre flujo de caja, historial de cobros o pagos pendientes.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        starttmp: {
+          type: 'string',
+          description: 'Fecha inicio ISO 8601 o Unix. Por defecto: últimos 90 días.',
+        },
+        endtmp: {
+          type: 'string',
+          description: 'Fecha fin ISO 8601 o Unix. Por defecto: hoy.',
+        },
+        limit: {
+          type: 'number',
+          description: 'Máximo de pagos a devolver (default 50).',
+        },
+      },
+    },
+  },
+  {
+    name: 'holded_send_document',
+    description:
+      'Envía un documento de Holded (factura, presupuesto, etc.) por email al destinatario indicado. IMPORTANTE: antes de ejecutar esta acción, confirma siempre con el usuario los datos (destinatario, documento) y espera su aprobación explícita.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        docType: {
+          type: 'string',
+          enum: ['invoice', 'salesreceipt', 'creditnote', 'estimate', 'proforma', 'purchase'],
+          description: 'Tipo de documento.',
+        },
+        documentId: {
+          type: 'string',
+          description: 'ID del documento en Holded.',
+        },
+        emails: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Lista de emails destinatarios.',
+        },
+        subject: {
+          type: 'string',
+          description: 'Asunto del email (opcional).',
+        },
+        body: {
+          type: 'string',
+          description: 'Cuerpo del email (opcional).',
+        },
+        confirmed: {
+          type: 'boolean',
+          description:
+            'Debe ser true. Solo llama a esta herramienta cuando el usuario haya confirmado explícitamente el envío.',
+        },
+      },
+      required: ['docType', 'documentId', 'emails', 'confirmed'],
+    },
+  },
 ] as const;
 
 export type HoldedToolName = (typeof HOLDED_CHAT_TOOLS)[number]['name'];
@@ -182,6 +283,40 @@ export async function executeHoldedTool(
         return await holdedListProjects(apiKey);
       case 'holded_list_employees':
         return await holdedListEmployees(apiKey);
+      case 'holded_get_verifactu_status':
+        return await holdedGetVerifactuStatus(apiKey, String(input.invoiceId ?? ''));
+      case 'holded_get_pnl':
+        return await holdedGetPnL(apiKey, {
+          year: typeof input.year === 'number' ? input.year : undefined,
+          starttmp: input.starttmp ? String(input.starttmp) : undefined,
+          endtmp: input.endtmp ? String(input.endtmp) : undefined,
+        });
+      case 'holded_list_payments':
+        return await holdedListPayments(apiKey, {
+          starttmp: input.starttmp ? String(input.starttmp) : undefined,
+          endtmp: input.endtmp ? String(input.endtmp) : undefined,
+          limit: typeof input.limit === 'number' ? Math.min(input.limit, 100) : 50,
+        });
+      case 'holded_send_document': {
+        if (!input.confirmed) {
+          return {
+            error: 'confirmation_required',
+            message:
+              'Esta acción requiere confirmación explícita del usuario. Muestra el resumen del envío y pide que confirme antes de proceder.',
+          };
+        }
+        const emails = Array.isArray(input.emails)
+          ? (input.emails as unknown[]).filter((e): e is string => typeof e === 'string')
+          : [];
+        if (emails.length === 0) {
+          return { error: 'invalid_input', message: 'Se requiere al menos un email destinatario.' };
+        }
+        return await holdedSendDocument(apiKey, String(input.docType ?? 'invoice'), String(input.documentId ?? ''), {
+          emails,
+          subject: typeof input.subject === 'string' ? input.subject : undefined,
+          body: typeof input.body === 'string' ? input.body : undefined,
+        });
+      }
       default:
         return { error: 'unknown_tool' };
     }


### PR DESCRIPTION
## Resumen

Amplía el arsenal de herramientas de Isaak de 10 a 14, añadiendo las funciones implementadas en el PR anterior al loop de tool_use del chat.

### Nuevas tools de lectura

- **`holded_get_verifactu_status`** — Responde «¿está registrada en Verifactu la factura F-2024-001?» con UUID, QR y huella directamente desde Holded.
- **`holded_get_pnl`** — P&L contable actualizado desde el libro diario (cuentas PGC 7xx/6xx). Más fiable que el escaneo de documentos; soporta `year`, `starttmp`, `endtmp`.
- **`holded_list_payments`** — Cobros y pagos de los últimos 90 días (configurable); responde preguntas de flujo de caja.

### Nueva tool de escritura con confirmación

- **`holded_send_document`** — Envía cualquier documento Holded por email. Tiene guardia `confirmed: boolean`: si el modelo llama sin `confirmed=true`, devuelve `confirmation_required` y no ejecuta el envío. El system prompt instruye a Isaak a presentar siempre el resumen (destinatario, documento, asunto) y esperar confirmación explícita antes de proceder.

### System prompt

Se añaden dos líneas de instrucción sobre cuándo usar cada herramienta nueva y el flujo de doble confirmación para `holded_send_document`.

## Test plan

- [ ] Preguntar «¿tiene UUID Verifactu la factura [ID]?» → Isaak llama `holded_get_verifactu_status` y responde con estado
- [ ] Preguntar «¿cuál es el resultado contable de este año?» → Isaak llama `holded_get_pnl` y presenta ingresos/gastos/margen
- [ ] Preguntar «muéstrame los cobros del mes» → Isaak llama `holded_list_payments`
- [ ] Pedir «envía la factura X a cliente@empresa.com» → Isaak presenta resumen y pide confirmación; solo envía tras «sí»
- [ ] Intentar enviar sin confirmar → Isaak recibe `confirmation_required` y vuelve a pedir confirmación