### PR TITLE
feat(isaak): Holded write tools + proactive banking agent

### DIFF
--- a/apps/isaak/app/api/cron/banking-alerts/route.ts
+++ b/apps/isaak/app/api/cron/banking-alerts/route.ts
@@ -1,0 +1,254 @@
+/**
+ * GET /api/cron/banking-alerts
+ *
+ * Runs daily at 07:30 UTC (08:30 CET). Proactive banking agent:
+ *
+ * 1. LOW BALANCE: for every tenant with active banking accounts, if the total
+ *    balance (already synced in SeAccount) is below LOW_BALANCE_THRESHOLD (€),
+ *    sends a WhatsApp + push notification. Deduplicated to one alert per 7 days.
+ *
+ * 2. EB EXPIRY (WA complement): connector-health already sends email alerts for
+ *    expiring Enable Banking sessions. This cron adds a WhatsApp notification
+ *    for the same condition (session expiring ≤7 days). Deduplicated separately.
+ *
+ * Auth: CRON_SECRET header (Vercel standard).
+ */
+
+import { timingSafeEqual } from 'crypto';
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/app/lib/prisma';
+import { createAlert } from '@/app/lib/isaak-alert-service';
+import { normalizePhone, sendWhatsAppTemplate } from '@/app/lib/whatsapp';
+import { sendPushToTenant } from '@/app/lib/push-service';
+import {
+  TEMPLATE_SALDO_BAJO,
+  buildSaldoBajoComponents,
+  TEMPLATE_EB_EXPIRY,
+  buildEbExpiryComponents,
+} from '@/app/lib/whatsapp-templates';
+
+export const runtime = 'nodejs';
+export const maxDuration = 120;
+
+// ── Deduplication helper (local, same logic as connector-health) ──────────────
+
+function daysAgo(n: number) {
+  return new Date(Date.now() - n * 86_400_000);
+}
+
+async function alreadyAlertedRecently(
+  tenantId: string,
+  type: string,
+  withinDays: number
+): Promise<boolean> {
+  const existing = await prisma.isaakAlert.findFirst({
+    where: { tenantId, type, createdAt: { gte: daysAgo(withinDays) } },
+  });
+  return existing !== null;
+}
+
+// Default low-balance threshold — override per deployment if needed
+const LOW_BALANCE_THRESHOLD =
+  Number(process.env.BANKING_LOW_BALANCE_THRESHOLD_EUR ?? 1000);
+
+// ── Auth ──────────────────────────────────────────────────────────────────────
+
+function validateCronSecret(request: NextRequest): boolean {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) return false;
+  const header = request.headers.get('authorization') ?? '';
+  const token = header.startsWith('Bearer ') ? header.slice(7) : '';
+  if (!token || token.length !== secret.length) return false;
+  try {
+    return timingSafeEqual(Buffer.from(token), Buffer.from(secret));
+  } catch {
+    return false;
+  }
+}
+
+// ── Helper: resolve first name from TenantProfile ────────────────────────────
+
+function firstNameFromProfile(
+  profile: { legalName?: string | null; tradeName?: string | null } | null
+): string {
+  const name = profile?.tradeName ?? profile?.legalName ?? '';
+  return name.split(' ')[0] ?? 'equipo';
+}
+
+// ── Helper: WA phone for tenant ───────────────────────────────────────────────
+
+async function getTenantWaPhone(tenantId: string): Promise<string | null> {
+  const thread = await prisma.whatsAppThread.findFirst({
+    where: { tenantId, status: 'open' },
+    select: { phoneNumber: true },
+    orderBy: { lastMessageAt: 'desc' },
+  });
+  return thread?.phoneNumber ?? null;
+}
+
+// ── Check 1: Low balance alert ────────────────────────────────────────────────
+
+async function checkLowBalances(): Promise<{
+  checked: number;
+  alerted: number;
+  errors: number;
+}> {
+  const result = { checked: 0, alerted: 0, errors: 0 };
+
+  // Aggregate balances per tenant
+  const balances = await prisma.seAccount.groupBy({
+    by: ['tenantId'],
+    where: { status: 'active' },
+    _sum: { balance: true },
+  });
+
+  for (const row of balances) {
+    result.checked++;
+    const tenantId = row.tenantId;
+    const totalBalance = Number(row._sum.balance ?? 0);
+    if (totalBalance >= LOW_BALANCE_THRESHOLD) continue;
+
+    try {
+      const alertType = 'banking_low_balance';
+      const alreadySent = await alreadyAlertedRecently(tenantId, alertType, 7);
+      if (alreadySent) continue;
+
+      const profile = await prisma.tenantProfile.findUnique({
+        where: { tenantId },
+        select: { legalName: true, tradeName: true },
+      });
+      const firstName = firstNameFromProfile(profile);
+      const saldoFmt = totalBalance.toLocaleString('es-ES', {
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0,
+      });
+
+      // Record alert (deduplication)
+      await createAlert({
+        tenantId,
+        type: alertType,
+        title: 'Saldo bancario bajo',
+        body: `Saldo total ${saldoFmt} € está por debajo del umbral de ${LOW_BALANCE_THRESHOLD} €.`,
+      });
+
+      // Push notification
+      await sendPushToTenant(tenantId, {
+        title: '⚠️ Saldo bancario bajo',
+        body: `Tu saldo total es ${saldoFmt} €. Revisa tu tesorería en Isaak.`,
+        url: '/banking',
+      }).catch((err) => console.error('[banking-alerts] push error', { tenantId, err }));
+
+      // WhatsApp notification
+      const phone = await getTenantWaPhone(tenantId);
+      if (phone) {
+        await sendWhatsAppTemplate(
+          normalizePhone(phone),
+          TEMPLATE_SALDO_BAJO,
+          'es_ES',
+          buildSaldoBajoComponents(firstName, saldoFmt)
+        ).catch((err) => console.error('[banking-alerts] WA error', { tenantId, err }));
+      }
+
+      result.alerted++;
+    } catch (err) {
+      console.error('[banking-alerts] low balance error', { tenantId, err });
+      result.errors++;
+    }
+  }
+
+  return result;
+}
+
+// ── Check 2: EB session expiry WA alert ───────────────────────────────────────
+
+async function checkEbExpiryWa(): Promise<{
+  checked: number;
+  alerted: number;
+  errors: number;
+}> {
+  const result = { checked: 0, alerted: 0, errors: 0 };
+  const now = new Date();
+  const in7Days = new Date(Date.now() + 7 * 86_400_000);
+
+  const connections = await prisma.seConnection.findMany({
+    where: {
+      provider: 'enablebanking',
+      status: 'active',
+      expiresAt: { lte: in7Days, gte: now },
+    },
+    select: { id: true, tenantId: true, providerName: true, expiresAt: true },
+  });
+
+  for (const conn of connections) {
+    result.checked++;
+    const { tenantId, providerName, expiresAt } = conn;
+    if (!expiresAt) continue;
+
+    try {
+      const alertType = `banking_eb_expiry_wa_${conn.id}`;
+      const alreadySent = await alreadyAlertedRecently(tenantId, alertType, 7);
+      if (alreadySent) continue;
+
+      const profile = await prisma.tenantProfile.findUnique({
+        where: { tenantId },
+        select: { legalName: true, tradeName: true },
+      });
+      const firstName = firstNameFromProfile(profile);
+      const fechaExpiracion = expiresAt.toLocaleDateString('es-ES', {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+      });
+
+      await createAlert({
+        tenantId,
+        type: alertType,
+        title: `Renovar conexión ${providerName}`,
+        body: `La sesión PSD2 con ${providerName} expira el ${fechaExpiracion}.`,
+      });
+
+      const phone = await getTenantWaPhone(tenantId);
+      if (phone) {
+        await sendWhatsAppTemplate(
+          normalizePhone(phone),
+          TEMPLATE_EB_EXPIRY,
+          'es_ES',
+          buildEbExpiryComponents(firstName, providerName, fechaExpiracion)
+        ).catch((err) => console.error('[banking-alerts] WA EB expiry error', { tenantId, err }));
+      }
+
+      result.alerted++;
+    } catch (err) {
+      console.error('[banking-alerts] EB expiry WA error', { tenantId: conn.tenantId, err });
+      result.errors++;
+    }
+  }
+
+  return result;
+}
+
+// ── Handler ───────────────────────────────────────────────────────────────────
+
+export async function GET(request: NextRequest) {
+  if (!validateCronSecret(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const [lowBalance, ebExpiry] = await Promise.allSettled([
+    checkLowBalances(),
+    checkEbExpiryWa(),
+  ]);
+
+  return NextResponse.json({
+    ok: true,
+    threshold: LOW_BALANCE_THRESHOLD,
+    lowBalance:
+      lowBalance.status === 'fulfilled'
+        ? lowBalance.value
+        : { error: String(lowBalance.reason) },
+    ebExpiry:
+      ebExpiry.status === 'fulfilled'
+        ? ebExpiry.value
+        : { error: String(ebExpiry.reason) },
+  });
+}

--- a/apps/isaak/app/lib/holded-api.ts
+++ b/apps/isaak/app/lib/holded-api.ts
@@ -408,3 +408,121 @@ export async function holdedListPayments(
   const limit = params?.limit ?? 50;
   return { payments: all.slice(0, limit), total: all.length, truncated: all.length > limit };
 }
+
+// ── Crear factura de venta ────────────────────────────────────────────────────
+
+export type CreateInvoiceParams = {
+  contactId: string;
+  date?: number;   // Unix timestamp — default: today
+  notes?: string;
+  currency?: string;
+  items: Array<{
+    name: string;
+    units: number;
+    subtotal: number; // unit price before tax
+    tax?: number;     // VAT %, default 21
+  }>;
+};
+
+export async function holdedCreateInvoice(
+  apiKey: string,
+  params: CreateInvoiceParams
+): Promise<{ id: string; docNumber?: string; raw: unknown }> {
+  const payload: Record<string, unknown> = {
+    contactId: params.contactId,
+    date: params.date ?? Math.floor(Date.now() / 1000),
+    notes: params.notes ?? '',
+    currency: params.currency ?? 'EUR',
+    items: params.items.map((item) => ({
+      name: item.name,
+      units: item.units,
+      subtotal: item.subtotal,
+      tax: item.tax ?? 21,
+    })),
+  };
+
+  const raw = (await holdedPost(
+    apiKey,
+    '/api/invoicing/v1/documents/invoice',
+    payload
+  )) as Record<string, unknown>;
+
+  return {
+    id: String(raw?.id ?? raw?.docId ?? ''),
+    docNumber: raw?.docNumber as string | undefined,
+    raw,
+  };
+}
+
+// ── Registrar cobro en factura ────────────────────────────────────────────────
+
+export type RegisterPaymentParams = {
+  docType?: string;  // default 'invoice'
+  documentId: string;
+  date?: number;     // Unix timestamp — default: today
+  amount: number;
+  accountId?: string; // treasury account ID (optional)
+};
+
+export async function holdedRegisterPayment(
+  apiKey: string,
+  params: RegisterPaymentParams
+): Promise<{ success: boolean; raw: unknown }> {
+  const docType = params.docType ?? 'invoice';
+  const payload: Record<string, unknown> = {
+    date: params.date ?? Math.floor(Date.now() / 1000),
+    amount: params.amount,
+  };
+  if (params.accountId) payload.accountId = params.accountId;
+
+  const raw = await holdedPost(
+    apiKey,
+    `/api/invoicing/v1/documents/${docType}/${params.documentId}/pay`,
+    payload
+  );
+
+  return { success: true, raw };
+}
+
+// ── Crear contacto ────────────────────────────────────────────────────────────
+
+export type CreateContactParams = {
+  name: string;
+  email?: string;
+  phone?: string;
+  nif?: string;                              // 'code' in Holded API
+  type?: 'client' | 'supplier' | 'both';    // 1 | 2 | 3
+  address?: string;
+  city?: string;
+  postalCode?: string;
+  country?: string; // ISO 2-letter, default 'ES'
+};
+
+export async function holdedCreateContact(
+  apiKey: string,
+  params: CreateContactParams
+): Promise<{ id: string; raw: unknown }> {
+  const typeMap: Record<string, number> = { client: 1, supplier: 2, both: 3 };
+  const payload: Record<string, unknown> = {
+    name: params.name,
+    country: params.country ?? 'ES',
+    type: typeMap[params.type ?? 'client'] ?? 1,
+  };
+  if (params.email) payload.email = params.email;
+  if (params.phone) payload.phone = params.phone;
+  if (params.nif) payload.code = params.nif;
+  if (params.address) payload.address = params.address;
+  if (params.city) payload.city = params.city;
+  if (params.postalCode) payload.cp = params.postalCode;
+
+  const raw = (await holdedPost(
+    apiKey,
+    '/api/invoicing/v1/contacts',
+    payload
+  )) as Record<string, unknown>;
+
+  return {
+    id: String(raw?.id ?? raw?.contactId ?? ''),
+    raw,
+  };
+}

--- a/apps/isaak/app/lib/holded-tools.ts
+++ b/apps/isaak/app/lib/holded-tools.ts
@@ -13,6 +13,9 @@ import {
   holdedListProjects,
   holdedListTreasuryAccounts,
   holdedSendDocument,
+  holdedCreateInvoice,
+  holdedRegisterPayment,
+  holdedCreateContact,
 } from './holded-api';
 
 // Anthropic tool definitions for Isaak chat — 14 tools (10 lectura + 4 nuevas)
@@ -195,6 +198,113 @@ export const HOLDED_CHAT_TOOLS = [
     },
   },
   {
+    name: 'holded_create_invoice',
+    description:
+      'Crea una factura de venta en Holded. IMPORTANTE: antes de ejecutar, muestra al usuario el resumen (cliente, líneas, importe total con IVA) y espera su confirmación explícita. Si no sabes el contactId, usa holded_list_contacts primero para buscarlo.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        contactId: {
+          type: 'string',
+          description: 'ID del cliente en Holded (obtenerlo con holded_list_contacts si no se conoce).',
+        },
+        items: {
+          type: 'array',
+          description: 'Líneas de la factura.',
+          items: {
+            type: 'object',
+            properties: {
+              name: { type: 'string', description: 'Descripción del concepto.' },
+              units: { type: 'number', description: 'Cantidad.' },
+              subtotal: { type: 'number', description: 'Precio unitario sin impuestos (€).' },
+              tax: { type: 'number', description: 'IVA en % (default 21). Usar 0 si exento.' },
+            },
+            required: ['name', 'units', 'subtotal'],
+          },
+        },
+        date: {
+          type: 'string',
+          description: 'Fecha de la factura YYYY-MM-DD. Por defecto: hoy.',
+        },
+        notes: { type: 'string', description: 'Notas o comentarios adicionales.' },
+        currency: { type: 'string', description: 'Código de moneda ISO (default EUR).' },
+        confirmed: {
+          type: 'boolean',
+          description:
+            'Debe ser true. Solo llama con confirmed=true cuando el usuario haya confirmado explícitamente los datos.',
+        },
+      },
+      required: ['contactId', 'items', 'confirmed'],
+    },
+  },
+  {
+    name: 'holded_register_payment',
+    description:
+      'Registra el cobro de una factura en Holded (la marca como pagada total o parcialmente). IMPORTANTE: confirma con el usuario el importe y la fecha antes de ejecutar.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        documentId: {
+          type: 'string',
+          description: 'ID de la factura en Holded (obtenerlo con holded_list_documents).',
+        },
+        amount: {
+          type: 'number',
+          description: 'Importe del cobro en €. Normalmente el total de la factura.',
+        },
+        date: {
+          type: 'string',
+          description: 'Fecha de cobro YYYY-MM-DD. Por defecto: hoy.',
+        },
+        docType: {
+          type: 'string',
+          enum: ['invoice', 'salesreceipt', 'purchase'],
+          description: 'Tipo de documento (default invoice).',
+        },
+        accountId: {
+          type: 'string',
+          description:
+            'ID de la cuenta de tesorería donde se registra el cobro (opcional). Usar holded_list_treasury_accounts para obtener IDs.',
+        },
+        confirmed: {
+          type: 'boolean',
+          description:
+            'Debe ser true. Solo llama con confirmed=true cuando el usuario haya confirmado.',
+        },
+      },
+      required: ['documentId', 'amount', 'confirmed'],
+    },
+  },
+  {
+    name: 'holded_create_contact',
+    description:
+      'Crea un nuevo contacto (cliente o proveedor) en Holded. IMPORTANTE: muestra al usuario los datos a crear y espera confirmación antes de ejecutar.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'Nombre del contacto o razón social.' },
+        email: { type: 'string', description: 'Email de contacto (opcional).' },
+        phone: { type: 'string', description: 'Teléfono (opcional).' },
+        nif: { type: 'string', description: 'NIF / CIF / NIE del contacto (opcional).' },
+        type: {
+          type: 'string',
+          enum: ['client', 'supplier', 'both'],
+          description: 'Tipo de contacto: client=cliente, supplier=proveedor, both=ambos. Default: client.',
+        },
+        address: { type: 'string', description: 'Dirección postal (opcional).' },
+        city: { type: 'string', description: 'Ciudad (opcional).' },
+        postalCode: { type: 'string', description: 'Código postal (opcional).' },
+        country: { type: 'string', description: 'País ISO 2 letras (default ES).' },
+        confirmed: {
+          type: 'boolean',
+          description:
+            'Debe ser true. Solo llama con confirmed=true cuando el usuario haya confirmado los datos.',
+        },
+      },
+      required: ['name', 'confirmed'],
+    },
+  },
+  {
     name: 'holded_send_document',
     description:
       'Envía un documento de Holded (factura, presupuesto, etc.) por email al destinatario indicado. IMPORTANTE: antes de ejecutar esta acción, confirma siempre con el usuario los datos (destinatario, documento) y espera su aprobación explícita.',
@@ -317,6 +427,115 @@ export async function executeHoldedTool(
           body: typeof input.body === 'string' ? input.body : undefined,
         });
       }
+
+      case 'holded_create_invoice': {
+        if (!input.confirmed) {
+          return {
+            error: 'confirmation_required',
+            message:
+              'Esta acción requiere confirmación explícita. Muestra al usuario el resumen de la factura (cliente, líneas, total con IVA) y espera que confirme antes de proceder.',
+          };
+        }
+        const contactId = String(input.contactId ?? '');
+        if (!contactId) {
+          return { error: 'invalid_input', message: 'Se requiere contactId. Usa holded_list_contacts para obtenerlo.' };
+        }
+        const rawItems = Array.isArray(input.items) ? input.items : [];
+        if (rawItems.length === 0) {
+          return { error: 'invalid_input', message: 'Se requiere al menos una línea de factura.' };
+        }
+        const items = rawItems.map((item) => {
+          const i = item as Record<string, unknown>;
+          return {
+            name: String(i.name ?? ''),
+            units: typeof i.units === 'number' ? i.units : 1,
+            subtotal: typeof i.subtotal === 'number' ? i.subtotal : 0,
+            tax: typeof i.tax === 'number' ? i.tax : 21,
+          };
+        });
+        const dateUnix = input.date
+          ? Math.floor(new Date(String(input.date)).getTime() / 1000)
+          : Math.floor(Date.now() / 1000);
+        const result = await holdedCreateInvoice(apiKey, {
+          contactId,
+          date: dateUnix,
+          notes: typeof input.notes === 'string' ? input.notes : undefined,
+          currency: typeof input.currency === 'string' ? input.currency : 'EUR',
+          items,
+        });
+        return {
+          success: true,
+          id: result.id,
+          docNumber: result.docNumber,
+          message: `Factura ${result.docNumber ?? result.id} creada correctamente en Holded.`,
+        };
+      }
+
+      case 'holded_register_payment': {
+        if (!input.confirmed) {
+          return {
+            error: 'confirmation_required',
+            message:
+              'Esta acción requiere confirmación explícita. Muestra al usuario el importe, la factura y la fecha de cobro, y espera que confirme.',
+          };
+        }
+        const documentId = String(input.documentId ?? '');
+        if (!documentId) {
+          return { error: 'invalid_input', message: 'Se requiere documentId.' };
+        }
+        const amount = typeof input.amount === 'number' ? input.amount : 0;
+        if (amount <= 0) {
+          return { error: 'invalid_input', message: 'El importe debe ser mayor que 0.' };
+        }
+        const dateUnix = input.date
+          ? Math.floor(new Date(String(input.date)).getTime() / 1000)
+          : Math.floor(Date.now() / 1000);
+        const result = await holdedRegisterPayment(apiKey, {
+          documentId,
+          docType: typeof input.docType === 'string' ? input.docType : 'invoice',
+          date: dateUnix,
+          amount,
+          accountId: typeof input.accountId === 'string' ? input.accountId : undefined,
+        });
+        return {
+          success: result.success,
+          message: `Cobro de ${amount} € registrado correctamente en la factura ${documentId}.`,
+        };
+      }
+
+      case 'holded_create_contact': {
+        if (!input.confirmed) {
+          return {
+            error: 'confirmation_required',
+            message:
+              'Esta acción requiere confirmación explícita. Muestra al usuario los datos del contacto a crear y espera que confirme.',
+          };
+        }
+        const name = String(input.name ?? '').trim();
+        if (!name) {
+          return { error: 'invalid_input', message: 'Se requiere el nombre del contacto.' };
+        }
+        const typeVal = typeof input.type === 'string' && ['client', 'supplier', 'both'].includes(input.type)
+          ? (input.type as 'client' | 'supplier' | 'both')
+          : 'client';
+        const result = await holdedCreateContact(apiKey, {
+          name,
+          email: typeof input.email === 'string' ? input.email : undefined,
+          phone: typeof input.phone === 'string' ? input.phone : undefined,
+          nif: typeof input.nif === 'string' ? input.nif : undefined,
+          type: typeVal,
+          address: typeof input.address === 'string' ? input.address : undefined,
+          city: typeof input.city === 'string' ? input.city : undefined,
+          postalCode: typeof input.postalCode === 'string' ? input.postalCode : undefined,
+          country: typeof input.country === 'string' ? input.country : 'ES',
+        });
+        return {
+          success: true,
+          id: result.id,
+          message: `Contacto "${name}" creado correctamente en Holded con ID ${result.id}.`,
+        };
+      }
+
       default:
         return { error: 'unknown_tool' };
     }

--- a/apps/isaak/app/lib/whatsapp-templates.ts
+++ b/apps/isaak/app/lib/whatsapp-templates.ts
@@ -102,6 +102,60 @@ export function buildModelo303Components(
   ];
 }
 
+// ── Template 4: Saldo bancario bajo ──────────────────────────────────────────
+//
+// Cuerpo para Meta:
+// "Hola {{1}}, tu saldo bancario está en {{2}} €, por debajo del umbral habitual.
+//  Accede a Isaak para revisar tu tesorería y tomar acción."
+//
+// Parámetros: [firstName, saldoEuros]
+// Registro en Meta: UTILITY — PENDIENTE DE REGISTRO
+
+export const TEMPLATE_SALDO_BAJO = 'saldo_bancario_bajo';
+
+export function buildSaldoBajoComponents(
+  firstName: string,
+  saldoEuros: string
+): WaTemplateComponent[] {
+  return [
+    {
+      type: 'body',
+      parameters: [
+        { type: 'text', text: firstName },
+        { type: 'text', text: saldoEuros },
+      ],
+    },
+  ];
+}
+
+// ── Template 5: Renovar conexión Enable Banking ───────────────────────────────
+//
+// Cuerpo para Meta:
+// "Hola {{1}}, tu conexión bancaria con {{2}} expira el {{3}}.
+//  Renuévala desde Isaak antes de que se desconecte."
+//
+// Parámetros: [firstName, bankName, fechaExpiracion]
+// Registro en Meta: UTILITY — PENDIENTE DE REGISTRO
+
+export const TEMPLATE_EB_EXPIRY = 'renovar_conexion_bancaria';
+
+export function buildEbExpiryComponents(
+  firstName: string,
+  bankName: string,
+  fechaExpiracion: string
+): WaTemplateComponent[] {
+  return [
+    {
+      type: 'body',
+      parameters: [
+        { type: 'text', text: firstName },
+        { type: 'text', text: bankName },
+        { type: 'text', text: fechaExpiracion },
+      ],
+    },
+  ];
+}
+
 // ── Selector automático de template por tipo de alerta ───────────────────────
 
 export type FiscalAlertTemplateInput = {

--- a/apps/isaak/vercel.json
+++ b/apps/isaak/vercel.json
@@ -24,6 +24,10 @@
     {
       "path": "/api/cron/eb-sync",
       "schedule": "0 */6 * * *"
+    },
+    {
+      "path": "/api/cron/banking-alerts",
+      "schedule": "30 7 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Resumen

Dos bloques de funcionalidad P1 del roadmap.

---

## 1. Holded Write Tools — Isaak pasa a actuar

Hasta ahora Isaak solo podía **leer** datos de Holded. Ahora puede **crear** registros con confirmación explícita del usuario.

### Nuevas funciones API (`holded-api.ts`)

- `holdedCreateInvoice()` — `POST /api/invoicing/v1/documents/invoice`
- `holdedRegisterPayment()` — `POST /api/invoicing/v1/documents/{docType}/{id}/pay`
- `holdedCreateContact()` — `POST /api/invoicing/v1/contacts`

### Nuevos LLM tools (`holded-tools.ts`) — total 17 tools (era 14)

| Tool | Acción | Confirmación |
|---|---|---|
| `holded_create_invoice` | Crea factura de venta con líneas + IVA | `confirmed=true` |
| `holded_register_payment` | Registra cobro en factura | `confirmed=true` |
| `holded_create_contact` | Crea cliente/proveedor | `confirmed=true` |

**Patrón de seguridad**: todos los write tools requieren `confirmed=true`. Sin esa flag devuelven `confirmation_required` y el LLM muestra el resumen al usuario antes de ejecutar. Igual que el ya existente `holded_send_document`.

---

## 2. Agente Proactivo Banking

### Cron `banking-alerts` (07:30 UTC diario)

**Alerta saldo bajo:**
- Suma saldos reales de `SeAccount` por tenant (ya sincronizados por `eb-sync`)
- Si total < umbral (default €1.000, configurable via `BANKING_LOW_BALANCE_THRESHOLD_EUR`)
- Envía push VAPID + WhatsApp template `saldo_bancario_bajo`
- Deduplicado: 1 alerta por tenant cada 7 días

**Alerta renovar EB (complemento WA al email ya existente):**
- Misma ventana ≤7 días que `connector-health`
- Envía WhatsApp template `renovar_conexion_bancaria` con nombre del banco + fecha
- Deduplicado por conexión cada 7 días

### Nuevos templates WhatsApp (`whatsapp-templates.ts`)

```
TEMPLATE_SALDO_BAJO = 'saldo_bancario_bajo'
  Hola {{1}}, tu saldo bancario está en {{2}} €, por debajo del umbral habitual.

TEMPLATE_EB_EXPIRY = 'renovar_conexion_bancaria'
  Hola {{1}}, tu conexión bancaria con {{2}} expira el {{3}}.
```

⚠️ Ambos templates deben registrarse en Meta Business Manager (categoría UTILITY, idioma es_ES) antes de que el cron pueda enviarlos.

---

## Test plan

- [ ] Vercel deploy verde
- [ ] `GET /api/cron/banking-alerts` con `Authorization: Bearer <CRON_SECRET>` devuelve `{ ok: true, lowBalance: {...}, ebExpiry: {...} }`
- [ ] Chat con Holded conectado: "crea una factura para [cliente]" → Isaak pide confirmación con resumen → "sí" → factura creada en Holded
- [ ] Chat: "registra el cobro de la factura FAC-001" → confirmación → pago registrado
- [ ] Chat: "añade el contacto Empresa XYZ" → confirmación → contacto creado en Holded

https://claude.ai/code/session_01XEgA9ynYQxzRUipm4CeXpq