### PR TITLE
feat(isaak): Fase 3 — Chift multi-ERP chat tools

### DIFF
--- a/apps/isaak/app/api/holded/chat/route.ts
+++ b/apps/isaak/app/api/holded/chat/route.ts
@@ -37,6 +37,11 @@ import {
   executeMicrosoftTool,
   isMicrosoftToolName,
 } from '@/app/lib/microsoft-tools';
+import {
+  CHIFT_CHAT_TOOLS,
+  executeChiftTool,
+  isChiftToolName,
+} from '@/app/lib/chift-tools';
 
 export const runtime = 'nodejs';
 
@@ -269,6 +274,7 @@ function buildLlmInstructions(input: {
   workspaceSignalsBlock: string | null;
   aeatBlock?: string | null;
   advisorBanner?: string | null;
+  chiftLine?: string | null;
   recentFacts?: { category: string; factKey: string; valueJson: unknown }[];
   fewShotExamples?: { question: string; response: string }[];
 }) {
@@ -357,6 +363,9 @@ function buildLlmInstructions(input: {
     'Si el usuario pide diagnostico, nombra al menos facturas, contactos y contabilidad aunque alguno falle.',
     'Herramientas disponibles: puedes usar holded_get_verifactu_status para verificar si una factura tiene UUID Verifactu; holded_get_pnl para obtener el resultado contable actualizado del año; holded_list_payments para ver cobros y pagos; holded_send_document para enviar documentos por email (SIEMPRE pide confirmación explícita antes de enviar).',
     'Para holded_send_document: muestra primero un resumen claro (destinatario, documento, asunto) y espera que el usuario responda "sí", "confirmar" o similar antes de ejecutar la tool con confirmed=true.',
+    input.chiftLine
+      ? `ERP adicional vía Chift: ${input.chiftLine} Herramientas disponibles: chift_check_connection, chift_list_invoices, chift_get_invoice, chift_list_contacts, chift_get_pnl.`
+      : 'ERP adicional vía Chift: no conectado.',
     input.workspaceSignalsBlock
       ? `Estado del workspace:\n${input.workspaceSignalsBlock}`
       : 'Estado del workspace: no disponible.',
@@ -432,6 +441,7 @@ async function buildLlmReply(input: {
   workspaceSignalsBlock: string | null;
   aeatBlock?: string | null;
   advisorBanner?: string | null;
+  chiftLine?: string | null;
   modelConfig?: HoldedChatModelConfig;
   memoryContext?: MemoryContext | null;
   fewShotExamples?: { question: string; response: string }[];
@@ -454,6 +464,7 @@ async function buildLlmReply(input: {
         workspaceSignalsBlock: input.workspaceSignalsBlock,
         aeatBlock: input.aeatBlock,
         advisorBanner: input.advisorBanner,
+        chiftLine: input.chiftLine,
         recentFacts: input.memoryContext?.recentFacts ?? [],
         fewShotExamples: input.fewShotExamples ?? [],
       }),
@@ -698,6 +709,7 @@ async function buildLlmReplyWithTools(input: {
   model: string;
   tenantId: string;
   userId: string;
+  chiftConnected?: boolean;
 }): Promise<string | null> {
   const MAX_ITERATIONS = 6;
 
@@ -719,7 +731,12 @@ async function buildLlmReplyWithTools(input: {
         max_tokens: 1024,
         system: input.systemPrompt,
         messages,
-        tools: [...HOLDED_CHAT_TOOLS, ...GOOGLE_CHAT_TOOLS, ...MICROSOFT_CHAT_TOOLS],
+        tools: [
+          ...HOLDED_CHAT_TOOLS,
+          ...GOOGLE_CHAT_TOOLS,
+          ...MICROSOFT_CHAT_TOOLS,
+          ...(input.chiftConnected ? CHIFT_CHAT_TOOLS : []),
+        ],
         tool_choice: { type: 'auto' },
       }),
     });
@@ -750,15 +767,17 @@ async function buildLlmReplyWithTools(input: {
     // Execute each tool call and collect results
     const toolResults: AnthropicContent[] = await Promise.all(
       toolUseBlocks.map(async (block) => {
-        const result = isGoogleToolName(block.name)
-          ? await executeGoogleTool(input.tenantId, input.userId, block.name, block.input)
-          : isMicrosoftToolName(block.name)
-            ? await executeMicrosoftTool(input.tenantId, input.userId, block.name, block.input)
-            : await executeHoldedTool(
-                input.holdedApiKey,
-                block.name as HoldedToolName,
-                block.input
-              );
+        const result = isChiftToolName(block.name)
+          ? await executeChiftTool(input.tenantId, block.name, block.input)
+          : isGoogleToolName(block.name)
+            ? await executeGoogleTool(input.tenantId, input.userId, block.name, block.input)
+            : isMicrosoftToolName(block.name)
+              ? await executeMicrosoftTool(input.tenantId, input.userId, block.name, block.input)
+              : await executeHoldedTool(
+                  input.holdedApiKey,
+                  block.name as HoldedToolName,
+                  block.input
+                );
         return {
           type: 'tool_result' as const,
           tool_use_id: block.id,
@@ -1187,7 +1206,7 @@ export async function POST(request: NextRequest) {
       aeatBlock = [certLine, notifLine].filter(Boolean).join('\n');
     }
 
-    const [memoryContext, fewShotExamples] = await Promise.all([
+    const [memoryContext, fewShotExamples, chiftConn] = await Promise.all([
       conversation
         ? getSimpleMemoryContext(
             { tenantId: session.tenantId, userId: session.userId },
@@ -1195,7 +1214,23 @@ export async function POST(request: NextRequest) {
           ).catch(() => null)
         : Promise.resolve(null),
       getTenantFewShotExamples(session.tenantId).catch(() => []),
+      prisma.externalConnection
+        .findFirst({
+          where: {
+            tenantId: session.tenantId,
+            provider: 'chift',
+            connectionStatus: 'connected',
+          },
+          select: { providerAccountId: true, companyIdentityJson: true },
+        })
+        .catch(() => null),
     ]);
+
+    const chiftConnected = Boolean(chiftConn?.providerAccountId);
+    const chiftIdentity = chiftConn?.companyIdentityJson as Record<string, unknown> | null;
+    const chiftLine = chiftConnected
+      ? `Conectado${chiftIdentity?.name ? ` a ${String(chiftIdentity.name)}` : ''}${chiftIdentity?.currency ? ` (${String(chiftIdentity.currency)})` : ''}.`
+      : null;
 
     try {
       const anthropicApiKey =
@@ -1207,6 +1242,7 @@ export async function POST(request: NextRequest) {
         workspaceSignalsBlock,
         aeatBlock,
         advisorBanner,
+        chiftLine,
         recentFacts: memoryContext?.recentFacts ?? [],
         fewShotExamples: fewShotExamples ?? [],
       });
@@ -1225,6 +1261,7 @@ export async function POST(request: NextRequest) {
             model: modelConfig?.model ?? 'claude-haiku-4-5-20251001',
             tenantId: session.tenantId,
             userId: session.userId,
+            chiftConnected,
           }).catch((error) => {
             console.warn('[holded/chat] tool loop failed, falling back', {
               tenantId: session.tenantId,
@@ -1240,6 +1277,7 @@ export async function POST(request: NextRequest) {
             workspaceSignalsBlock,
             aeatBlock,
             advisorBanner,
+            chiftLine,
             modelConfig,
             memoryContext,
             fewShotExamples,

--- a/apps/isaak/app/lib/chift-tools.ts
+++ b/apps/isaak/app/lib/chift-tools.ts
@@ -1,0 +1,219 @@
+import { prisma } from '@/app/lib/prisma';
+import { ChiftErpClient } from './chift-erp-client';
+
+export const CHIFT_CHAT_TOOLS = [
+  {
+    name: 'chift_check_connection',
+    description:
+      'Comprueba si el usuario tiene un ERP conectado vía Chift (Sage, Xero, QuickBooks, Cegid u otros). Úsalo cuando el usuario pregunte sobre su ERP o antes de intentar usar otras herramientas de Chift si no estás seguro de si está conectado.',
+    input_schema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'chift_list_invoices',
+    description:
+      'Lista facturas de venta o de compra desde el ERP conectado vía Chift. Úsalo cuando el usuario pregunte por facturas, ventas o gastos en su ERP (Sage, Xero, QuickBooks, etc.).',
+    input_schema: {
+      type: 'object',
+      properties: {
+        type: {
+          type: 'string',
+          enum: ['invoice', 'purchase'],
+          description: 'Tipo de documento. invoice=factura de venta, purchase=factura de compra.',
+        },
+        from: { type: 'string', description: 'Fecha inicio YYYY-MM-DD.' },
+        to: { type: 'string', description: 'Fecha fin YYYY-MM-DD.' },
+        limit: { type: 'number', description: 'Máximo de facturas a devolver (default 50, max 100).' },
+      },
+    },
+  },
+  {
+    name: 'chift_get_invoice',
+    description: 'Obtiene el detalle completo (líneas, impuestos, contacto) de una factura del ERP conectado vía Chift.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        invoiceId: { type: 'string', description: 'ID de la factura en el ERP.' },
+        type: {
+          type: 'string',
+          enum: ['invoice', 'purchase'],
+          description: 'Tipo de factura (default: invoice).',
+        },
+      },
+      required: ['invoiceId'],
+    },
+  },
+  {
+    name: 'chift_list_contacts',
+    description: 'Lista clientes y proveedores desde el ERP conectado vía Chift.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        limit: { type: 'number', description: 'Máximo de contactos a devolver (default 50).' },
+      },
+    },
+  },
+  {
+    name: 'chift_get_pnl',
+    description:
+      'Calcula el P&L (ingresos, gastos, resultado bruto) del ERP conectado a partir de sus asientos contables. Úsalo cuando el usuario pregunte por beneficio, margen o resultado contable y tenga un ERP distinto de Holded.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        from: {
+          type: 'string',
+          description: 'Fecha inicio YYYY-MM-DD. Por defecto: 1 enero del año actual.',
+        },
+        to: {
+          type: 'string',
+          description: 'Fecha fin YYYY-MM-DD. Por defecto: hoy.',
+        },
+      },
+    },
+  },
+] as const;
+
+export type ChiftToolName = (typeof CHIFT_CHAT_TOOLS)[number]['name'];
+
+const CHIFT_TOOL_NAMES = new Set<string>(CHIFT_CHAT_TOOLS.map((t) => t.name));
+export function isChiftToolName(name: string): name is ChiftToolName {
+  return CHIFT_TOOL_NAMES.has(name);
+}
+
+type ToolInput = Record<string, unknown>;
+
+async function getChiftConsumerId(tenantId: string): Promise<string | null> {
+  const conn = await prisma.externalConnection
+    .findFirst({
+      where: { tenantId, provider: 'chift', connectionStatus: { not: 'disconnected' } },
+      select: { providerAccountId: true },
+    })
+    .catch(() => null);
+  return conn?.providerAccountId ?? null;
+}
+
+export async function executeChiftTool(
+  tenantId: string,
+  toolName: ChiftToolName,
+  input: ToolInput
+): Promise<unknown> {
+  try {
+    if (toolName === 'chift_check_connection') {
+      const conn = await prisma.externalConnection
+        .findFirst({
+          where: { tenantId, provider: 'chift', connectionStatus: { not: 'disconnected' } },
+          select: {
+            connectionStatus: true,
+            providerAccountId: true,
+            companyIdentityJson: true,
+            connectedAt: true,
+          },
+        })
+        .catch(() => null);
+      if (!conn?.providerAccountId) {
+        return {
+          connected: false,
+          message:
+            'No hay ningún ERP conectado vía Chift. El usuario puede conectar desde Workspace > Conectores.',
+        };
+      }
+      const identity = conn.companyIdentityJson as Record<string, unknown> | null;
+      return {
+        connected: true,
+        status: conn.connectionStatus,
+        companyName: identity?.name ?? null,
+        companyVat: identity?.vat ?? null,
+        currency: identity?.currency ?? null,
+        connectedAt: conn.connectedAt?.toISOString() ?? null,
+      };
+    }
+
+    const consumerId = await getChiftConsumerId(tenantId);
+    if (!consumerId) {
+      return { error: 'not_connected', message: 'No hay ningún ERP conectado vía Chift.' };
+    }
+
+    const client = new ChiftErpClient(consumerId);
+
+    switch (toolName) {
+      case 'chift_list_invoices': {
+        const invoices = await client.listInvoices({
+          type: input.type === 'purchase' ? 'purchase' : 'invoice',
+          from: input.from ? String(input.from) : undefined,
+          to: input.to ? String(input.to) : undefined,
+          limit: typeof input.limit === 'number' ? Math.min(input.limit, 100) : 50,
+        });
+        return { invoices: invoices.slice(0, 50), count: invoices.length };
+      }
+
+      case 'chift_get_invoice': {
+        const invoiceId = String(input.invoiceId ?? '');
+        if (!invoiceId) return { error: 'missing_invoice_id' };
+        const inv = await client.getInvoice(
+          invoiceId,
+          input.type === 'purchase' ? 'purchase' : 'invoice'
+        );
+        return inv ?? { error: 'not_found' };
+      }
+
+      case 'chift_list_contacts': {
+        const contacts = await client.listContacts();
+        const limit = typeof input.limit === 'number' ? Math.min(input.limit, 100) : 50;
+        return { contacts: contacts.slice(0, limit), count: contacts.length };
+      }
+
+      case 'chift_get_pnl': {
+        const now = new Date();
+        const from = input.from ? String(input.from) : `${now.getFullYear()}-01-01`;
+        const to = input.to ? String(input.to) : now.toISOString().slice(0, 10);
+
+        const entries = await client.listAccountEntries({ from, to });
+
+        let income = 0;
+        let expenses = 0;
+
+        for (const e of entries) {
+          const acc = e.account.toLowerCase();
+          // PGC Spanish: 7xx = income, 6xx = expense.
+          // English fallback: common keywords for international ERPs.
+          const isIncome =
+            /^7/.test(e.account) ||
+            acc.includes('sales') ||
+            acc.includes('revenue') ||
+            acc.includes('income') ||
+            acc.includes('ingreso') ||
+            acc.includes('venta');
+          const isExpense =
+            /^6/.test(e.account) ||
+            acc.includes('cost') ||
+            acc.includes('expense') ||
+            acc.includes('gasto') ||
+            acc.includes('compra') ||
+            acc.includes('purchase');
+
+          if (isIncome) income += e.credit - e.debit;
+          if (isExpense) expenses += Math.abs(e.debit - e.credit);
+        }
+
+        const grossProfit = income - expenses;
+        const margin = income > 0 ? Math.round((grossProfit / income) * 10000) / 100 : null;
+
+        return {
+          period: { from, to },
+          income: Math.round(income * 100) / 100,
+          expenses: Math.round(expenses * 100) / 100,
+          grossProfit: Math.round(grossProfit * 100) / 100,
+          margin,
+          entriesProcessed: entries.length,
+        };
+      }
+
+      default:
+        return { error: 'unknown_tool' };
+    }
+  } catch (err) {
+    return {
+      error: 'tool_execution_failed',
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `chift-tools.ts` with 5 Isaak chat tools covering any ERP connected via Chift (Sage, Xero, QuickBooks, Cegid, Odoo and 40+ more)
- **`chift_check_connection`** — ERP connection status and company info
- **`chift_list_invoices`** — Sales/purchase invoices with date filters
- **`chift_get_invoice`** — Full invoice detail (lines, taxes, contact)
- **`chift_list_contacts`** — Clients and suppliers list
- **`chift_get_pnl`** — P&L from journal entries using PGC 6xx/7xx account codes + English keyword fallback for international ERPs (Xero, QuickBooks, etc.)

Wiring in `/api/holded/chat`:
- Chift tools conditionally added to the Anthropic tools array (only when tenant has an active Chift connection — zero payload overhead for non-Chift users)
- `chift_*` calls dispatched to `executeChiftTool(tenantId, ...)` in the tool-use loop, before Google/Microsoft/Holded routing
- Chift connection info injected into the system prompt so Isaak knows a second ERP is available

## Test plan

- [ ] Connect a test Chift ERP and ask "¿cuánto he facturado este mes?" → Isaak calls `chift_list_invoices` and returns invoice data
- [ ] Ask "¿cuál es mi beneficio este año?" with Chift → calls `chift_get_pnl`, returns income/expenses/margin
- [ ] Ask "¿quiénes son mis clientes?" → calls `chift_list_contacts`
- [ ] Without Chift connection → `chift_check_connection` returns `connected: false`
- [ ] Tenant with only Holded (no Chift) → Chift tools NOT included in Anthropic request (verified via logs)
- [ ] TypeScript compiles cleanly (0 new errors)

https://claude.ai/code/session_01XEgA9ynYQxzRUipm4CeXpq