### PR TITLE
feat(banking): conciliación auto-apply ≥0.95 con undo de falsos positivos

### DIFF
--- a/apps/isaak/app/(workspace)/banking/page.tsx
+++ b/apps/isaak/app/(workspace)/banking/page.tsx
@@ -71,6 +71,18 @@ type ReconcileSuggestion = {
   }[];
 };
 
+type AutoMatched = {
+  txId: string;
+  txAmount: number;
+  txMadeOn: string;
+  txDescription: string;
+  expenseId: string | null;
+  expenseDescription: string | null;
+  expenseSupplier: string | null;
+  scorePercent: number;
+  matchedAt: string;
+};
+
 type Aspsp = {
   name: string;
   country: string;
@@ -107,8 +119,10 @@ export default function BankingPage() {
   // Reconciliation state
   const [reconcileStats, setReconcileStats] = useState<ReconcileStats | null>(null);
   const [suggestions, setSuggestions] = useState<ReconcileSuggestion[]>([]);
+  const [autoMatched, setAutoMatched] = useState<AutoMatched[]>([]);
   const [reconciling, setReconciling] = useState(false);
   const [confirmingTx, setConfirmingTx] = useState<string | null>(null);
+  const [undoingTxId, setUndoingTxId] = useState<string | null>(null);
 
   // Bank picker (Enable Banking)
   const [pickerOpen, setPickerOpen] = useState(false);
@@ -148,9 +162,11 @@ export default function BankingPage() {
       const data = (await res.json()) as {
         stats: ReconcileStats;
         suggestions: ReconcileSuggestion[];
+        autoMatched: AutoMatched[];
       };
       setReconcileStats(data.stats ?? null);
       setSuggestions(data.suggestions ?? []);
+      setAutoMatched(data.autoMatched ?? []);
     }
   }, []);
 
@@ -280,6 +296,20 @@ export default function BankingPage() {
       await loadReconcile();
     } finally {
       setConfirmingTx(null);
+    }
+  }
+
+  async function handleUndo(txId: string) {
+    setUndoingTxId(txId);
+    try {
+      await fetch('/api/isaak/banking/reconcile', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'undo', txId }),
+      });
+      await loadReconcile();
+    } finally {
+      setUndoingTxId(null);
     }
   }
 
@@ -640,6 +670,60 @@ export default function BankingPage() {
                     {reconciling ? 'Ejecutando…' : 'Reconciliar'}
                   </button>
                 </div>
+
+                {/* Auto-applied matches (≥95% score) */}
+                {autoMatched.length > 0 && (
+                  <div className="overflow-hidden rounded-xl border border-emerald-200 bg-white shadow-sm">
+                    <div className="flex items-center justify-between border-b border-emerald-100 bg-emerald-50/40 px-5 py-3">
+                      <div className="flex items-center gap-2">
+                        <CheckCircle2 size={14} className="text-emerald-600" />
+                        <span className="text-[12px] font-semibold text-emerald-900">
+                          Auto-aplicados ({autoMatched.length})
+                        </span>
+                      </div>
+                      <span className="text-[10px] text-emerald-700">
+                        Score ≥95% · Últimos 30 días
+                      </span>
+                    </div>
+                    <ul className="divide-y divide-slate-50">
+                      {autoMatched.map((m) => (
+                        <li key={m.txId} className="flex items-center gap-3 px-5 py-3">
+                          <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-emerald-50">
+                            <CheckCircle2 size={12} className="text-emerald-600" />
+                          </div>
+                          <div className="min-w-0 flex-1">
+                            <div className="flex items-center justify-between gap-2">
+                              <p className="truncate text-[12px] font-medium text-slate-800">
+                                {m.txDescription || 'Sin descripción'}
+                              </p>
+                              <span className="shrink-0 text-[12px] font-semibold text-slate-700">
+                                {fmtMoney(Math.abs(m.txAmount))}
+                              </span>
+                            </div>
+                            <p className="mt-0.5 truncate text-[10px] text-slate-400">
+                              {fmtDate(m.txMadeOn)} ↔ {m.expenseSupplier || m.expenseDescription || 'gasto'}
+                              {' · '}
+                              <span className="font-semibold text-emerald-600">{m.scorePercent}%</span>
+                            </p>
+                          </div>
+                          <button
+                            type="button"
+                            disabled={undoingTxId === m.txId}
+                            onClick={() => void handleUndo(m.txId)}
+                            title="Deshacer match (falso positivo)"
+                            className="shrink-0 rounded-md border border-slate-200 px-2.5 py-1 text-[10px] font-medium text-slate-600 transition hover:border-rose-300 hover:bg-rose-50 hover:text-rose-600 disabled:opacity-50"
+                          >
+                            {undoingTxId === m.txId ? (
+                              <Loader2 size={10} className="animate-spin" />
+                            ) : (
+                              'Deshacer'
+                            )}
+                          </button>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
 
                 {/* Suggestions */}
                 {suggestions.length === 0 ? (

--- a/apps/isaak/app/api/isaak/banking/reconcile/route.ts
+++ b/apps/isaak/app/api/isaak/banking/reconcile/route.ts
@@ -4,22 +4,29 @@
  *     Devuelve { matched, skipped, total }.
  *
  * GET /api/isaak/banking/reconcile
- *   → Devuelve estadísticas + sugerencias pendientes (hasta 20 transacciones).
+ *   → Devuelve estadísticas + sugerencias pendientes (hasta 20 transacciones)
+ *     + matches auto-aplicados recientes (últimos 30 días).
  *
  * POST /api/isaak/banking/reconcile  { action: 'confirm', txId, expenseId }
  *   → Confirma manualmente un match.
  *
  * POST /api/isaak/banking/reconcile  { action: 'dismiss', txId }
  *   → Descarta la transacción (marca como conciliada sin gasto asociado).
+ *
+ * POST /api/isaak/banking/reconcile  { action: 'undo', txId }
+ *   → Deshace un match (falso positivo del auto-apply).
  */
 
 import { NextRequest, NextResponse } from 'next/server';
 import { getHoldedSession } from '@/app/lib/holded-session';
 import { prisma } from '@/app/lib/prisma';
 import {
+  AUTO_APPLY_THRESHOLD,
   reconcileTenant,
   loadPendingSuggestions,
+  loadRecentAutoMatched,
   confirmMatch,
+  undoMatch,
 } from '@/app/lib/bank-reconciliation';
 
 export const runtime = 'nodejs';
@@ -31,7 +38,7 @@ export async function GET(_req: NextRequest) {
   }
   const { tenantId } = session;
 
-  const [totalTx, reconciledTx, suggestions] = await Promise.all([
+  const [totalTx, reconciledTx, suggestions, autoMatched] = await Promise.all([
     prisma.seTransaction.count({
       where: { tenantId, amount: { lt: 0 }, duplicated: false, status: 'posted' },
     }),
@@ -39,6 +46,7 @@ export async function GET(_req: NextRequest) {
       where: { tenantId, amount: { lt: 0 }, duplicated: false, reconciledAt: { not: null } },
     }),
     loadPendingSuggestions(tenantId, 20),
+    loadRecentAutoMatched(tenantId, 20),
   ]);
 
   return NextResponse.json({
@@ -46,6 +54,7 @@ export async function GET(_req: NextRequest) {
       total: totalTx,
       reconciled: reconciledTx,
       pending: totalTx - reconciledTx,
+      autoApplyThreshold: AUTO_APPLY_THRESHOLD,
     },
     suggestions: suggestions.map(({ tx, candidates }) => ({
       tx: {
@@ -62,6 +71,17 @@ export async function GET(_req: NextRequest) {
         evidenceReasons: c.evidenceReasons,
         scoreComponents: c.scoreComponents,
       })),
+    })),
+    autoMatched: autoMatched.map((m) => ({
+      txId: m.txId,
+      txAmount: m.txAmount,
+      txMadeOn: m.txMadeOn,
+      txDescription: m.txDescription,
+      expenseId: m.expenseId,
+      expenseDescription: m.expenseDescription,
+      expenseSupplier: m.expenseSupplier,
+      scorePercent: Math.round(m.matchScore * 100),
+      matchedAt: m.matchedAt.toISOString(),
     })),
   });
 }
@@ -103,6 +123,14 @@ export async function POST(req: NextRequest) {
       where: { id: body.txId },
       data: { reconciledAt: new Date() },
     });
+    return NextResponse.json({ ok: true });
+  }
+
+  if (body.action === 'undo') {
+    if (!body.txId) return NextResponse.json({ error: 'txId requerido.' }, { status: 400 });
+    const tx = await prisma.seTransaction.findFirst({ where: { id: body.txId, tenantId } });
+    if (!tx) return NextResponse.json({ error: 'Transacción no encontrada.' }, { status: 404 });
+    await undoMatch(tenantId, body.txId);
     return NextResponse.json({ ok: true });
   }
 

--- a/apps/isaak/app/lib/bank-reconciliation.ts
+++ b/apps/isaak/app/lib/bank-reconciliation.ts
@@ -7,11 +7,18 @@
  * o bruto (`expense.amount × (1 + expense.taxRate)`). Se prueba ambos y se toma el mejor.
  *
  * Score final = amountScore×0.40 + dateScore×0.35 + textScore×0.25
- * Auto-match cuando score ≥ confidenceThreshold (default 0.85).
+ *
+ * Tiers:
+ *   - score ≥ AUTO_APPLY_THRESHOLD (0.95): auto-aplicado silenciosamente, marcado reconciliado
+ *   - SUGGEST_THRESHOLD (0.50) ≤ score < AUTO_APPLY_THRESHOLD: audit creado, requiere confirmación humana
+ *   - score < SUGGEST_THRESHOLD: descartado
  */
 
 import { prisma } from './prisma';
 import type { Prisma } from '@prisma/client';
+
+export const AUTO_APPLY_THRESHOLD = 0.95;
+export const SUGGEST_THRESHOLD = 0.5;
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Types
@@ -238,7 +245,9 @@ export async function reconcileTenant(tenantId: string): Promise<{
   const config = await prisma.bankReconciliationConfig.findUnique({
     where: { tenantId },
   });
-  const threshold = config?.confidenceThreshold ?? 0.85;
+  // Bumped default from 0.85 → 0.95: only auto-apply on very high confidence.
+  // Lower scores still create audit records for human review.
+  const threshold = config?.confidenceThreshold ?? AUTO_APPLY_THRESHOLD;
 
   // Transacciones negativas (gastos) aún no conciliadas
   const transactions = await prisma.seTransaction.findMany({
@@ -325,6 +334,89 @@ export async function confirmMatch(
   await prisma.seTransaction.update({
     where: { id: txId },
     data: { reconciledAt: new Date() },
+  });
+}
+
+/**
+ * Deshace un match: borra el audit y limpia `reconciledAt`.
+ * Útil para corregir falsos positivos del auto-match.
+ */
+export async function undoMatch(tenantId: string, txId: string): Promise<void> {
+  await prisma.seTransactionMatchAudit.deleteMany({
+    where: { tenantId, seTransactionId: txId },
+  });
+  await prisma.seTransaction.update({
+    where: { id: txId },
+    data: { reconciledAt: null },
+  });
+}
+
+/**
+ * Carga matches recientemente auto-aplicados (últimos 30 días) para revisión.
+ * El usuario puede deshacerlos si detecta un falso positivo.
+ */
+export async function loadRecentAutoMatched(
+  tenantId: string,
+  limit = 20
+): Promise<
+  Array<{
+    txId: string;
+    txAmount: number;
+    txMadeOn: string;
+    txDescription: string;
+    expenseId: string | null;
+    expenseDescription: string | null;
+    expenseSupplier: string | null;
+    matchScore: number;
+    matchedAt: Date;
+  }>
+> {
+  const thirtyDaysAgo = new Date(Date.now() - 30 * 86_400_000);
+
+  const audits = await prisma.seTransactionMatchAudit.findMany({
+    where: {
+      tenantId,
+      autoMatched: true,
+      matchedExpenseId: { not: null },
+      createdAt: { gte: thirtyDaysAgo },
+    },
+    orderBy: { createdAt: 'desc' },
+    take: limit,
+  });
+
+  const txIds = audits.map((a) => a.seTransactionId);
+  const expenseIds = audits
+    .map((a) => a.matchedExpenseId)
+    .filter((id): id is string => id !== null);
+
+  const [transactions, expenses] = await Promise.all([
+    prisma.seTransaction.findMany({
+      where: { id: { in: txIds } },
+      select: { id: true, amount: true, madeOn: true, description: true, payee: true },
+    }),
+    prisma.expenseRecord.findMany({
+      where: { id: { in: expenseIds } },
+      select: { id: true, description: true, supplier: { select: { name: true } } },
+    }),
+  ]);
+
+  const txMap = new Map(transactions.map((t) => [t.id, t]));
+  const expMap = new Map(expenses.map((e) => [e.id, e]));
+
+  return audits.map((a) => {
+    const tx = txMap.get(a.seTransactionId);
+    const exp = a.matchedExpenseId ? expMap.get(a.matchedExpenseId) : null;
+    return {
+      txId: a.seTransactionId,
+      txAmount: tx ? Number(tx.amount) : 0,
+      txMadeOn: tx?.madeOn ?? '',
+      txDescription: tx?.description ?? tx?.payee ?? '',
+      expenseId: a.matchedExpenseId,
+      expenseDescription: exp?.description ?? null,
+      expenseSupplier: exp?.supplier?.name ?? null,
+      matchScore: a.matchScore,
+      matchedAt: a.createdAt,
+    };
   });
 }
 


### PR DESCRIPTION
## Conciliación bancaria: auto-apply más conservador + undo

Mejora la fiabilidad del auto-match bancario subiendo el umbral por defecto y añadiendo un mecanismo de undo para falsos positivos.

---

### Cambios

**Threshold por defecto: 0.85 → 0.95**

Más conservador: el cron solo auto-aplica matches con muy alta confianza. Scores entre 0.50 y 0.95 generan un audit pero NO marcan `reconciledAt` — quedan como sugerencias para revisión humana en la UI.

Tenants que ya han customizado `BankReconciliationConfig.confidenceThreshold` no se ven afectados (siguen usando su valor).

**Nuevas constantes exportadas** (`bank-reconciliation.ts`):
- `AUTO_APPLY_THRESHOLD = 0.95`
- `SUGGEST_THRESHOLD = 0.5`

**Nuevos helpers**:
- `undoMatch(tenantId, txId)` — borra audit + limpia `reconciledAt`
- `loadRecentAutoMatched(tenantId)` — últimos 30 días de auto-matches

**Nueva acción API**:

`POST /api/isaak/banking/reconcile`  body: `{action: undo, txId}` → deshace un auto-match (corrige falsos positivos)

**GET /reconcile** ahora devuelve también `autoMatched[]` con:
- txId, txAmount, txMadeOn, txDescription
- expenseSupplier / expenseDescription
- scorePercent (0-100)
- matchedAt

### UI

Nueva sección verde **"Auto-aplicados"** en `/banking` → pestaña reconciliar:
- Lista de matches confirmados automáticamente (≥95%)
- Score visible · contraparte (proveedor/gasto)
- Botón "Deshacer" por fila para corregir errores
- Solo se muestra si hay auto-aplicados (oculto si vacío)

### Por qué esto importa

El auto-match a 0.85 generaba demasiados falsos positivos (similitud de importes en gastos recurrentes). Con 0.95 los matches son casi siempre correctos, y para los casos límite el usuario ahora tiene visibilidad y control para deshacer.

https://claude.ai/code/session_01XEgA9ynYQxzRUipm4CeXpq