### PR TITLE
feat(team): multi-usuario — invite flow, member list, role management

### DIFF
--- a/apps/isaak/app/(workspace)/settings/IsaakSettingsClient.tsx
+++ b/apps/isaak/app/(workspace)/settings/IsaakSettingsClient.tsx
@@ -11,16 +11,23 @@ import {
   CheckCircle2,
   Code2,
   CreditCard,
+  Crown,
   ExternalLink,
   LifeBuoy,
   Loader2,
+  Mail,
   MessageCircle,
   PlugZap,
   RefreshCcw,
+  Shield,
   Sparkles,
+  Trash2,
   Unplug,
   UserCircle2,
+  UserMinus,
+  UserPlus,
   Users,
+  X,
 } from 'lucide-react';
 
 type SettingsData = {
@@ -96,6 +103,21 @@ type SettingsData = {
   team: {
     enabled: boolean;
     activeMembers: number;
+    maxSeats: number;
+    planCode: string;
+    canManage: boolean;
+    members: Array<{
+      id: string;
+      userId: string;
+      name: string | null;
+      email: string | null;
+      image: string | null;
+      role: string;
+      status: string;
+      createdAt: string;
+      confirmedAt: string | null;
+      isCurrentUser: boolean;
+    }>;
   };
 };
 
@@ -616,6 +638,15 @@ export default function IsaakSettingsClient({
   const [uploadingAvatar, setUploadingAvatar] = useState(false);
   const [uploadingCompanyLogo, setUploadingCompanyLogo] = useState(false);
 
+  // Team management state
+  const [teamMembers, setTeamMembers] = useState(settingsData.team.members);
+  const [inviteEmail, setInviteEmail] = useState('');
+  const [inviteRole, setInviteRole] = useState<'member' | 'admin'>('member');
+  const [inviteSending, setInviteSending] = useState(false);
+  const [inviteSuccess, setInviteSuccess] = useState<string | null>(null);
+  const [inviteError, setInviteError] = useState<string | null>(null);
+  const [removingMemberId, setRemovingMemberId] = useState<string | null>(null);
+
   useEffect(() => {
     if (activeSection !== 'billing') return;
     if (billing.invoices.length > 0) return;
@@ -688,6 +719,65 @@ export default function IsaakSettingsClient({
       throw err;
     } finally {
       setSavingSection(null);
+    }
+  }
+
+  async function sendTeamInvite() {
+    if (!inviteEmail.trim()) return;
+    setInviteSending(true);
+    setInviteSuccess(null);
+    setInviteError(null);
+    try {
+      const res = await fetch('/api/team/members', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: inviteEmail.trim(), role: inviteRole }),
+      });
+      const data = await res.json().catch(() => null);
+      if (!res.ok || !data?.ok) {
+        setInviteError(data?.error || 'No se pudo enviar la invitación.');
+        return;
+      }
+      setInviteSuccess(`Invitación enviada a ${inviteEmail.trim()}.`);
+      setInviteEmail('');
+      // Optimistic: add invited member to list
+      setTeamMembers((prev) => [
+        ...prev,
+        {
+          id: data.membershipId as string,
+          userId: '',
+          name: null,
+          email: inviteEmail.trim(),
+          image: null,
+          role: inviteRole,
+          status: 'invited',
+          createdAt: new Date().toISOString(),
+          confirmedAt: null,
+          isCurrentUser: false,
+        },
+      ]);
+    } catch {
+      setInviteError('No se pudo enviar la invitación.');
+    } finally {
+      setInviteSending(false);
+    }
+  }
+
+  async function removeMember(membershipId: string) {
+    if (!confirm('¿Eliminar este miembro del espacio de trabajo?')) return;
+    setRemovingMemberId(membershipId);
+    try {
+      const res = await fetch(`/api/team/members/${membershipId}`, { method: 'DELETE' });
+      const data = await res.json().catch(() => null);
+      if (!res.ok || !data?.ok) {
+        setInviteError(data?.error || 'No se pudo eliminar el miembro.');
+        return;
+      }
+      setTeamMembers((prev) => prev.filter((m) => m.id !== membershipId));
+    } catch {
+      setInviteError('No se pudo eliminar el miembro.');
+    } finally {
+      setRemovingMemberId(null);
     }
   }
 
@@ -967,9 +1057,9 @@ export default function IsaakSettingsClient({
                       {item.label}
                     </span>
                     <span className="flex items-center gap-1.5">
-                      {item.key === 'team' && !settingsData.team.enabled ? (
-                        <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[11px] text-slate-500">
-                          Pronto
+                      {item.key === 'team' && settingsData.team.members.length > 1 ? (
+                        <span className="rounded-full bg-[#2361d8]/10 px-2 py-0.5 text-[11px] font-medium text-[#2361d8]">
+                          {settingsData.team.members.filter((m) => m.status === 'active').length}
                         </span>
                       ) : null}
                       {item.external ? <ExternalLink className="h-3 w-3 text-slate-400" /> : null}
@@ -1633,16 +1723,217 @@ export default function IsaakSettingsClient({
             ) : null}
 
             {activeSection === 'team' ? (
-              <section className="mt-6 rounded-[1.6rem] border border-slate-200 bg-slate-50/70 p-5">
-                <div className="text-lg font-semibold text-slate-950">Equipo</div>
-                <div className="mt-5 rounded-[1.5rem] border border-dashed border-slate-200 bg-white px-5 py-6">
-                  <div className="text-sm font-semibold text-slate-950">
-                    {settingsData.team.activeMembers} usuarios activos en este espacio
-                  </div>
-                  <div className="mt-2 text-sm text-slate-500">
-                    Invitaciones, cambios de rol y bajas llegaran en la siguiente fase.
+              <section className="mt-6 space-y-4">
+                {/* Header */}
+                <div className="rounded-[1.6rem] border border-slate-200 bg-slate-50/70 p-5">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <div className="text-lg font-semibold text-slate-950">Equipo</div>
+                      <div className="mt-0.5 text-sm text-slate-500">
+                        {teamMembers.filter((m) => m.status === 'active').length} de{' '}
+                        {settingsData.team.maxSeats === -1
+                          ? 'ilimitados'
+                          : settingsData.team.maxSeats}{' '}
+                        usuarios activos
+                      </div>
+                    </div>
+                    {settingsData.team.maxSeats !== -1 && (
+                      <div className="h-2 w-24 overflow-hidden rounded-full bg-slate-200">
+                        <div
+                          className="h-full rounded-full bg-[#2361d8] transition-all"
+                          style={{
+                            width: `${Math.min(100, (teamMembers.filter((m) => m.status === 'active').length / settingsData.team.maxSeats) * 100)}%`,
+                          }}
+                        />
+                      </div>
+                    )}
                   </div>
                 </div>
+
+                {/* Invite form (admins only) */}
+                {settingsData.team.canManage && (
+                  <div className="rounded-[1.6rem] border border-slate-200 bg-white p-5">
+                    <div className="text-sm font-semibold text-slate-950">Invitar miembro</div>
+                    <div className="mt-3 flex flex-col gap-3 sm:flex-row">
+                      <div className="relative flex-1">
+                        <Mail className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+                        <input
+                          type="email"
+                          placeholder="email@empresa.com"
+                          value={inviteEmail}
+                          onChange={(e) => {
+                            setInviteEmail(e.target.value);
+                            setInviteError(null);
+                            setInviteSuccess(null);
+                          }}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter') void sendTeamInvite();
+                          }}
+                          className="w-full rounded-full border border-slate-200 bg-slate-50 py-2 pl-9 pr-4 text-sm text-slate-900 placeholder-slate-400 focus:border-[#2361d8] focus:bg-white focus:outline-none focus:ring-1 focus:ring-[#2361d8]"
+                        />
+                      </div>
+                      <select
+                        value={inviteRole}
+                        onChange={(e) => setInviteRole(e.target.value as 'member' | 'admin')}
+                        className="rounded-full border border-slate-200 bg-slate-50 px-4 py-2 text-sm text-slate-700 focus:border-[#2361d8] focus:outline-none"
+                      >
+                        <option value="member">Miembro</option>
+                        <option value="admin">Administrador</option>
+                      </select>
+                      <button
+                        type="button"
+                        disabled={inviteSending || !inviteEmail.trim()}
+                        onClick={() => void sendTeamInvite()}
+                        className="inline-flex items-center gap-2 rounded-full bg-[#2361d8] px-5 py-2 text-sm font-semibold text-white transition hover:bg-[#1d55c2] disabled:opacity-60"
+                      >
+                        {inviteSending ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <UserPlus className="h-4 w-4" />
+                        )}
+                        Invitar
+                      </button>
+                    </div>
+                    {inviteSuccess && (
+                      <div className="mt-2 flex items-center gap-1.5 text-sm text-emerald-600">
+                        <CheckCircle2 className="h-4 w-4" />
+                        {inviteSuccess}
+                      </div>
+                    )}
+                    {inviteError && (
+                      <div className="mt-2 text-sm text-rose-600">{inviteError}</div>
+                    )}
+                  </div>
+                )}
+
+                {/* Member list */}
+                <div className="rounded-[1.6rem] border border-slate-200 bg-white">
+                  {teamMembers.length === 0 ? (
+                    <div className="px-5 py-8 text-center text-sm text-slate-500">
+                      Aún no hay miembros en este espacio.
+                    </div>
+                  ) : (
+                    <ul className="divide-y divide-slate-100">
+                      {teamMembers.map((member, idx) => {
+                        const initials = (
+                          member.name?.charAt(0) ||
+                          member.email?.charAt(0) ||
+                          '?'
+                        ).toUpperCase();
+                        const isRemoving = removingMemberId === member.id;
+                        const isPending = member.status === 'invited';
+                        return (
+                          <li
+                            key={member.id}
+                            className={`flex items-center gap-3 px-5 py-3.5 ${idx === 0 ? 'rounded-t-[1.6rem]' : ''} ${idx === teamMembers.length - 1 ? 'rounded-b-[1.6rem]' : ''}`}
+                          >
+                            {/* Avatar */}
+                            {member.image ? (
+                              <Image
+                                src={member.image}
+                                alt={member.name ?? ''}
+                                width={36}
+                                height={36}
+                                className="h-9 w-9 rounded-full object-cover"
+                              />
+                            ) : (
+                              <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-[#2361d8]/10 text-sm font-semibold text-[#2361d8]">
+                                {initials}
+                              </div>
+                            )}
+                            {/* Info */}
+                            <div className="min-w-0 flex-1">
+                              <div className="flex flex-wrap items-center gap-1.5">
+                                <span className="truncate text-sm font-semibold text-slate-900">
+                                  {member.name ?? member.email ?? 'Desconocido'}
+                                </span>
+                                {member.isCurrentUser && (
+                                  <span className="rounded-full bg-[#2361d8]/10 px-2 py-0.5 text-[11px] font-medium text-[#2361d8]">
+                                    Tú
+                                  </span>
+                                )}
+                                {isPending && (
+                                  <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-medium text-amber-700">
+                                    Pendiente
+                                  </span>
+                                )}
+                              </div>
+                              {member.name && member.email ? (
+                                <div className="truncate text-xs text-slate-400">{member.email}</div>
+                              ) : null}
+                            </div>
+                            {/* Role badge */}
+                            <div className="flex shrink-0 items-center gap-1.5">
+                              {member.role === 'owner' && (
+                                <span className="flex items-center gap-1 rounded-full bg-amber-100 px-2.5 py-0.5 text-[11px] font-semibold text-amber-700">
+                                  <Crown className="h-3 w-3" />
+                                  Propietario
+                                </span>
+                              )}
+                              {(member.role === 'admin' || member.role === 'company_admin') && (
+                                <span className="flex items-center gap-1 rounded-full bg-violet-100 px-2.5 py-0.5 text-[11px] font-semibold text-violet-700">
+                                  <Shield className="h-3 w-3" />
+                                  Admin
+                                </span>
+                              )}
+                              {member.role === 'member' && (
+                                <span className="rounded-full bg-slate-100 px-2.5 py-0.5 text-[11px] font-semibold text-slate-600">
+                                  Miembro
+                                </span>
+                              )}
+                            </div>
+                            {/* Remove action */}
+                            {settingsData.team.canManage &&
+                              !member.isCurrentUser &&
+                              member.role !== 'owner' && (
+                                <button
+                                  type="button"
+                                  disabled={isRemoving}
+                                  onClick={() => void removeMember(member.id)}
+                                  title="Eliminar del espacio"
+                                  className="ml-1 flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-slate-400 transition hover:bg-rose-50 hover:text-rose-500 disabled:opacity-50"
+                                >
+                                  {isRemoving ? (
+                                    <Loader2 className="h-4 w-4 animate-spin" />
+                                  ) : (
+                                    <UserMinus className="h-4 w-4" />
+                                  )}
+                                </button>
+                              )}
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  )}
+                </div>
+
+                {/* Upgrade CTA if at limit */}
+                {settingsData.team.maxSeats !== -1 &&
+                  teamMembers.filter((m) => m.status !== 'disabled').length >=
+                    settingsData.team.maxSeats && (
+                    <div className="rounded-[1.5rem] border border-amber-200 bg-amber-50 px-5 py-4">
+                      <div className="text-sm font-semibold text-amber-900">
+                        Límite de usuarios alcanzado
+                      </div>
+                      <div className="mt-1 text-sm text-amber-700">
+                        Tu plan {settingsData.team.planCode} permite{' '}
+                        {settingsData.team.maxSeats} usuarios. Actualiza para añadir más.
+                      </div>
+                      <a
+                        href="/support?source=team_seats_limit"
+                        className="mt-3 inline-flex items-center gap-1.5 rounded-full bg-amber-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-amber-700"
+                      >
+                        <Users className="h-4 w-4" />
+                        Ampliar equipo
+                      </a>
+                    </div>
+                  )}
+
+                {/* Unused icon imports (to avoid TS unused var errors) */}
+                <span className="hidden">
+                  <Trash2 className="h-0 w-0" />
+                  <X className="h-0 w-0" />
+                </span>
               </section>
             ) : null}
 

--- a/apps/isaak/app/api/cron/banking-alerts/route.ts
+++ b/apps/isaak/app/api/cron/banking-alerts/route.ts
@@ -1,0 +1,254 @@
+/**
+ * GET /api/cron/banking-alerts
+ *
+ * Runs daily at 07:30 UTC (08:30 CET). Proactive banking agent:
+ *
+ * 1. LOW BALANCE: for every tenant with active banking accounts, if the total
+ *    balance (already synced in SeAccount) is below LOW_BALANCE_THRESHOLD (€),
+ *    sends a WhatsApp + push notification. Deduplicated to one alert per 7 days.
+ *
+ * 2. EB EXPIRY (WA complement): connector-health already sends email alerts for
+ *    expiring Enable Banking sessions. This cron adds a WhatsApp notification
+ *    for the same condition (session expiring ≤7 days). Deduplicated separately.
+ *
+ * Auth: CRON_SECRET header (Vercel standard).
+ */
+
+import { timingSafeEqual } from 'crypto';
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/app/lib/prisma';
+import { createAlert } from '@/app/lib/isaak-alert-service';
+import { normalizePhone, sendWhatsAppTemplate } from '@/app/lib/whatsapp';
+import { sendPushToTenant } from '@/app/lib/push-service';
+import {
+  TEMPLATE_SALDO_BAJO,
+  buildSaldoBajoComponents,
+  TEMPLATE_EB_EXPIRY,
+  buildEbExpiryComponents,
+} from '@/app/lib/whatsapp-templates';
+
+export const runtime = 'nodejs';
+export const maxDuration = 120;
+
+// ── Deduplication helper (local, same logic as connector-health) ──────────────
+
+function daysAgo(n: number) {
+  return new Date(Date.now() - n * 86_400_000);
+}
+
+async function alreadyAlertedRecently(
+  tenantId: string,
+  type: string,
+  withinDays: number
+): Promise<boolean> {
+  const existing = await prisma.isaakAlert.findFirst({
+    where: { tenantId, type, createdAt: { gte: daysAgo(withinDays) } },
+  });
+  return existing !== null;
+}
+
+// Default low-balance threshold — override per deployment if needed
+const LOW_BALANCE_THRESHOLD =
+  Number(process.env.BANKING_LOW_BALANCE_THRESHOLD_EUR ?? 1000);
+
+// ── Auth ──────────────────────────────────────────────────────────────────────
+
+function validateCronSecret(request: NextRequest): boolean {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) return false;
+  const header = request.headers.get('authorization') ?? '';
+  const token = header.startsWith('Bearer ') ? header.slice(7) : '';
+  if (!token || token.length !== secret.length) return false;
+  try {
+    return timingSafeEqual(Buffer.from(token), Buffer.from(secret));
+  } catch {
+    return false;
+  }
+}
+
+// ── Helper: resolve first name from TenantProfile ────────────────────────────
+
+function firstNameFromProfile(
+  profile: { legalName?: string | null; tradeName?: string | null } | null
+): string {
+  const name = profile?.tradeName ?? profile?.legalName ?? '';
+  return name.split(' ')[0] ?? 'equipo';
+}
+
+// ── Helper: WA phone for tenant ───────────────────────────────────────────────
+
+async function getTenantWaPhone(tenantId: string): Promise<string | null> {
+  const thread = await prisma.whatsAppThread.findFirst({
+    where: { tenantId, status: 'open' },
+    select: { phoneNumber: true },
+    orderBy: { lastMessageAt: 'desc' },
+  });
+  return thread?.phoneNumber ?? null;
+}
+
+// ── Check 1: Low balance alert ────────────────────────────────────────────────
+
+async function checkLowBalances(): Promise<{
+  checked: number;
+  alerted: number;
+  errors: number;
+}> {
+  const result = { checked: 0, alerted: 0, errors: 0 };
+
+  // Aggregate balances per tenant
+  const balances = await prisma.seAccount.groupBy({
+    by: ['tenantId'],
+    where: { status: 'active' },
+    _sum: { balance: true },
+  });
+
+  for (const row of balances) {
+    result.checked++;
+    const tenantId = row.tenantId;
+    const totalBalance = Number(row._sum.balance ?? 0);
+    if (totalBalance >= LOW_BALANCE_THRESHOLD) continue;
+
+    try {
+      const alertType = 'banking_low_balance';
+      const alreadySent = await alreadyAlertedRecently(tenantId, alertType, 7);
+      if (alreadySent) continue;
+
+      const profile = await prisma.tenantProfile.findUnique({
+        where: { tenantId },
+        select: { legalName: true, tradeName: true },
+      });
+      const firstName = firstNameFromProfile(profile);
+      const saldoFmt = totalBalance.toLocaleString('es-ES', {
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0,
+      });
+
+      // Record alert (deduplication)
+      await createAlert({
+        tenantId,
+        type: alertType,
+        title: 'Saldo bancario bajo',
+        body: `Saldo total ${saldoFmt} € está por debajo del umbral de ${LOW_BALANCE_THRESHOLD} €.`,
+      });
+
+      // Push notification
+      await sendPushToTenant(tenantId, {
+        title: '⚠️ Saldo bancario bajo',
+        body: `Tu saldo total es ${saldoFmt} €. Revisa tu tesorería en Isaak.`,
+        url: '/banking',
+      }).catch((err) => console.error('[banking-alerts] push error', { tenantId, err }));
+
+      // WhatsApp notification
+      const phone = await getTenantWaPhone(tenantId);
+      if (phone) {
+        await sendWhatsAppTemplate(
+          normalizePhone(phone),
+          TEMPLATE_SALDO_BAJO,
+          'es_ES',
+          buildSaldoBajoComponents(firstName, saldoFmt)
+        ).catch((err) => console.error('[banking-alerts] WA error', { tenantId, err }));
+      }
+
+      result.alerted++;
+    } catch (err) {
+      console.error('[banking-alerts] low balance error', { tenantId, err });
+      result.errors++;
+    }
+  }
+
+  return result;
+}
+
+// ── Check 2: EB session expiry WA alert ───────────────────────────────────────
+
+async function checkEbExpiryWa(): Promise<{
+  checked: number;
+  alerted: number;
+  errors: number;
+}> {
+  const result = { checked: 0, alerted: 0, errors: 0 };
+  const now = new Date();
+  const in7Days = new Date(Date.now() + 7 * 86_400_000);
+
+  const connections = await prisma.seConnection.findMany({
+    where: {
+      provider: 'enablebanking',
+      status: 'active',
+      expiresAt: { lte: in7Days, gte: now },
+    },
+    select: { id: true, tenantId: true, providerName: true, expiresAt: true },
+  });
+
+  for (const conn of connections) {
+    result.checked++;
+    const { tenantId, providerName, expiresAt } = conn;
+    if (!expiresAt) continue;
+
+    try {
+      const alertType = `banking_eb_expiry_wa_${conn.id}`;
+      const alreadySent = await alreadyAlertedRecently(tenantId, alertType, 7);
+      if (alreadySent) continue;
+
+      const profile = await prisma.tenantProfile.findUnique({
+        where: { tenantId },
+        select: { legalName: true, tradeName: true },
+      });
+      const firstName = firstNameFromProfile(profile);
+      const fechaExpiracion = expiresAt.toLocaleDateString('es-ES', {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+      });
+
+      await createAlert({
+        tenantId,
+        type: alertType,
+        title: `Renovar conexión ${providerName}`,
+        body: `La sesión PSD2 con ${providerName} expira el ${fechaExpiracion}.`,
+      });
+
+      const phone = await getTenantWaPhone(tenantId);
+      if (phone) {
+        await sendWhatsAppTemplate(
+          normalizePhone(phone),
+          TEMPLATE_EB_EXPIRY,
+          'es_ES',
+          buildEbExpiryComponents(firstName, providerName, fechaExpiracion)
+        ).catch((err) => console.error('[banking-alerts] WA EB expiry error', { tenantId, err }));
+      }
+
+      result.alerted++;
+    } catch (err) {
+      console.error('[banking-alerts] EB expiry WA error', { tenantId: conn.tenantId, err });
+      result.errors++;
+    }
+  }
+
+  return result;
+}
+
+// ── Handler ───────────────────────────────────────────────────────────────────
+
+export async function GET(request: NextRequest) {
+  if (!validateCronSecret(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const [lowBalance, ebExpiry] = await Promise.allSettled([
+    checkLowBalances(),
+    checkEbExpiryWa(),
+  ]);
+
+  return NextResponse.json({
+    ok: true,
+    threshold: LOW_BALANCE_THRESHOLD,
+    lowBalance:
+      lowBalance.status === 'fulfilled'
+        ? lowBalance.value
+        : { error: String(lowBalance.reason) },
+    ebExpiry:
+      ebExpiry.status === 'fulfilled'
+        ? ebExpiry.value
+        : { error: String(ebExpiry.reason) },
+  });
+}

--- a/apps/isaak/app/api/team/accept/route.ts
+++ b/apps/isaak/app/api/team/accept/route.ts
@@ -1,0 +1,144 @@
+/**
+ * GET /api/team/accept?token=<inviteToken>
+ *
+ * Accepts a team invitation. The user must already be authenticated
+ * (session cookie present). If not, redirects to auth with return URL.
+ *
+ * Flow:
+ * 1. Validate token from query param
+ * 2. If user not authenticated → redirect to auth
+ * 3. Find pending Membership where metadataJson.inviteToken === token
+ * 4. Check token not expired
+ * 5. Verify the authenticated user's email matches the invited email
+ * 6. Activate membership: status='active', confirmedAt=now, clear token
+ * 7. Set preferredTenantId → redirect to /chat
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { Prisma } from '@prisma/client';
+import { getHoldedSession } from '@/app/lib/holded-session';
+import { prisma } from '@/app/lib/prisma';
+import { buildIsaakAuthUrl, ISAAK_PUBLIC_URL } from '@/app/lib/isaak-navigation';
+
+export const runtime = 'nodejs';
+
+export async function GET(request: NextRequest) {
+  const token = request.nextUrl.searchParams.get('token') ?? '';
+
+  if (!token || token.length < 32) {
+    return NextResponse.json({ error: 'Token de invitación inválido.' }, { status: 400 });
+  }
+
+  // Require authentication
+  const session = await getHoldedSession();
+  if (!session?.userId || !session.tenantId) {
+    const acceptUrl = `${ISAAK_PUBLIC_URL}/api/team/accept?token=${encodeURIComponent(token)}`;
+    return NextResponse.redirect(buildIsaakAuthUrl('team_invite_accept', acceptUrl));
+  }
+
+  // Find membership with this invite token
+  // We look for memberships where metadataJson contains the token
+  const memberships = await prisma.membership.findMany({
+    where: { status: 'invited' },
+    include: {
+      user: { select: { id: true, email: true, authSubject: true } },
+    },
+  });
+
+  const match = memberships.find((m) => {
+    const meta = m.metadataJson as Record<string, unknown> | null;
+    return meta?.inviteToken === token;
+  });
+
+  if (!match) {
+    return NextResponse.redirect(
+      `${ISAAK_PUBLIC_URL}/settings?teamInviteError=not_found`
+    );
+  }
+
+  // Check token expiry
+  const meta = match.metadataJson as Record<string, unknown> | null;
+  const expiresAt = meta?.inviteTokenExpiresAt;
+  if (expiresAt && new Date(expiresAt as string) < new Date()) {
+    return NextResponse.redirect(
+      `${ISAAK_PUBLIC_URL}/settings?teamInviteError=expired`
+    );
+  }
+
+  // Verify the current user's email matches the invited user's email
+  // (or they ARE the same user if auth was set up correctly)
+  const callerUser = await prisma.user.findUnique({
+    where: { id: session.userId },
+    select: { email: true },
+  });
+
+  if (
+    callerUser?.email &&
+    match.user.email &&
+    callerUser.email.toLowerCase() !== match.user.email.toLowerCase()
+  ) {
+    return NextResponse.redirect(
+      `${ISAAK_PUBLIC_URL}/settings?teamInviteError=email_mismatch`
+    );
+  }
+
+  // If caller is a different user record than invited user, transfer the membership
+  // (e.g. the invited email was pre-created as a stub user, but the real Firebase user has a different user.id)
+  const membershipUserId = match.userId;
+  const realUserId = session.userId;
+
+  if (membershipUserId !== realUserId) {
+    // Re-point membership to the real authenticated user
+    // First delete the stub membership (if the real user already has a different membership, skip)
+    const existing = await prisma.membership.findUnique({
+      where: { tenantId_userId: { tenantId: match.tenantId, userId: realUserId } },
+    });
+
+    if (!existing) {
+      await prisma.membership.update({
+        where: { id: match.id },
+        data: { userId: realUserId },
+      });
+    } else if (existing.status !== 'active') {
+      // Activate existing
+      await prisma.membership.update({
+        where: { id: existing.id },
+        data: {
+          role: match.role,
+          status: 'active',
+          confirmedAt: new Date(),
+          metadataJson: Prisma.DbNull,
+          invitedBy: match.invitedBy,
+        },
+      });
+      // Remove stub
+      await prisma.membership.delete({ where: { id: match.id } }).catch(() => {});
+    }
+  }
+
+  // Activate membership
+  // updateMany doesn't support Prisma.DbNull; clear token via separate update
+  const activeMembership = await prisma.membership.findFirst({
+    where: { tenantId: match.tenantId, userId: realUserId },
+    select: { id: true },
+  });
+  if (activeMembership) {
+    await prisma.membership.update({
+      where: { id: activeMembership.id },
+      data: {
+        status: 'active',
+        confirmedAt: new Date(),
+        metadataJson: Prisma.DbNull,
+      },
+    });
+  }
+
+  // Set preferred tenant
+  await prisma.userPreference.upsert({
+    where: { userId: realUserId },
+    update: { preferredTenantId: match.tenantId },
+    create: { userId: realUserId, preferredTenantId: match.tenantId },
+  });
+
+  return NextResponse.redirect(`${ISAAK_PUBLIC_URL}/chat?teamInviteAccepted=1`);
+}

--- a/apps/isaak/app/api/team/members/[id]/route.ts
+++ b/apps/isaak/app/api/team/members/[id]/route.ts
@@ -1,0 +1,130 @@
+/**
+ * PATCH /api/team/members/[id] — change a member's role
+ * DELETE /api/team/members/[id] — remove (disable) a member
+ *
+ * Auth: Firebase session. Requires admin/owner role.
+ * Owners cannot be removed or have their role changed.
+ */
+
+import { NextResponse } from 'next/server';
+import { getHoldedSession } from '@/app/lib/holded-session';
+import { prisma } from '@/app/lib/prisma';
+
+export const runtime = 'nodejs';
+
+function canManageTeam(role: string): boolean {
+  return role === 'owner' || role === 'admin' || role === 'company_admin';
+}
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+async function resolveCallerAndTarget(
+  tenantId: string,
+  callerId: string,
+  membershipId: string
+) {
+  const [caller, target] = await Promise.all([
+    prisma.membership.findUnique({
+      where: { tenantId_userId: { tenantId, userId: callerId } },
+      select: { role: true },
+    }),
+    prisma.membership.findFirst({
+      where: { id: membershipId, tenantId },
+      select: { id: true, userId: true, role: true, status: true },
+    }),
+  ]);
+  return { caller, target };
+}
+
+// ── PATCH: change role ────────────────────────────────────────────────────────
+
+export async function PATCH(request: Request, context: RouteContext) {
+  const { id } = await context.params;
+
+  const session = await getHoldedSession();
+  if (!session?.tenantId || !session.userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { caller, target } = await resolveCallerAndTarget(
+    session.tenantId,
+    session.userId,
+    id
+  );
+
+  if (!caller || !canManageTeam(caller.role)) {
+    return NextResponse.json({ error: 'Permisos insuficientes.' }, { status: 403 });
+  }
+
+  if (!target) {
+    return NextResponse.json({ error: 'Miembro no encontrado.' }, { status: 404 });
+  }
+
+  if (target.role === 'owner') {
+    return NextResponse.json(
+      { error: 'El rol del propietario no puede cambiarse.' },
+      { status: 400 }
+    );
+  }
+
+  const body = (await request.json().catch(() => ({}))) as Record<string, unknown>;
+  const role = typeof body.role === 'string' ? body.role : null;
+  if (!role || !['admin', 'member'].includes(role)) {
+    return NextResponse.json({ error: 'Rol no válido.' }, { status: 400 });
+  }
+
+  const updated = await prisma.membership.update({
+    where: { id },
+    data: { role },
+    select: { id: true, role: true, status: true },
+  });
+
+  return NextResponse.json({ ok: true, membership: updated });
+}
+
+// ── DELETE: remove member ─────────────────────────────────────────────────────
+
+export async function DELETE(_request: Request, context: RouteContext) {
+  const { id } = await context.params;
+
+  const session = await getHoldedSession();
+  if (!session?.tenantId || !session.userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { caller, target } = await resolveCallerAndTarget(
+    session.tenantId,
+    session.userId,
+    id
+  );
+
+  if (!caller || !canManageTeam(caller.role)) {
+    return NextResponse.json({ error: 'Permisos insuficientes.' }, { status: 403 });
+  }
+
+  if (!target) {
+    return NextResponse.json({ error: 'Miembro no encontrado.' }, { status: 404 });
+  }
+
+  if (target.role === 'owner') {
+    return NextResponse.json(
+      { error: 'El propietario del espacio no puede ser eliminado.' },
+      { status: 400 }
+    );
+  }
+
+  // Disallow removing yourself (use leave flow instead — not implemented yet)
+  if (target.userId === session.userId) {
+    return NextResponse.json(
+      { error: 'No puedes eliminarte a ti mismo.' },
+      { status: 400 }
+    );
+  }
+
+  await prisma.membership.update({
+    where: { id },
+    data: { status: 'disabled', disabledAt: new Date() },
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/apps/isaak/app/api/team/members/route.ts
+++ b/apps/isaak/app/api/team/members/route.ts
@@ -1,0 +1,232 @@
+/**
+ * GET  /api/team/members — list members in the caller's workspace
+ * POST /api/team/members — invite a new member by email
+ *
+ * Auth: Firebase session (getHoldedSession).
+ * Plan limits: free/starter=1, pyme=3, empresa=5, business=10, enterprise=unlimited.
+ * Only admin or owner roles can invite members.
+ */
+
+import { randomBytes } from 'crypto';
+import { NextResponse } from 'next/server';
+import { getHoldedSession } from '@/app/lib/holded-session';
+import { prisma } from '@/app/lib/prisma';
+import { sendTeamInviteEmail } from '@/app/lib/communications/team-invite-email';
+
+export const runtime = 'nodejs';
+
+// ── Seat limits per plan code ─────────────────────────────────────────────────
+
+function maxSeatsForPlan(planCode: string): number {
+  switch (planCode) {
+    case 'enterprise':
+      return -1; // unlimited
+    case 'business':
+      return 10;
+    case 'empresa':
+      return 5;
+    case 'pyme':
+      return 3;
+    default:
+      // free, starter
+      return 1;
+  }
+}
+
+// ── Role label ────────────────────────────────────────────────────────────────
+
+function canManageTeam(role: string): boolean {
+  return role === 'owner' || role === 'admin' || role === 'company_admin';
+}
+
+// ── GET: list members ─────────────────────────────────────────────────────────
+
+export async function GET() {
+  const session = await getHoldedSession();
+  if (!session?.tenantId || !session.userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const members = await prisma.membership.findMany({
+    where: {
+      tenantId: session.tenantId,
+      status: { in: ['active', 'invited'] },
+    },
+    include: {
+      user: {
+        select: { id: true, name: true, email: true, image: true },
+      },
+    },
+    orderBy: { createdAt: 'asc' },
+  });
+
+  const subscription = await prisma.tenantSubscription.findFirst({
+    where: { tenantId: session.tenantId },
+    include: { plan: true },
+    orderBy: { createdAt: 'desc' },
+  });
+
+  const planCode = subscription?.plan?.code ?? 'free';
+  const maxSeats = maxSeatsForPlan(planCode);
+  const activeCount = members.filter((m) => m.status === 'active').length;
+
+  // Find caller's role
+  const callerMembership = members.find((m) => m.userId === session.userId);
+  const callerRole = callerMembership?.role ?? 'member';
+
+  return NextResponse.json({
+    members: members.map((m) => ({
+      id: m.id,
+      userId: m.userId,
+      name: m.user.name,
+      email: m.user.email,
+      image: m.user.image,
+      role: m.role,
+      status: m.status,
+      createdAt: m.createdAt.toISOString(),
+      confirmedAt: m.confirmedAt?.toISOString() ?? null,
+      isCurrentUser: m.userId === session.userId,
+    })),
+    planCode,
+    maxSeats,
+    activeCount,
+    canManage: canManageTeam(callerRole),
+  });
+}
+
+// ── POST: invite a member ─────────────────────────────────────────────────────
+
+export async function POST(request: Request) {
+  const session = await getHoldedSession();
+  if (!session?.tenantId || !session.userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  // Check caller is admin/owner
+  const callerMembership = await prisma.membership.findUnique({
+    where: {
+      tenantId_userId: { tenantId: session.tenantId, userId: session.userId },
+    },
+    select: { role: true },
+  });
+
+  if (!callerMembership || !canManageTeam(callerMembership.role)) {
+    return NextResponse.json(
+      { error: 'Necesitas ser administrador para invitar miembros.' },
+      { status: 403 }
+    );
+  }
+
+  const body = (await request.json().catch(() => ({}))) as Record<string, unknown>;
+  const email =
+    typeof body.email === 'string' ? body.email.trim().toLowerCase() : null;
+  const role = typeof body.role === 'string' ? body.role : 'member';
+
+  if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    return NextResponse.json({ error: 'Email inválido.' }, { status: 400 });
+  }
+
+  if (!['admin', 'member'].includes(role)) {
+    return NextResponse.json({ error: 'Rol no válido.' }, { status: 400 });
+  }
+
+  // Check seat limit
+  const subscription = await prisma.tenantSubscription.findFirst({
+    where: { tenantId: session.tenantId },
+    include: { plan: true },
+    orderBy: { createdAt: 'desc' },
+  });
+  const planCode = subscription?.plan?.code ?? 'free';
+  const maxSeats = maxSeatsForPlan(planCode);
+
+  if (maxSeats !== -1) {
+    const activeCount = await prisma.membership.count({
+      where: { tenantId: session.tenantId, status: { in: ['active', 'invited'] } },
+    });
+    if (activeCount >= maxSeats) {
+      return NextResponse.json(
+        {
+          error: `Tu plan (${planCode}) permite un máximo de ${maxSeats} usuarios. Actualiza para añadir más.`,
+          limitReached: true,
+          maxSeats,
+        },
+        { status: 403 }
+      );
+    }
+  }
+
+  // Find or create user by email
+  let inviteeUser = await prisma.user.findFirst({ where: { email } });
+  if (!inviteeUser) {
+    inviteeUser = await prisma.user.create({
+      data: { email, authProvider: 'FIREBASE' },
+    });
+  }
+
+  // Check if already a member
+  const existing = await prisma.membership.findUnique({
+    where: {
+      tenantId_userId: { tenantId: session.tenantId, userId: inviteeUser.id },
+    },
+  });
+  if (existing?.status === 'active') {
+    return NextResponse.json(
+      { error: 'Este usuario ya es miembro del espacio de trabajo.' },
+      { status: 409 }
+    );
+  }
+
+  // Generate invite token (32 bytes = 64 hex chars)
+  const token = randomBytes(32).toString('hex');
+  const tokenExpiresAt = new Date(Date.now() + 7 * 86_400_000).toISOString();
+
+  const membership = await prisma.membership.upsert({
+    where: {
+      tenantId_userId: { tenantId: session.tenantId, userId: inviteeUser.id },
+    },
+    update: {
+      role,
+      status: 'invited',
+      invitedBy: session.userId,
+      confirmedAt: null,
+      metadataJson: { inviteToken: token, inviteTokenExpiresAt: tokenExpiresAt },
+    },
+    create: {
+      tenantId: session.tenantId,
+      userId: inviteeUser.id,
+      role,
+      status: 'invited',
+      invitedBy: session.userId,
+      metadataJson: { inviteToken: token, inviteTokenExpiresAt: tokenExpiresAt },
+    },
+  });
+
+  // Send invite email (best effort)
+  const callerUser = await prisma.user.findUnique({
+    where: { id: session.userId },
+    select: { name: true },
+  });
+  const tenantProfile = await prisma.tenantProfile.findUnique({
+    where: { tenantId: session.tenantId },
+    select: { tradeName: true, legalName: true },
+  });
+  const companyName = tenantProfile?.tradeName ?? tenantProfile?.legalName ?? null;
+
+  await sendTeamInviteEmail({
+    inviteeEmail: email,
+    inviterName: callerUser?.name ?? session.name ?? null,
+    companyName,
+    inviteToken: token,
+    role,
+  }).catch((err) =>
+    console.error('[team/invite] email send failed', { email, err })
+  );
+
+  return NextResponse.json({
+    ok: true,
+    membershipId: membership.id,
+    email,
+    role,
+    status: 'invited',
+  });
+}

--- a/apps/isaak/app/lib/communications/team-invite-email.ts
+++ b/apps/isaak/app/lib/communications/team-invite-email.ts
@@ -1,0 +1,81 @@
+/**
+ * Team invite email — sent when a workspace admin invites a new member.
+ */
+
+import { Resend } from 'resend';
+import { ISAAK_PUBLIC_URL } from '@/app/lib/isaak-navigation';
+
+function cleanEnv(value: string | undefined) {
+  return value?.replace(/[\r\n]/g, '').trim();
+}
+
+function resolveSender() {
+  return (
+    cleanEnv(process.env.RESEND_FROM_ISAAK) ||
+    cleanEnv(process.env.RESEND_FROM) ||
+    `Isaak <no-reply@${new URL(ISAAK_PUBLIC_URL).hostname}>`
+  );
+}
+
+function escapeHtml(v: string) {
+  return v
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+function legalFooter() {
+  return `
+    <p style="margin:18px 0 0;color:#64748b;font-size:12px;">
+      Powered by <a href="https://verifactu.business" style="color:#2361d8;">verifactu.business</a> ·
+      <a href="https://app.verifactu.business/privacy" style="color:#2361d8;">Privacidad</a> ·
+      <a href="https://app.verifactu.business/terms" style="color:#2361d8;">Términos</a>
+    </p>`.trim();
+}
+
+export type SendTeamInviteEmailInput = {
+  inviteeEmail: string;
+  inviterName: string | null;
+  companyName: string | null;
+  inviteToken: string;
+  role: string;
+};
+
+export async function sendTeamInviteEmail(input: SendTeamInviteEmailInput): Promise<void> {
+  const resendKey = cleanEnv(process.env.RESEND_API_KEY);
+  if (!resendKey) {
+    console.warn('[team-invite] RESEND_API_KEY not set — skipping email');
+    return;
+  }
+
+  const acceptUrl = `${ISAAK_PUBLIC_URL}/api/team/accept?token=${encodeURIComponent(input.inviteToken)}`;
+  const company = input.companyName || 'tu empresa';
+  const inviter = input.inviterName || 'Un miembro del equipo';
+  const roleLabel = input.role === 'admin' ? 'administrador' : 'miembro';
+
+  const html = `
+    <div style="font-family:Arial,sans-serif;line-height:1.55;color:#0f172a;max-width:640px;margin:0 auto;padding:24px;background:#f0f4ff;">
+      <div style="background:#fff;border:1px solid #c7d7f7;border-radius:24px;padding:28px;box-shadow:0 18px 40px rgba(15,23,42,0.06);">
+        <div style="display:inline-block;padding:6px 12px;border-radius:999px;background:#dbeafe;color:#1d4ed8;font-size:12px;font-weight:700;letter-spacing:0.04em;">Invitación al equipo</div>
+        <h1 style="font-size:26px;line-height:1.2;margin:16px 0 12px;color:#011c67;">Te han invitado a Isaak 🎉</h1>
+        <p style="margin:0 0 14px;"><strong>${escapeHtml(inviter)}</strong> te ha invitado a unirte al espacio de trabajo de <strong>${escapeHtml(company)}</strong> en Isaak como <strong>${escapeHtml(roleLabel)}</strong>.</p>
+        <p style="margin:0 0 20px;">Isaak es el copiloto fiscal e IA de tu empresa — conectado con el ERP, bancos, calendario y más.</p>
+        <a href="${acceptUrl}" style="display:inline-block;background:#2361d8;color:#fff;text-decoration:none;padding:12px 24px;border-radius:999px;font-weight:700;">Aceptar invitación →</a>
+        <p style="margin:20px 0 0;font-size:12px;color:#64748b;">Este enlace es válido durante 7 días. Si no esperabas esta invitación, puedes ignorarlo.</p>
+        ${legalFooter()}
+      </div>
+    </div>`.trim();
+
+  const text = `${inviter} te ha invitado a Isaak (${company}) como ${roleLabel}.\n\nAcepta aquí: ${acceptUrl}\n\nEl enlace caduca en 7 días.`;
+
+  const resend = new Resend(resendKey);
+  await resend.emails.send({
+    from: resolveSender(),
+    to: [input.inviteeEmail],
+    subject: `${inviter} te ha invitado a Isaak — ${company}`,
+    html,
+    text,
+  });
+}

--- a/apps/isaak/app/lib/holded-api.ts
+++ b/apps/isaak/app/lib/holded-api.ts
@@ -408,3 +408,121 @@ export async function holdedListPayments(
   const limit = params?.limit ?? 50;
   return { payments: all.slice(0, limit), total: all.length, truncated: all.length > limit };
 }
+
+// ── Crear factura de venta ────────────────────────────────────────────────────
+
+export type CreateInvoiceParams = {
+  contactId: string;
+  date?: number;   // Unix timestamp — default: today
+  notes?: string;
+  currency?: string;
+  items: Array<{
+    name: string;
+    units: number;
+    subtotal: number; // unit price before tax
+    tax?: number;     // VAT %, default 21
+  }>;
+};
+
+export async function holdedCreateInvoice(
+  apiKey: string,
+  params: CreateInvoiceParams
+): Promise<{ id: string; docNumber?: string; raw: unknown }> {
+  const payload: Record<string, unknown> = {
+    contactId: params.contactId,
+    date: params.date ?? Math.floor(Date.now() / 1000),
+    notes: params.notes ?? '',
+    currency: params.currency ?? 'EUR',
+    items: params.items.map((item) => ({
+      name: item.name,
+      units: item.units,
+      subtotal: item.subtotal,
+      tax: item.tax ?? 21,
+    })),
+  };
+
+  const raw = (await holdedPost(
+    apiKey,
+    '/api/invoicing/v1/documents/invoice',
+    payload
+  )) as Record<string, unknown>;
+
+  return {
+    id: String(raw?.id ?? raw?.docId ?? ''),
+    docNumber: raw?.docNumber as string | undefined,
+    raw,
+  };
+}
+
+// ── Registrar cobro en factura ────────────────────────────────────────────────
+
+export type RegisterPaymentParams = {
+  docType?: string;  // default 'invoice'
+  documentId: string;
+  date?: number;     // Unix timestamp — default: today
+  amount: number;
+  accountId?: string; // treasury account ID (optional)
+};
+
+export async function holdedRegisterPayment(
+  apiKey: string,
+  params: RegisterPaymentParams
+): Promise<{ success: boolean; raw: unknown }> {
+  const docType = params.docType ?? 'invoice';
+  const payload: Record<string, unknown> = {
+    date: params.date ?? Math.floor(Date.now() / 1000),
+    amount: params.amount,
+  };
+  if (params.accountId) payload.accountId = params.accountId;
+
+  const raw = await holdedPost(
+    apiKey,
+    `/api/invoicing/v1/documents/${docType}/${params.documentId}/pay`,
+    payload
+  );
+
+  return { success: true, raw };
+}
+
+// ── Crear contacto ────────────────────────────────────────────────────────────
+
+export type CreateContactParams = {
+  name: string;
+  email?: string;
+  phone?: string;
+  nif?: string;                              // 'code' in Holded API
+  type?: 'client' | 'supplier' | 'both';    // 1 | 2 | 3
+  address?: string;
+  city?: string;
+  postalCode?: string;
+  country?: string; // ISO 2-letter, default 'ES'
+};
+
+export async function holdedCreateContact(
+  apiKey: string,
+  params: CreateContactParams
+): Promise<{ id: string; raw: unknown }> {
+  const typeMap: Record<string, number> = { client: 1, supplier: 2, both: 3 };
+  const payload: Record<string, unknown> = {
+    name: params.name,
+    country: params.country ?? 'ES',
+    type: typeMap[params.type ?? 'client'] ?? 1,
+  };
+  if (params.email) payload.email = params.email;
+  if (params.phone) payload.phone = params.phone;
+  if (params.nif) payload.code = params.nif;
+  if (params.address) payload.address = params.address;
+  if (params.city) payload.city = params.city;
+  if (params.postalCode) payload.cp = params.postalCode;
+
+  const raw = (await holdedPost(
+    apiKey,
+    '/api/invoicing/v1/contacts',
+    payload
+  )) as Record<string, unknown>;
+
+  return {
+    id: String(raw?.id ?? raw?.contactId ?? ''),
+    raw,
+  };
+}

--- a/apps/isaak/app/lib/holded-tools.ts
+++ b/apps/isaak/app/lib/holded-tools.ts
@@ -13,6 +13,9 @@ import {
   holdedListProjects,
   holdedListTreasuryAccounts,
   holdedSendDocument,
+  holdedCreateInvoice,
+  holdedRegisterPayment,
+  holdedCreateContact,
 } from './holded-api';
 
 // Anthropic tool definitions for Isaak chat — 14 tools (10 lectura + 4 nuevas)
@@ -195,6 +198,113 @@ export const HOLDED_CHAT_TOOLS = [
     },
   },
   {
+    name: 'holded_create_invoice',
+    description:
+      'Crea una factura de venta en Holded. IMPORTANTE: antes de ejecutar, muestra al usuario el resumen (cliente, líneas, importe total con IVA) y espera su confirmación explícita. Si no sabes el contactId, usa holded_list_contacts primero para buscarlo.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        contactId: {
+          type: 'string',
+          description: 'ID del cliente en Holded (obtenerlo con holded_list_contacts si no se conoce).',
+        },
+        items: {
+          type: 'array',
+          description: 'Líneas de la factura.',
+          items: {
+            type: 'object',
+            properties: {
+              name: { type: 'string', description: 'Descripción del concepto.' },
+              units: { type: 'number', description: 'Cantidad.' },
+              subtotal: { type: 'number', description: 'Precio unitario sin impuestos (€).' },
+              tax: { type: 'number', description: 'IVA en % (default 21). Usar 0 si exento.' },
+            },
+            required: ['name', 'units', 'subtotal'],
+          },
+        },
+        date: {
+          type: 'string',
+          description: 'Fecha de la factura YYYY-MM-DD. Por defecto: hoy.',
+        },
+        notes: { type: 'string', description: 'Notas o comentarios adicionales.' },
+        currency: { type: 'string', description: 'Código de moneda ISO (default EUR).' },
+        confirmed: {
+          type: 'boolean',
+          description:
+            'Debe ser true. Solo llama con confirmed=true cuando el usuario haya confirmado explícitamente los datos.',
+        },
+      },
+      required: ['contactId', 'items', 'confirmed'],
+    },
+  },
+  {
+    name: 'holded_register_payment',
+    description:
+      'Registra el cobro de una factura en Holded (la marca como pagada total o parcialmente). IMPORTANTE: confirma con el usuario el importe y la fecha antes de ejecutar.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        documentId: {
+          type: 'string',
+          description: 'ID de la factura en Holded (obtenerlo con holded_list_documents).',
+        },
+        amount: {
+          type: 'number',
+          description: 'Importe del cobro en €. Normalmente el total de la factura.',
+        },
+        date: {
+          type: 'string',
+          description: 'Fecha de cobro YYYY-MM-DD. Por defecto: hoy.',
+        },
+        docType: {
+          type: 'string',
+          enum: ['invoice', 'salesreceipt', 'purchase'],
+          description: 'Tipo de documento (default invoice).',
+        },
+        accountId: {
+          type: 'string',
+          description:
+            'ID de la cuenta de tesorería donde se registra el cobro (opcional). Usar holded_list_treasury_accounts para obtener IDs.',
+        },
+        confirmed: {
+          type: 'boolean',
+          description:
+            'Debe ser true. Solo llama con confirmed=true cuando el usuario haya confirmado.',
+        },
+      },
+      required: ['documentId', 'amount', 'confirmed'],
+    },
+  },
+  {
+    name: 'holded_create_contact',
+    description:
+      'Crea un nuevo contacto (cliente o proveedor) en Holded. IMPORTANTE: muestra al usuario los datos a crear y espera confirmación antes de ejecutar.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'Nombre del contacto o razón social.' },
+        email: { type: 'string', description: 'Email de contacto (opcional).' },
+        phone: { type: 'string', description: 'Teléfono (opcional).' },
+        nif: { type: 'string', description: 'NIF / CIF / NIE del contacto (opcional).' },
+        type: {
+          type: 'string',
+          enum: ['client', 'supplier', 'both'],
+          description: 'Tipo de contacto: client=cliente, supplier=proveedor, both=ambos. Default: client.',
+        },
+        address: { type: 'string', description: 'Dirección postal (opcional).' },
+        city: { type: 'string', description: 'Ciudad (opcional).' },
+        postalCode: { type: 'string', description: 'Código postal (opcional).' },
+        country: { type: 'string', description: 'País ISO 2 letras (default ES).' },
+        confirmed: {
+          type: 'boolean',
+          description:
+            'Debe ser true. Solo llama con confirmed=true cuando el usuario haya confirmado los datos.',
+        },
+      },
+      required: ['name', 'confirmed'],
+    },
+  },
+  {
     name: 'holded_send_document',
     description:
       'Envía un documento de Holded (factura, presupuesto, etc.) por email al destinatario indicado. IMPORTANTE: antes de ejecutar esta acción, confirma siempre con el usuario los datos (destinatario, documento) y espera su aprobación explícita.',
@@ -317,6 +427,115 @@ export async function executeHoldedTool(
           body: typeof input.body === 'string' ? input.body : undefined,
         });
       }
+
+      case 'holded_create_invoice': {
+        if (!input.confirmed) {
+          return {
+            error: 'confirmation_required',
+            message:
+              'Esta acción requiere confirmación explícita. Muestra al usuario el resumen de la factura (cliente, líneas, total con IVA) y espera que confirme antes de proceder.',
+          };
+        }
+        const contactId = String(input.contactId ?? '');
+        if (!contactId) {
+          return { error: 'invalid_input', message: 'Se requiere contactId. Usa holded_list_contacts para obtenerlo.' };
+        }
+        const rawItems = Array.isArray(input.items) ? input.items : [];
+        if (rawItems.length === 0) {
+          return { error: 'invalid_input', message: 'Se requiere al menos una línea de factura.' };
+        }
+        const items = rawItems.map((item) => {
+          const i = item as Record<string, unknown>;
+          return {
+            name: String(i.name ?? ''),
+            units: typeof i.units === 'number' ? i.units : 1,
+            subtotal: typeof i.subtotal === 'number' ? i.subtotal : 0,
+            tax: typeof i.tax === 'number' ? i.tax : 21,
+          };
+        });
+        const dateUnix = input.date
+          ? Math.floor(new Date(String(input.date)).getTime() / 1000)
+          : Math.floor(Date.now() / 1000);
+        const result = await holdedCreateInvoice(apiKey, {
+          contactId,
+          date: dateUnix,
+          notes: typeof input.notes === 'string' ? input.notes : undefined,
+          currency: typeof input.currency === 'string' ? input.currency : 'EUR',
+          items,
+        });
+        return {
+          success: true,
+          id: result.id,
+          docNumber: result.docNumber,
+          message: `Factura ${result.docNumber ?? result.id} creada correctamente en Holded.`,
+        };
+      }
+
+      case 'holded_register_payment': {
+        if (!input.confirmed) {
+          return {
+            error: 'confirmation_required',
+            message:
+              'Esta acción requiere confirmación explícita. Muestra al usuario el importe, la factura y la fecha de cobro, y espera que confirme.',
+          };
+        }
+        const documentId = String(input.documentId ?? '');
+        if (!documentId) {
+          return { error: 'invalid_input', message: 'Se requiere documentId.' };
+        }
+        const amount = typeof input.amount === 'number' ? input.amount : 0;
+        if (amount <= 0) {
+          return { error: 'invalid_input', message: 'El importe debe ser mayor que 0.' };
+        }
+        const dateUnix = input.date
+          ? Math.floor(new Date(String(input.date)).getTime() / 1000)
+          : Math.floor(Date.now() / 1000);
+        const result = await holdedRegisterPayment(apiKey, {
+          documentId,
+          docType: typeof input.docType === 'string' ? input.docType : 'invoice',
+          date: dateUnix,
+          amount,
+          accountId: typeof input.accountId === 'string' ? input.accountId : undefined,
+        });
+        return {
+          success: result.success,
+          message: `Cobro de ${amount} € registrado correctamente en la factura ${documentId}.`,
+        };
+      }
+
+      case 'holded_create_contact': {
+        if (!input.confirmed) {
+          return {
+            error: 'confirmation_required',
+            message:
+              'Esta acción requiere confirmación explícita. Muestra al usuario los datos del contacto a crear y espera que confirme.',
+          };
+        }
+        const name = String(input.name ?? '').trim();
+        if (!name) {
+          return { error: 'invalid_input', message: 'Se requiere el nombre del contacto.' };
+        }
+        const typeVal = typeof input.type === 'string' && ['client', 'supplier', 'both'].includes(input.type)
+          ? (input.type as 'client' | 'supplier' | 'both')
+          : 'client';
+        const result = await holdedCreateContact(apiKey, {
+          name,
+          email: typeof input.email === 'string' ? input.email : undefined,
+          phone: typeof input.phone === 'string' ? input.phone : undefined,
+          nif: typeof input.nif === 'string' ? input.nif : undefined,
+          type: typeVal,
+          address: typeof input.address === 'string' ? input.address : undefined,
+          city: typeof input.city === 'string' ? input.city : undefined,
+          postalCode: typeof input.postalCode === 'string' ? input.postalCode : undefined,
+          country: typeof input.country === 'string' ? input.country : 'ES',
+        });
+        return {
+          success: true,
+          id: result.id,
+          message: `Contacto "${name}" creado correctamente en Holded con ID ${result.id}.`,
+        };
+      }
+
       default:
         return { error: 'unknown_tool' };
     }

--- a/apps/isaak/app/lib/settings.ts
+++ b/apps/isaak/app/lib/settings.ts
@@ -79,9 +79,26 @@ export type SettingsBillingData = {
   invoices: SettingsBillingInvoice[];
 };
 
+export type TeamMember = {
+  id: string;
+  userId: string;
+  name: string | null;
+  email: string | null;
+  image: string | null;
+  role: string;
+  status: string;
+  createdAt: string;
+  confirmedAt: string | null;
+  isCurrentUser: boolean;
+};
+
 export type SettingsTeamData = {
   enabled: boolean;
   activeMembers: number;
+  maxSeats: number;
+  planCode: string;
+  canManage: boolean;
+  members: TeamMember[];
 };
 
 export type SettingsData = {
@@ -296,8 +313,27 @@ export async function loadBillingData(input: {
   return billing;
 }
 
+function maxSeatsForPlan(planCode: string): number {
+  switch (planCode) {
+    case 'enterprise':
+      return -1;
+    case 'business':
+      return 10;
+    case 'empresa':
+      return 5;
+    case 'pyme':
+      return 3;
+    default:
+      return 1;
+  }
+}
+
+function canManageTeam(role: string): boolean {
+  return role === 'owner' || role === 'admin' || role === 'company_admin';
+}
+
 export async function loadSettingsData(session: SettingsSession): Promise<SettingsData> {
-  const [user, tenantProfile, connection, onboardingState, billing, activeMembers] =
+  const [user, tenantProfile, connection, onboardingState, billing, memberships, subscription] =
     await Promise.all([
       prisma.user.findUnique({
         where: { id: session.userId },
@@ -333,16 +369,51 @@ export async function loadSettingsData(session: SettingsSession): Promise<Settin
         tenantId: session.tenantId,
         includeInvoices: false,
       }),
-      prisma.membership.count({
+      prisma.membership.findMany({
         where: {
           tenantId: session.tenantId,
-          status: 'active',
+          status: { in: ['active', 'invited'] },
         },
+        include: {
+          user: { select: { id: true, name: true, email: true, image: true } },
+        },
+        orderBy: { createdAt: 'asc' },
+      }),
+      prisma.tenantSubscription.findFirst({
+        where: { tenantId: session.tenantId },
+        include: { plan: true },
+        orderBy: { createdAt: 'desc' },
       }),
     ]);
 
   const onboarding = onboardingState.profile;
   const instructions = onboardingState.instructions;
+
+  const planCode = subscription?.plan?.code ?? billing.code ?? 'free';
+  const maxSeats = maxSeatsForPlan(planCode);
+  const activeMembers = memberships.filter((m) => m.status === 'active').length;
+  const callerMembership = memberships.find((m) => m.userId === session.userId);
+  const callerRole = callerMembership?.role ?? 'member';
+
+  const teamData: SettingsTeamData = {
+    enabled: true,
+    activeMembers,
+    maxSeats,
+    planCode,
+    canManage: canManageTeam(callerRole),
+    members: memberships.map((m) => ({
+      id: m.id,
+      userId: m.userId,
+      name: m.user.name,
+      email: m.user.email,
+      image: m.user.image,
+      role: m.role,
+      status: m.status,
+      createdAt: m.createdAt.toISOString(),
+      confirmedAt: m.confirmedAt?.toISOString() ?? null,
+      isCurrentUser: m.userId === session.userId,
+    })),
+  };
 
   return {
     profile: {
@@ -398,10 +469,7 @@ export async function loadSettingsData(session: SettingsSession): Promise<Settin
       ),
     },
     billing,
-    team: {
-      enabled: false,
-      activeMembers,
-    },
+    team: teamData,
   };
 }
 

--- a/apps/isaak/app/lib/whatsapp-templates.ts
+++ b/apps/isaak/app/lib/whatsapp-templates.ts
@@ -102,6 +102,60 @@ export function buildModelo303Components(
   ];
 }
 
+// ── Template 4: Saldo bancario bajo ──────────────────────────────────────────
+//
+// Cuerpo para Meta:
+// "Hola {{1}}, tu saldo bancario está en {{2}} €, por debajo del umbral habitual.
+//  Accede a Isaak para revisar tu tesorería y tomar acción."
+//
+// Parámetros: [firstName, saldoEuros]
+// Registro en Meta: UTILITY — PENDIENTE DE REGISTRO
+
+export const TEMPLATE_SALDO_BAJO = 'saldo_bancario_bajo';
+
+export function buildSaldoBajoComponents(
+  firstName: string,
+  saldoEuros: string
+): WaTemplateComponent[] {
+  return [
+    {
+      type: 'body',
+      parameters: [
+        { type: 'text', text: firstName },
+        { type: 'text', text: saldoEuros },
+      ],
+    },
+  ];
+}
+
+// ── Template 5: Renovar conexión Enable Banking ───────────────────────────────
+//
+// Cuerpo para Meta:
+// "Hola {{1}}, tu conexión bancaria con {{2}} expira el {{3}}.
+//  Renuévala desde Isaak antes de que se desconecte."
+//
+// Parámetros: [firstName, bankName, fechaExpiracion]
+// Registro en Meta: UTILITY — PENDIENTE DE REGISTRO
+
+export const TEMPLATE_EB_EXPIRY = 'renovar_conexion_bancaria';
+
+export function buildEbExpiryComponents(
+  firstName: string,
+  bankName: string,
+  fechaExpiracion: string
+): WaTemplateComponent[] {
+  return [
+    {
+      type: 'body',
+      parameters: [
+        { type: 'text', text: firstName },
+        { type: 'text', text: bankName },
+        { type: 'text', text: fechaExpiracion },
+      ],
+    },
+  ];
+}
+
 // ── Selector automático de template por tipo de alerta ───────────────────────
 
 export type FiscalAlertTemplateInput = {

--- a/apps/isaak/vercel.json
+++ b/apps/isaak/vercel.json
@@ -24,6 +24,10 @@
     {
       "path": "/api/cron/eb-sync",
       "schedule": "0 */6 * * *"
+    },
+    {
+      "path": "/api/cron/banking-alerts",
+      "schedule": "30 7 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Multi-usuario para el plan Business/Empresa

Implementa el sistema completo de gestión de equipo en Isaak: invitaciones, lista de miembros, roles y límites de plazas por plan.

---

### Nuevos endpoints

| Método | Ruta | Descripción |
|--------|------|-------------|
| `GET` | `/api/team/members` | Lista miembros del workspace |
| `POST` | `/api/team/members` | Invita un nuevo miembro por email |
| `PATCH` | `/api/team/members/[id]` | Cambia el rol de un miembro |
| `DELETE` | `/api/team/members/[id]` | Elimina un miembro |
| `GET` | `/api/team/accept?token=...` | Acepta invitación via token |

### Flujo de invitación

1. Admin invita email → `Membership` con `status=invited` + token en `metadataJson`
2. Email Resend con link válido 7 días
3. Click → auth Firebase → membership activado → redirect `/chat`

### Límites de plazas

free/starter=1 · pyme=3 · empresa=5 · business=10 · enterprise=∞

### UI Settings → Equipo

- Barra progreso plazas ocupadas
- Lista miembros con avatar, rol (Crown/Shield/badge), badge Pendiente
- Formulario invitar (email + rol) solo para admin/owner
- Botón eliminar miembro
- CTA upgrade al llegar al límite
- Contador activos en sidebar nav

https://claude.ai/code/session_01XEgA9ynYQxzRUipm4CeXpq