### PR TITLE
feat(isaak): banking open-banking chat tools (Salt Edge)

### DIFF
--- a/apps/isaak/app/api/holded/chat/route.ts
+++ b/apps/isaak/app/api/holded/chat/route.ts
@@ -37,6 +37,11 @@ import {
   executeMicrosoftTool,
   isMicrosoftToolName,
 } from '@/app/lib/microsoft-tools';
+import {
+  CHIFT_CHAT_TOOLS,
+  executeChiftTool,
+  isChiftToolName,
+} from '@/app/lib/chift-tools';
 
 export const runtime = 'nodejs';
 
@@ -269,6 +274,7 @@ function buildLlmInstructions(input: {
   workspaceSignalsBlock: string | null;
   aeatBlock?: string | null;
   advisorBanner?: string | null;
+  chiftLine?: string | null;
   recentFacts?: { category: string; factKey: string; valueJson: unknown }[];
   fewShotExamples?: { question: string; response: string }[];
 }) {
@@ -357,6 +363,9 @@ function buildLlmInstructions(input: {
     'Si el usuario pide diagnostico, nombra al menos facturas, contactos y contabilidad aunque alguno falle.',
     'Herramientas disponibles: puedes usar holded_get_verifactu_status para verificar si una factura tiene UUID Verifactu; holded_get_pnl para obtener el resultado contable actualizado del año; holded_list_payments para ver cobros y pagos; holded_send_document para enviar documentos por email (SIEMPRE pide confirmación explícita antes de enviar).',
     'Para holded_send_document: muestra primero un resumen claro (destinatario, documento, asunto) y espera que el usuario responda "sí", "confirmar" o similar antes de ejecutar la tool con confirmed=true.',
+    input.chiftLine
+      ? `ERP adicional vía Chift: ${input.chiftLine} Herramientas disponibles: chift_check_connection, chift_list_invoices, chift_get_invoice, chift_list_contacts, chift_get_pnl.`
+      : 'ERP adicional vía Chift: no conectado.',
     input.workspaceSignalsBlock
       ? `Estado del workspace:\n${input.workspaceSignalsBlock}`
       : 'Estado del workspace: no disponible.',
@@ -432,6 +441,7 @@ async function buildLlmReply(input: {
   workspaceSignalsBlock: string | null;
   aeatBlock?: string | null;
   advisorBanner?: string | null;
+  chiftLine?: string | null;
   modelConfig?: HoldedChatModelConfig;
   memoryContext?: MemoryContext | null;
   fewShotExamples?: { question: string; response: string }[];
@@ -454,6 +464,7 @@ async function buildLlmReply(input: {
         workspaceSignalsBlock: input.workspaceSignalsBlock,
         aeatBlock: input.aeatBlock,
         advisorBanner: input.advisorBanner,
+        chiftLine: input.chiftLine,
         recentFacts: input.memoryContext?.recentFacts ?? [],
         fewShotExamples: input.fewShotExamples ?? [],
       }),
@@ -698,6 +709,7 @@ async function buildLlmReplyWithTools(input: {
   model: string;
   tenantId: string;
   userId: string;
+  chiftConnected?: boolean;
 }): Promise<string | null> {
   const MAX_ITERATIONS = 6;
 
@@ -719,7 +731,12 @@ async function buildLlmReplyWithTools(input: {
         max_tokens: 1024,
         system: input.systemPrompt,
         messages,
-        tools: [...HOLDED_CHAT_TOOLS, ...GOOGLE_CHAT_TOOLS, ...MICROSOFT_CHAT_TOOLS],
+        tools: [
+          ...HOLDED_CHAT_TOOLS,
+          ...GOOGLE_CHAT_TOOLS,
+          ...MICROSOFT_CHAT_TOOLS,
+          ...(input.chiftConnected ? CHIFT_CHAT_TOOLS : []),
+        ],
         tool_choice: { type: 'auto' },
       }),
     });
@@ -750,15 +767,17 @@ async function buildLlmReplyWithTools(input: {
     // Execute each tool call and collect results
     const toolResults: AnthropicContent[] = await Promise.all(
       toolUseBlocks.map(async (block) => {
-        const result = isGoogleToolName(block.name)
-          ? await executeGoogleTool(input.tenantId, input.userId, block.name, block.input)
-          : isMicrosoftToolName(block.name)
-            ? await executeMicrosoftTool(input.tenantId, input.userId, block.name, block.input)
-            : await executeHoldedTool(
-                input.holdedApiKey,
-                block.name as HoldedToolName,
-                block.input
-              );
+        const result = isChiftToolName(block.name)
+          ? await executeChiftTool(input.tenantId, block.name, block.input)
+          : isGoogleToolName(block.name)
+            ? await executeGoogleTool(input.tenantId, input.userId, block.name, block.input)
+            : isMicrosoftToolName(block.name)
+              ? await executeMicrosoftTool(input.tenantId, input.userId, block.name, block.input)
+              : await executeHoldedTool(
+                  input.holdedApiKey,
+                  block.name as HoldedToolName,
+                  block.input
+                );
         return {
           type: 'tool_result' as const,
           tool_use_id: block.id,
@@ -1187,7 +1206,7 @@ export async function POST(request: NextRequest) {
       aeatBlock = [certLine, notifLine].filter(Boolean).join('\n');
     }
 
-    const [memoryContext, fewShotExamples] = await Promise.all([
+    const [memoryContext, fewShotExamples, chiftConn] = await Promise.all([
       conversation
         ? getSimpleMemoryContext(
             { tenantId: session.tenantId, userId: session.userId },
@@ -1195,7 +1214,23 @@ export async function POST(request: NextRequest) {
           ).catch(() => null)
         : Promise.resolve(null),
       getTenantFewShotExamples(session.tenantId).catch(() => []),
+      prisma.externalConnection
+        .findFirst({
+          where: {
+            tenantId: session.tenantId,
+            provider: 'chift',
+            connectionStatus: 'connected',
+          },
+          select: { providerAccountId: true, companyIdentityJson: true },
+        })
+        .catch(() => null),
     ]);
+
+    const chiftConnected = Boolean(chiftConn?.providerAccountId);
+    const chiftIdentity = chiftConn?.companyIdentityJson as Record<string, unknown> | null;
+    const chiftLine = chiftConnected
+      ? `Conectado${chiftIdentity?.name ? ` a ${String(chiftIdentity.name)}` : ''}${chiftIdentity?.currency ? ` (${String(chiftIdentity.currency)})` : ''}.`
+      : null;
 
     try {
       const anthropicApiKey =
@@ -1207,6 +1242,7 @@ export async function POST(request: NextRequest) {
         workspaceSignalsBlock,
         aeatBlock,
         advisorBanner,
+        chiftLine,
         recentFacts: memoryContext?.recentFacts ?? [],
         fewShotExamples: fewShotExamples ?? [],
       });
@@ -1225,6 +1261,7 @@ export async function POST(request: NextRequest) {
             model: modelConfig?.model ?? 'claude-haiku-4-5-20251001',
             tenantId: session.tenantId,
             userId: session.userId,
+            chiftConnected,
           }).catch((error) => {
             console.warn('[holded/chat] tool loop failed, falling back', {
               tenantId: session.tenantId,
@@ -1240,6 +1277,7 @@ export async function POST(request: NextRequest) {
             workspaceSignalsBlock,
             aeatBlock,
             advisorBanner,
+            chiftLine,
             modelConfig,
             memoryContext,
             fewShotExamples,

--- a/apps/isaak/app/api/holded/chat/route.ts
+++ b/apps/isaak/app/api/holded/chat/route.ts
@@ -42,6 +42,11 @@ import {
   executeChiftTool,
   isChiftToolName,
 } from '@/app/lib/chift-tools';
+import {
+  BANKING_CHAT_TOOLS,
+  executeBankingTool,
+  isBankingToolName,
+} from '@/app/lib/banking-tools';
 
 export const runtime = 'nodejs';
 
@@ -275,6 +280,7 @@ function buildLlmInstructions(input: {
   aeatBlock?: string | null;
   advisorBanner?: string | null;
   chiftLine?: string | null;
+  bankingLine?: string | null;
   recentFacts?: { category: string; factKey: string; valueJson: unknown }[];
   fewShotExamples?: { question: string; response: string }[];
 }) {
@@ -366,6 +372,9 @@ function buildLlmInstructions(input: {
     input.chiftLine
       ? `ERP adicional vía Chift: ${input.chiftLine} Herramientas disponibles: chift_check_connection, chift_list_invoices, chift_get_invoice, chift_list_contacts, chift_get_pnl.`
       : 'ERP adicional vía Chift: no conectado.',
+    input.bankingLine
+      ? `Banca abierta: ${input.bankingLine} Herramientas disponibles: banking_list_accounts (saldos reales), banking_list_transactions (movimientos), banking_get_cash_summary (flujo de caja). Prioriza estos datos de banco sobre los de Holded cuando el usuario pregunte por su saldo real o liquidez.`
+      : 'Banca abierta: no conectada.',
     input.workspaceSignalsBlock
       ? `Estado del workspace:\n${input.workspaceSignalsBlock}`
       : 'Estado del workspace: no disponible.',
@@ -442,6 +451,7 @@ async function buildLlmReply(input: {
   aeatBlock?: string | null;
   advisorBanner?: string | null;
   chiftLine?: string | null;
+  bankingLine?: string | null;
   modelConfig?: HoldedChatModelConfig;
   memoryContext?: MemoryContext | null;
   fewShotExamples?: { question: string; response: string }[];
@@ -465,6 +475,7 @@ async function buildLlmReply(input: {
         aeatBlock: input.aeatBlock,
         advisorBanner: input.advisorBanner,
         chiftLine: input.chiftLine,
+        bankingLine: input.bankingLine,
         recentFacts: input.memoryContext?.recentFacts ?? [],
         fewShotExamples: input.fewShotExamples ?? [],
       }),
@@ -710,6 +721,7 @@ async function buildLlmReplyWithTools(input: {
   tenantId: string;
   userId: string;
   chiftConnected?: boolean;
+  bankingConnected?: boolean;
 }): Promise<string | null> {
   const MAX_ITERATIONS = 6;
 
@@ -736,6 +748,7 @@ async function buildLlmReplyWithTools(input: {
           ...GOOGLE_CHAT_TOOLS,
           ...MICROSOFT_CHAT_TOOLS,
           ...(input.chiftConnected ? CHIFT_CHAT_TOOLS : []),
+          ...(input.bankingConnected ? BANKING_CHAT_TOOLS : []),
         ],
         tool_choice: { type: 'auto' },
       }),
@@ -767,7 +780,9 @@ async function buildLlmReplyWithTools(input: {
     // Execute each tool call and collect results
     const toolResults: AnthropicContent[] = await Promise.all(
       toolUseBlocks.map(async (block) => {
-        const result = isChiftToolName(block.name)
+        const result = isBankingToolName(block.name)
+          ? await executeBankingTool(input.tenantId, block.name, block.input)
+          : isChiftToolName(block.name)
           ? await executeChiftTool(input.tenantId, block.name, block.input)
           : isGoogleToolName(block.name)
             ? await executeGoogleTool(input.tenantId, input.userId, block.name, block.input)
@@ -1206,7 +1221,7 @@ export async function POST(request: NextRequest) {
       aeatBlock = [certLine, notifLine].filter(Boolean).join('\n');
     }
 
-    const [memoryContext, fewShotExamples, chiftConn] = await Promise.all([
+    const [memoryContext, fewShotExamples, chiftConn, bankingAccounts] = await Promise.all([
       conversation
         ? getSimpleMemoryContext(
             { tenantId: session.tenantId, userId: session.userId },
@@ -1224,12 +1239,26 @@ export async function POST(request: NextRequest) {
           select: { providerAccountId: true, companyIdentityJson: true },
         })
         .catch(() => null),
+      prisma.seAccount
+        .findMany({
+          where: { tenantId: session.tenantId, status: 'active' },
+          select: { balance: true, currency: true, name: true },
+        })
+        .catch(() => [] as { balance: number; currency: string; name: string }[]),
     ]);
 
     const chiftConnected = Boolean(chiftConn?.providerAccountId);
     const chiftIdentity = chiftConn?.companyIdentityJson as Record<string, unknown> | null;
     const chiftLine = chiftConnected
       ? `Conectado${chiftIdentity?.name ? ` a ${String(chiftIdentity.name)}` : ''}${chiftIdentity?.currency ? ` (${String(chiftIdentity.currency)})` : ''}.`
+      : null;
+
+    const bankingConnected = bankingAccounts.length > 0;
+    const bankingTotalBalance = Math.round(
+      bankingAccounts.reduce((s, a) => s + Number(a.balance), 0) * 100
+    ) / 100;
+    const bankingLine = bankingConnected
+      ? `${bankingAccounts.length} cuenta${bankingAccounts.length > 1 ? 's' : ''} bancaria${bankingAccounts.length > 1 ? 's' : ''} conectada${bankingAccounts.length > 1 ? 's' : ''}. Saldo total actual: ${bankingTotalBalance.toLocaleString('es-ES', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} EUR.`
       : null;
 
     try {
@@ -1243,6 +1272,7 @@ export async function POST(request: NextRequest) {
         aeatBlock,
         advisorBanner,
         chiftLine,
+        bankingLine,
         recentFacts: memoryContext?.recentFacts ?? [],
         fewShotExamples: fewShotExamples ?? [],
       });
@@ -1262,6 +1292,7 @@ export async function POST(request: NextRequest) {
             tenantId: session.tenantId,
             userId: session.userId,
             chiftConnected,
+            bankingConnected,
           }).catch((error) => {
             console.warn('[holded/chat] tool loop failed, falling back', {
               tenantId: session.tenantId,
@@ -1278,6 +1309,7 @@ export async function POST(request: NextRequest) {
             aeatBlock,
             advisorBanner,
             chiftLine,
+            bankingLine,
             modelConfig,
             memoryContext,
             fewShotExamples,

--- a/apps/isaak/app/lib/banking-tools.ts
+++ b/apps/isaak/app/lib/banking-tools.ts
@@ -1,0 +1,264 @@
+import { prisma } from '@/app/lib/prisma';
+
+export const BANKING_CHAT_TOOLS = [
+  {
+    name: 'banking_check_connection',
+    description:
+      'Comprueba si el usuario tiene cuentas bancarias conectadas vía banca abierta (Salt Edge / open banking). Úsalo antes de usar otras herramientas de banca o cuando el usuario pregunte sobre su saldo real.',
+    input_schema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'banking_list_accounts',
+    description:
+      'Lista las cuentas bancarias conectadas con sus saldos en tiempo real. Úsalo cuando el usuario pregunte por su saldo bancario, liquidez, cuánto tiene en el banco o en qué cuentas opera.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        includeSummary: {
+          type: 'boolean',
+          description: 'Si true, incluye el saldo total agregado de todas las cuentas.',
+        },
+      },
+    },
+  },
+  {
+    name: 'banking_list_transactions',
+    description:
+      'Lista los movimientos bancarios reales de las cuentas conectadas. Úsalo cuando el usuario pregunte por cobros recibidos, pagos realizados, gastos del banco o flujo de caja real.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        accountId: {
+          type: 'string',
+          description: 'ID de la cuenta bancaria. Si no se indica, devuelve de todas las cuentas.',
+        },
+        fromDate: {
+          type: 'string',
+          description: 'Fecha inicio YYYY-MM-DD. Por defecto: últimos 30 días.',
+        },
+        toDate: {
+          type: 'string',
+          description: 'Fecha fin YYYY-MM-DD. Por defecto: hoy.',
+        },
+        limit: {
+          type: 'number',
+          description: 'Máximo de movimientos a devolver (default 50, max 200).',
+        },
+        onlyIncoming: {
+          type: 'boolean',
+          description: 'Si true, solo devuelve cobros (amount > 0).',
+        },
+        onlyOutgoing: {
+          type: 'boolean',
+          description: 'Si true, solo devuelve pagos (amount < 0).',
+        },
+      },
+    },
+  },
+  {
+    name: 'banking_get_cash_summary',
+    description:
+      'Devuelve un resumen de tesorería: saldo total disponible, entradas y salidas en un período. Úsalo cuando el usuario pregunte por flujo de caja, liquidez total o cuánto ha entrado y salido en un período.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        fromDate: {
+          type: 'string',
+          description: 'Fecha inicio YYYY-MM-DD. Por defecto: 1 enero del año actual.',
+        },
+        toDate: {
+          type: 'string',
+          description: 'Fecha fin YYYY-MM-DD. Por defecto: hoy.',
+        },
+      },
+    },
+  },
+] as const;
+
+export type BankingToolName = (typeof BANKING_CHAT_TOOLS)[number]['name'];
+
+const BANKING_TOOL_NAMES = new Set<string>(BANKING_CHAT_TOOLS.map((t) => t.name));
+export function isBankingToolName(name: string): name is BankingToolName {
+  return BANKING_TOOL_NAMES.has(name);
+}
+
+type ToolInput = Record<string, unknown>;
+
+function thirtyDaysAgo() {
+  const d = new Date();
+  d.setDate(d.getDate() - 30);
+  return d.toISOString().slice(0, 10);
+}
+
+function today() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function startOfYear() {
+  return `${new Date().getFullYear()}-01-01`;
+}
+
+export async function executeBankingTool(
+  tenantId: string,
+  toolName: BankingToolName,
+  input: ToolInput
+): Promise<unknown> {
+  try {
+    switch (toolName) {
+      case 'banking_check_connection': {
+        const customer = await prisma.seCustomer
+          .findUnique({
+            where: { tenantId },
+            include: {
+              connections: { where: { status: 'active' }, select: { id: true, providerName: true, status: true } },
+            },
+          })
+          .catch(() => null);
+
+        if (!customer) {
+          return {
+            connected: false,
+            message:
+              'No hay cuentas bancarias conectadas. El usuario puede conectar su banco desde Workspace > Banca.',
+          };
+        }
+
+        const accountCount = await prisma.seAccount
+          .count({ where: { tenantId, status: 'active' } })
+          .catch(() => 0);
+
+        return {
+          connected: accountCount > 0,
+          activeConnections: customer.connections.length,
+          activeAccounts: accountCount,
+          providers: customer.connections.map((c) => c.providerName),
+        };
+      }
+
+      case 'banking_list_accounts': {
+        const accounts = await prisma.seAccount.findMany({
+          where: { tenantId, status: 'active' },
+          include: { connection: { select: { providerName: true, status: true } } },
+          orderBy: { createdAt: 'desc' },
+        });
+
+        if (accounts.length === 0) {
+          return { connected: false, message: 'No hay cuentas bancarias activas.' };
+        }
+
+        const mapped = accounts.map((a) => ({
+          id: a.id,
+          name: a.name,
+          nature: a.nature,
+          balance: Number(a.balance),
+          currency: a.currency,
+          iban: a.iban,
+          bank: a.connection.providerName,
+        }));
+
+        const includeSummary = input.includeSummary !== false;
+        const totalBalance = accounts.reduce((sum, a) => sum + Number(a.balance), 0);
+
+        return {
+          accounts: mapped,
+          count: mapped.length,
+          ...(includeSummary ? { totalBalance: Math.round(totalBalance * 100) / 100 } : {}),
+        };
+      }
+
+      case 'banking_list_transactions': {
+        const fromDate = input.fromDate ? String(input.fromDate) : thirtyDaysAgo();
+        const toDate = input.toDate ? String(input.toDate) : today();
+        const limit = typeof input.limit === 'number' ? Math.min(input.limit, 200) : 50;
+        const accountId = input.accountId ? String(input.accountId) : undefined;
+
+        const transactions = await prisma.seTransaction.findMany({
+          where: {
+            tenantId,
+            madeOn: { gte: fromDate, lte: toDate },
+            status: 'posted',
+            duplicated: false,
+            ...(accountId ? { accountId } : {}),
+          },
+          orderBy: { madeOn: 'desc' },
+          take: limit,
+          select: {
+            id: true,
+            madeOn: true,
+            amount: true,
+            currency: true,
+            description: true,
+            category: true,
+            payee: true,
+            payer: true,
+            accountId: true,
+          },
+        });
+
+        const mapped2 = transactions
+          .map((tx) => ({ ...tx, amount: Number(tx.amount) }))
+          .filter((tx) => {
+            if (input.onlyIncoming === true) return tx.amount > 0;
+            if (input.onlyOutgoing === true) return tx.amount < 0;
+            return true;
+          })
+          .slice(0, limit);
+
+        return {
+          transactions: mapped2,
+          count: mapped2.length,
+          period: { from: fromDate, to: toDate },
+        };
+      }
+
+      case 'banking_get_cash_summary': {
+        const fromDate = input.fromDate ? String(input.fromDate) : startOfYear();
+        const toDate = input.toDate ? String(input.toDate) : today();
+
+        const [accounts, txStats] = await Promise.all([
+          prisma.seAccount.findMany({
+            where: { tenantId, status: 'active' },
+            select: { balance: true, currency: true },
+          }),
+          prisma.seTransaction.findMany({
+            where: {
+              tenantId,
+              madeOn: { gte: fromDate, lte: toDate },
+              status: 'posted',
+              duplicated: false,
+            },
+            select: { amount: true },
+          }),
+        ]);
+
+        const totalBalance = Math.round(accounts.reduce((s, a) => s + Number(a.balance), 0) * 100) / 100;
+
+        let totalIn = 0;
+        let totalOut = 0;
+        for (const tx of txStats) {
+          const amt = Number(tx.amount);
+          if (amt > 0) totalIn += amt;
+          else totalOut += Math.abs(amt);
+        }
+
+        return {
+          totalBalance,
+          period: { from: fromDate, to: toDate },
+          totalIn: Math.round(totalIn * 100) / 100,
+          totalOut: Math.round(totalOut * 100) / 100,
+          netCashFlow: Math.round((totalIn - totalOut) * 100) / 100,
+          transactionsAnalyzed: txStats.length,
+          accountCount: accounts.length,
+        };
+      }
+
+      default:
+        return { error: 'unknown_tool' };
+    }
+  } catch (err) {
+    return {
+      error: 'tool_execution_failed',
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/apps/isaak/app/lib/chift-tools.ts
+++ b/apps/isaak/app/lib/chift-tools.ts
@@ -1,0 +1,219 @@
+import { prisma } from '@/app/lib/prisma';
+import { ChiftErpClient } from './chift-erp-client';
+
+export const CHIFT_CHAT_TOOLS = [
+  {
+    name: 'chift_check_connection',
+    description:
+      'Comprueba si el usuario tiene un ERP conectado vía Chift (Sage, Xero, QuickBooks, Cegid u otros). Úsalo cuando el usuario pregunte sobre su ERP o antes de intentar usar otras herramientas de Chift si no estás seguro de si está conectado.',
+    input_schema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'chift_list_invoices',
+    description:
+      'Lista facturas de venta o de compra desde el ERP conectado vía Chift. Úsalo cuando el usuario pregunte por facturas, ventas o gastos en su ERP (Sage, Xero, QuickBooks, etc.).',
+    input_schema: {
+      type: 'object',
+      properties: {
+        type: {
+          type: 'string',
+          enum: ['invoice', 'purchase'],
+          description: 'Tipo de documento. invoice=factura de venta, purchase=factura de compra.',
+        },
+        from: { type: 'string', description: 'Fecha inicio YYYY-MM-DD.' },
+        to: { type: 'string', description: 'Fecha fin YYYY-MM-DD.' },
+        limit: { type: 'number', description: 'Máximo de facturas a devolver (default 50, max 100).' },
+      },
+    },
+  },
+  {
+    name: 'chift_get_invoice',
+    description: 'Obtiene el detalle completo (líneas, impuestos, contacto) de una factura del ERP conectado vía Chift.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        invoiceId: { type: 'string', description: 'ID de la factura en el ERP.' },
+        type: {
+          type: 'string',
+          enum: ['invoice', 'purchase'],
+          description: 'Tipo de factura (default: invoice).',
+        },
+      },
+      required: ['invoiceId'],
+    },
+  },
+  {
+    name: 'chift_list_contacts',
+    description: 'Lista clientes y proveedores desde el ERP conectado vía Chift.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        limit: { type: 'number', description: 'Máximo de contactos a devolver (default 50).' },
+      },
+    },
+  },
+  {
+    name: 'chift_get_pnl',
+    description:
+      'Calcula el P&L (ingresos, gastos, resultado bruto) del ERP conectado a partir de sus asientos contables. Úsalo cuando el usuario pregunte por beneficio, margen o resultado contable y tenga un ERP distinto de Holded.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        from: {
+          type: 'string',
+          description: 'Fecha inicio YYYY-MM-DD. Por defecto: 1 enero del año actual.',
+        },
+        to: {
+          type: 'string',
+          description: 'Fecha fin YYYY-MM-DD. Por defecto: hoy.',
+        },
+      },
+    },
+  },
+] as const;
+
+export type ChiftToolName = (typeof CHIFT_CHAT_TOOLS)[number]['name'];
+
+const CHIFT_TOOL_NAMES = new Set<string>(CHIFT_CHAT_TOOLS.map((t) => t.name));
+export function isChiftToolName(name: string): name is ChiftToolName {
+  return CHIFT_TOOL_NAMES.has(name);
+}
+
+type ToolInput = Record<string, unknown>;
+
+async function getChiftConsumerId(tenantId: string): Promise<string | null> {
+  const conn = await prisma.externalConnection
+    .findFirst({
+      where: { tenantId, provider: 'chift', connectionStatus: { not: 'disconnected' } },
+      select: { providerAccountId: true },
+    })
+    .catch(() => null);
+  return conn?.providerAccountId ?? null;
+}
+
+export async function executeChiftTool(
+  tenantId: string,
+  toolName: ChiftToolName,
+  input: ToolInput
+): Promise<unknown> {
+  try {
+    if (toolName === 'chift_check_connection') {
+      const conn = await prisma.externalConnection
+        .findFirst({
+          where: { tenantId, provider: 'chift', connectionStatus: { not: 'disconnected' } },
+          select: {
+            connectionStatus: true,
+            providerAccountId: true,
+            companyIdentityJson: true,
+            connectedAt: true,
+          },
+        })
+        .catch(() => null);
+      if (!conn?.providerAccountId) {
+        return {
+          connected: false,
+          message:
+            'No hay ningún ERP conectado vía Chift. El usuario puede conectar desde Workspace > Conectores.',
+        };
+      }
+      const identity = conn.companyIdentityJson as Record<string, unknown> | null;
+      return {
+        connected: true,
+        status: conn.connectionStatus,
+        companyName: identity?.name ?? null,
+        companyVat: identity?.vat ?? null,
+        currency: identity?.currency ?? null,
+        connectedAt: conn.connectedAt?.toISOString() ?? null,
+      };
+    }
+
+    const consumerId = await getChiftConsumerId(tenantId);
+    if (!consumerId) {
+      return { error: 'not_connected', message: 'No hay ningún ERP conectado vía Chift.' };
+    }
+
+    const client = new ChiftErpClient(consumerId);
+
+    switch (toolName) {
+      case 'chift_list_invoices': {
+        const invoices = await client.listInvoices({
+          type: input.type === 'purchase' ? 'purchase' : 'invoice',
+          from: input.from ? String(input.from) : undefined,
+          to: input.to ? String(input.to) : undefined,
+          limit: typeof input.limit === 'number' ? Math.min(input.limit, 100) : 50,
+        });
+        return { invoices: invoices.slice(0, 50), count: invoices.length };
+      }
+
+      case 'chift_get_invoice': {
+        const invoiceId = String(input.invoiceId ?? '');
+        if (!invoiceId) return { error: 'missing_invoice_id' };
+        const inv = await client.getInvoice(
+          invoiceId,
+          input.type === 'purchase' ? 'purchase' : 'invoice'
+        );
+        return inv ?? { error: 'not_found' };
+      }
+
+      case 'chift_list_contacts': {
+        const contacts = await client.listContacts();
+        const limit = typeof input.limit === 'number' ? Math.min(input.limit, 100) : 50;
+        return { contacts: contacts.slice(0, limit), count: contacts.length };
+      }
+
+      case 'chift_get_pnl': {
+        const now = new Date();
+        const from = input.from ? String(input.from) : `${now.getFullYear()}-01-01`;
+        const to = input.to ? String(input.to) : now.toISOString().slice(0, 10);
+
+        const entries = await client.listAccountEntries({ from, to });
+
+        let income = 0;
+        let expenses = 0;
+
+        for (const e of entries) {
+          const acc = e.account.toLowerCase();
+          // PGC Spanish: 7xx = income, 6xx = expense.
+          // English fallback: common keywords for international ERPs.
+          const isIncome =
+            /^7/.test(e.account) ||
+            acc.includes('sales') ||
+            acc.includes('revenue') ||
+            acc.includes('income') ||
+            acc.includes('ingreso') ||
+            acc.includes('venta');
+          const isExpense =
+            /^6/.test(e.account) ||
+            acc.includes('cost') ||
+            acc.includes('expense') ||
+            acc.includes('gasto') ||
+            acc.includes('compra') ||
+            acc.includes('purchase');
+
+          if (isIncome) income += e.credit - e.debit;
+          if (isExpense) expenses += Math.abs(e.debit - e.credit);
+        }
+
+        const grossProfit = income - expenses;
+        const margin = income > 0 ? Math.round((grossProfit / income) * 10000) / 100 : null;
+
+        return {
+          period: { from, to },
+          income: Math.round(income * 100) / 100,
+          expenses: Math.round(expenses * 100) / 100,
+          grossProfit: Math.round(grossProfit * 100) / 100,
+          margin,
+          entriesProcessed: entries.length,
+        };
+      }
+
+      default:
+        return { error: 'unknown_tool' };
+    }
+  } catch (err) {
+    return {
+      error: 'tool_execution_failed',
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Builds on top of PR #110 (Chift). Adds 4 Isaak chat tools that read **real bank data** from the Salt Edge open-banking integration already stored in Prisma:

- **`banking_check_connection`** — how many accounts are connected and which banks
- **`banking_list_accounts`** — account list with live balances + optional total aggregation
- **`banking_list_transactions`** — bank movements with date range, direction filters (income/expense), optional account filter
- **`banking_get_cash_summary`** — cash flow summary: totalBalance, totalIn, totalOut, netCashFlow for a period

All reads go directly to Prisma (`seAccount`, `seTransaction`) — no external API call needed at chat time, keeping latency low.

**System prompt changes:**
- Current total bank balance pre-fetched alongside memory context and injected into the system prompt so Isaak knows the cash position before the first message
- Isaak instructed to prefer live bank data over Holded treasury when answering balance/liquidity questions
- Banking tools only added to the Anthropic request when the tenant has ≥1 active `seAccount`

> Merge order: #110 (Chift) → this PR (#111) to avoid conflicts in route.ts

## Test plan

- [ ] User with open banking connected asks "¿cuánto tengo en el banco?" → Isaak calls `banking_list_accounts`, returns real balances
- [ ] Ask "¿cuáles son mis últimos movimientos?" → calls `banking_list_transactions` with default 30-day window
- [ ] Ask "¿cuánto he cobrado este mes?" → calls with `onlyIncoming: true`
- [ ] `banking_get_cash_summary` returns income, expenses, net cash flow for the year
- [ ] User without open banking → tools NOT in Anthropic request (verified via logs)
- [ ] TypeScript compiles cleanly (0 new errors)

https://claude.ai/code/session_01XEgA9ynYQxzRUipm4CeXpq