### PR TITLE
feat(team): tenant switcher — multi-workspace navigation

### DIFF
--- a/apps/isaak/app/(workspace)/settings/IsaakSettingsClient.tsx
+++ b/apps/isaak/app/(workspace)/settings/IsaakSettingsClient.tsx
@@ -118,6 +118,13 @@ type SettingsData = {
       confirmedAt: string | null;
       isCurrentUser: boolean;
     }>;
+    workspaces: Array<{
+      tenantId: string;
+      name: string;
+      taxId: string | null;
+      role: string;
+      isCurrent: boolean;
+    }>;
   };
 };
 
@@ -646,6 +653,7 @@ export default function IsaakSettingsClient({
   const [inviteSuccess, setInviteSuccess] = useState<string | null>(null);
   const [inviteError, setInviteError] = useState<string | null>(null);
   const [removingMemberId, setRemovingMemberId] = useState<string | null>(null);
+  const [switchingTenantId, setSwitchingTenantId] = useState<string | null>(null);
 
   useEffect(() => {
     if (activeSection !== 'billing') return;
@@ -760,6 +768,28 @@ export default function IsaakSettingsClient({
       setInviteError('No se pudo enviar la invitación.');
     } finally {
       setInviteSending(false);
+    }
+  }
+
+  async function switchWorkspace(tenantId: string) {
+    setSwitchingTenantId(tenantId);
+    try {
+      const res = await fetch('/api/team/switch', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tenantId }),
+      });
+      const data = await res.json().catch(() => null);
+      if (!res.ok || !data?.ok) {
+        setInviteError(data?.error || 'No se pudo cambiar de espacio.');
+        return;
+      }
+      // Hard reload to refresh server-side session resolution
+      window.location.assign('/chat?workspaceSwitched=1');
+    } catch {
+      setInviteError('No se pudo cambiar de espacio.');
+    } finally {
+      setSwitchingTenantId(null);
     }
   }
 
@@ -1724,6 +1754,58 @@ export default function IsaakSettingsClient({
 
             {activeSection === 'team' ? (
               <section className="mt-6 space-y-4">
+                {/* Workspaces switcher (if user has more than 1) */}
+                {settingsData.team.workspaces.length > 1 && (
+                  <div className="rounded-[1.6rem] border border-slate-200 bg-white p-5">
+                    <div className="text-sm font-semibold text-slate-950">Tus espacios</div>
+                    <div className="mt-0.5 text-xs text-slate-500">
+                      Cambia entre los workspaces a los que perteneces.
+                    </div>
+                    <ul className="mt-3 divide-y divide-slate-100">
+                      {settingsData.team.workspaces.map((ws) => {
+                        const isSwitching = switchingTenantId === ws.tenantId;
+                        return (
+                          <li
+                            key={ws.tenantId}
+                            className="flex items-center gap-3 py-3"
+                          >
+                            <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-[#2361d8]/10 text-sm font-semibold text-[#2361d8]">
+                              {ws.name.charAt(0).toUpperCase()}
+                            </div>
+                            <div className="min-w-0 flex-1">
+                              <div className="truncate text-sm font-semibold text-slate-900">
+                                {ws.name}
+                              </div>
+                              <div className="truncate text-xs text-slate-400">
+                                {ws.taxId ?? `${ws.role}`}
+                              </div>
+                            </div>
+                            {ws.isCurrent ? (
+                              <span className="rounded-full bg-emerald-100 px-3 py-1 text-[11px] font-semibold text-emerald-700">
+                                Activo
+                              </span>
+                            ) : (
+                              <button
+                                type="button"
+                                disabled={isSwitching || switchingTenantId !== null}
+                                onClick={() => void switchWorkspace(ws.tenantId)}
+                                className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-700 transition hover:border-[#2361d8] hover:text-[#2361d8] disabled:opacity-50"
+                              >
+                                {isSwitching ? (
+                                  <Loader2 className="h-3 w-3 animate-spin" />
+                                ) : (
+                                  <RefreshCcw className="h-3 w-3" />
+                                )}
+                                Cambiar
+                              </button>
+                            )}
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  </div>
+                )}
+
                 {/* Header */}
                 <div className="rounded-[1.6rem] border border-slate-200 bg-slate-50/70 p-5">
                   <div className="flex items-center justify-between">

--- a/apps/isaak/app/api/team/switch/route.ts
+++ b/apps/isaak/app/api/team/switch/route.ts
@@ -1,0 +1,47 @@
+/**
+ * POST /api/team/switch — switch the active workspace
+ *
+ * Body: { tenantId: string }
+ * Updates UserPreference.preferredTenantId after verifying the user has an
+ * active membership in the target tenant.
+ */
+
+import { NextResponse } from 'next/server';
+import { getHoldedSession } from '@/app/lib/holded-session';
+import { prisma } from '@/app/lib/prisma';
+
+export const runtime = 'nodejs';
+
+export async function POST(request: Request) {
+  const session = await getHoldedSession();
+  if (!session?.userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const body = (await request.json().catch(() => ({}))) as Record<string, unknown>;
+  const tenantId = typeof body.tenantId === 'string' ? body.tenantId : null;
+  if (!tenantId) {
+    return NextResponse.json({ error: 'tenantId requerido.' }, { status: 400 });
+  }
+
+  // Verify user has active membership in target tenant
+  const membership = await prisma.membership.findUnique({
+    where: { tenantId_userId: { tenantId, userId: session.userId } },
+    select: { status: true },
+  });
+
+  if (!membership || membership.status !== 'active') {
+    return NextResponse.json(
+      { error: 'No tienes acceso a este espacio de trabajo.' },
+      { status: 403 }
+    );
+  }
+
+  await prisma.userPreference.upsert({
+    where: { userId: session.userId },
+    update: { preferredTenantId: tenantId },
+    create: { userId: session.userId, preferredTenantId: tenantId },
+  });
+
+  return NextResponse.json({ ok: true, tenantId });
+}

--- a/apps/isaak/app/api/team/workspaces/route.ts
+++ b/apps/isaak/app/api/team/workspaces/route.ts
@@ -1,0 +1,46 @@
+/**
+ * GET /api/team/workspaces — list all tenants where the current user has an active membership
+ *
+ * Used to populate the workspace switcher UI.
+ */
+
+import { NextResponse } from 'next/server';
+import { getHoldedSession } from '@/app/lib/holded-session';
+import { prisma } from '@/app/lib/prisma';
+
+export const runtime = 'nodejs';
+
+export async function GET() {
+  const session = await getHoldedSession();
+  if (!session?.userId || !session.tenantId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const memberships = await prisma.membership.findMany({
+    where: { userId: session.userId, status: 'active' },
+    include: {
+      tenant: {
+        include: {
+          profile: {
+            select: { tradeName: true, legalName: true, taxId: true },
+          },
+        },
+      },
+    },
+    orderBy: { createdAt: 'asc' },
+  });
+
+  return NextResponse.json({
+    workspaces: memberships.map((m) => ({
+      tenantId: m.tenantId,
+      role: m.role,
+      name:
+        m.tenant.profile?.tradeName ??
+        m.tenant.profile?.legalName ??
+        m.tenant.name ??
+        'Espacio sin nombre',
+      taxId: m.tenant.profile?.taxId ?? null,
+      isCurrent: m.tenantId === session.tenantId,
+    })),
+  });
+}

--- a/apps/isaak/app/lib/holded-session.ts
+++ b/apps/isaak/app/lib/holded-session.ts
@@ -5,6 +5,30 @@ import {
 } from '@verifactu/auth';
 import { prisma } from './prisma';
 
+// If the user has switched to a different workspace via UserPreference,
+// use that tenantId — but only if they still have an active membership there.
+async function resolveEffectiveTenantId(
+  userId: string,
+  cookieTenantId: string
+): Promise<string> {
+  const pref = await prisma.userPreference.findUnique({
+    where: { userId },
+    select: { preferredTenantId: true },
+  });
+
+  const preferred = pref?.preferredTenantId;
+  if (!preferred || preferred === cookieTenantId) {
+    return cookieTenantId;
+  }
+
+  const membership = await prisma.membership.findUnique({
+    where: { tenantId_userId: { tenantId: preferred, userId } },
+    select: { status: true },
+  });
+
+  return membership?.status === 'active' ? preferred : cookieTenantId;
+}
+
 export async function getHoldedSession() {
   const cookieStore = await cookies();
   const session = await resolveSharedTenantSession({
@@ -17,7 +41,11 @@ export async function getHoldedSession() {
   });
 
   if (session?.userId) {
-    return session;
+    const effectiveTenantId = await resolveEffectiveTenantId(
+      session.userId,
+      session.tenantId
+    );
+    return { ...session, tenantId: effectiveTenantId };
   }
 
   const payload = await getSharedSessionPayloadFromCookieStore(cookieStore);

--- a/apps/isaak/app/lib/settings.ts
+++ b/apps/isaak/app/lib/settings.ts
@@ -92,6 +92,14 @@ export type TeamMember = {
   isCurrentUser: boolean;
 };
 
+export type WorkspaceSummary = {
+  tenantId: string;
+  name: string;
+  taxId: string | null;
+  role: string;
+  isCurrent: boolean;
+};
+
 export type SettingsTeamData = {
   enabled: boolean;
   activeMembers: number;
@@ -99,6 +107,7 @@ export type SettingsTeamData = {
   planCode: string;
   canManage: boolean;
   members: TeamMember[];
+  workspaces: WorkspaceSummary[];
 };
 
 export type SettingsData = {
@@ -333,8 +342,16 @@ function canManageTeam(role: string): boolean {
 }
 
 export async function loadSettingsData(session: SettingsSession): Promise<SettingsData> {
-  const [user, tenantProfile, connection, onboardingState, billing, memberships, subscription] =
-    await Promise.all([
+  const [
+    user,
+    tenantProfile,
+    connection,
+    onboardingState,
+    billing,
+    memberships,
+    subscription,
+    userWorkspaces,
+  ] = await Promise.all([
       prisma.user.findUnique({
         where: { id: session.userId },
         select: { id: true, name: true, email: true, image: true, phone: true },
@@ -384,6 +401,20 @@ export async function loadSettingsData(session: SettingsSession): Promise<Settin
         include: { plan: true },
         orderBy: { createdAt: 'desc' },
       }),
+      prisma.membership.findMany({
+        where: { userId: session.userId, status: 'active' },
+        include: {
+          tenant: {
+            select: {
+              id: true,
+              name: true,
+              legalName: true,
+              profile: { select: { tradeName: true, legalName: true, taxId: true } },
+            },
+          },
+        },
+        orderBy: { createdAt: 'asc' },
+      }),
     ]);
 
   const onboarding = onboardingState.profile;
@@ -394,6 +425,19 @@ export async function loadSettingsData(session: SettingsSession): Promise<Settin
   const activeMembers = memberships.filter((m) => m.status === 'active').length;
   const callerMembership = memberships.find((m) => m.userId === session.userId);
   const callerRole = callerMembership?.role ?? 'member';
+
+  const workspaces: WorkspaceSummary[] = userWorkspaces.map((m) => ({
+    tenantId: m.tenantId,
+    role: m.role,
+    name:
+      m.tenant.profile?.tradeName ??
+      m.tenant.profile?.legalName ??
+      m.tenant.legalName ??
+      m.tenant.name ??
+      'Espacio sin nombre',
+    taxId: m.tenant.profile?.taxId ?? null,
+    isCurrent: m.tenantId === session.tenantId,
+  }));
 
   const teamData: SettingsTeamData = {
     enabled: true,
@@ -413,6 +457,7 @@ export async function loadSettingsData(session: SettingsSession): Promise<Settin
       confirmedAt: m.confirmedAt?.toISOString() ?? null,
       isCurrentUser: m.userId === session.userId,
     })),
+    workspaces,
   };
 
   return {


### PR DESCRIPTION
## Tenant switcher para multi-workspace

Complemento del PR #118: permite a usuarios con membership en varios espacios cambiar entre ellos desde Settings → Equipo.

---

### Cambios

**`getHoldedSession()`** ahora resuelve el `tenantId` efectivo:
1. Obtiene `payload.tenantId` del cookie compartido (parent app)
2. Si `UserPreference.preferredTenantId` existe y el usuario tiene `Membership` activa allí → override
3. Si no, usa el cookie tenantId

Esto permite que un usuario invitado a un workspace pueda navegar a él aunque el cookie aún apunte a su tenant inicial.

### Nuevos endpoints

| Método | Ruta | Descripción |
|--------|------|-------------|
| `GET` | `/api/team/workspaces` | Lista workspaces activos del usuario |
| `POST` | `/api/team/switch` | Cambia `preferredTenantId` tras verificar membership |

### UI

- Nueva card "Tus espacios" en Settings → Equipo (solo si >1 workspace)
- Avatar de inicial, nombre del workspace, NIF/rol, badge "Activo" o botón "Cambiar"
- Tras switch → hard reload a `/chat?workspaceSwitched=1` para refrescar sesión SSR

### Seguridad

- `/api/team/switch` valida que el usuario tiene membership activa en el tenant destino antes de actualizar preference
- 403 si no es miembro activo

https://claude.ai/code/session_01XEgA9ynYQxzRUipm4CeXpq