### PR TITLE
feat(resumen): cash flow chart semanal con datos reales de banca

### DIFF
--- a/apps/isaak/app/(workspace)/resumen/components/CashFlowChart.tsx
+++ b/apps/isaak/app/(workspace)/resumen/components/CashFlowChart.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+export type CashFlowPoint = {
+  label: string;
+  inflow: number;
+  outflow: number;
+  net: number;
+};
+
+function formatEur(value: number) {
+  const abs = Math.abs(value);
+  if (abs >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (abs >= 1_000) return `${(value / 1_000).toFixed(0)}k`;
+  return `${value.toFixed(0)}`;
+}
+
+function CustomTooltip({
+  active,
+  payload,
+  label,
+}: {
+  active?: boolean;
+  payload?: Array<{ name: string; value: number; color: string; payload: CashFlowPoint }>;
+  label?: string;
+}) {
+  if (!active || !payload?.length) return null;
+  const point = payload[0]?.payload;
+  return (
+    <div className="rounded-xl border border-slate-100 bg-white px-3 py-2 text-[12px] shadow-lg">
+      <p className="mb-1 font-semibold text-slate-700">{label}</p>
+      <p className="text-emerald-600">
+        Entradas:{' '}
+        <span className="font-semibold">
+          {payload[0]?.value.toLocaleString('es-ES', { maximumFractionDigits: 0 })} €
+        </span>
+      </p>
+      <p className="text-rose-500">
+        Salidas:{' '}
+        <span className="font-semibold">
+          {Math.abs(payload[1]?.value ?? 0).toLocaleString('es-ES', {
+            maximumFractionDigits: 0,
+          })}{' '}
+          €
+        </span>
+      </p>
+      {point && (
+        <p
+          className={`mt-1 border-t border-slate-100 pt-1 font-semibold ${point.net >= 0 ? 'text-emerald-700' : 'text-rose-600'}`}
+        >
+          Neto: {point.net.toLocaleString('es-ES', { maximumFractionDigits: 0 })} €
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default function CashFlowChart({ data }: { data: CashFlowPoint[] }) {
+  // Outflow is plotted as negative so bars go down
+  const chartData = data.map((d) => ({
+    ...d,
+    outflowNeg: -d.outflow,
+  }));
+
+  return (
+    <ResponsiveContainer width="100%" height={200}>
+      <BarChart data={chartData} barSize={14} stackOffset="sign">
+        <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#f1f5f9" />
+        <XAxis
+          dataKey="label"
+          axisLine={false}
+          tickLine={false}
+          tick={{ fontSize: 10, fill: '#94a3b8' }}
+        />
+        <YAxis
+          axisLine={false}
+          tickLine={false}
+          tick={{ fontSize: 10, fill: '#94a3b8' }}
+          tickFormatter={formatEur}
+          width={45}
+        />
+        <Tooltip content={<CustomTooltip />} cursor={{ fill: '#f8fafc' }} />
+        <Bar dataKey="inflow" name="Entradas" fill="#10b981" radius={[3, 3, 0, 0]} stackId="cf" />
+        <Bar
+          dataKey="outflowNeg"
+          name="Salidas"
+          fill="#f43f5e"
+          radius={[0, 0, 3, 3]}
+          stackId="cf"
+        />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/apps/isaak/app/(workspace)/resumen/page.tsx
+++ b/apps/isaak/app/(workspace)/resumen/page.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/app/lib/isaak-workspace-signals';
 import { prisma } from '@/app/lib/prisma';
 import ResumenChart, { type MonthlyPoint } from './components/ResumenChart';
+import CashFlowChart, { type CashFlowPoint } from './components/CashFlowChart';
 
 export const metadata: Metadata = { title: 'Resumen — Isaak' };
 
@@ -76,6 +77,80 @@ type CashForecast = {
   recentOut: number;
 };
 
+async function loadCashFlowSeries(tenantId: string, weeks = 12): Promise<CashFlowPoint[]> {
+  try {
+    const now = new Date();
+    // Anchor to Monday of current week
+    const monday = new Date(now);
+    const dow = monday.getDay() || 7;
+    monday.setDate(monday.getDate() - (dow - 1));
+    monday.setHours(0, 0, 0, 0);
+
+    const from = new Date(monday);
+    from.setDate(from.getDate() - (weeks - 1) * 7);
+    const fromStr = from.toISOString().slice(0, 10);
+
+    const txs = await prisma.seTransaction.findMany({
+      where: {
+        tenantId,
+        madeOn: { gte: fromStr },
+        status: 'posted',
+        duplicated: false,
+      },
+      select: { amount: true, madeOn: true },
+    });
+
+    if (txs.length === 0) return [];
+
+    // Bucket transactions by week start (Monday)
+    const buckets = new Map<string, { inflow: number; outflow: number }>();
+    for (let i = 0; i < weeks; i++) {
+      const ws = new Date(from);
+      ws.setDate(ws.getDate() + i * 7);
+      const key = ws.toISOString().slice(0, 10);
+      buckets.set(key, { inflow: 0, outflow: 0 });
+    }
+
+    for (const tx of txs) {
+      const txDate = new Date(tx.madeOn);
+      const diffDays = Math.floor((txDate.getTime() - from.getTime()) / 86_400_000);
+      if (diffDays < 0) continue;
+      const weekIndex = Math.floor(diffDays / 7);
+      if (weekIndex >= weeks) continue;
+
+      const ws = new Date(from);
+      ws.setDate(ws.getDate() + weekIndex * 7);
+      const key = ws.toISOString().slice(0, 10);
+      const bucket = buckets.get(key);
+      if (!bucket) continue;
+
+      const amt = Number(tx.amount);
+      if (amt > 0) bucket.inflow += amt;
+      else bucket.outflow += Math.abs(amt);
+    }
+
+    const points: CashFlowPoint[] = [];
+    let i = 0;
+    for (const [key, bucket] of buckets) {
+      const d = new Date(key);
+      const label =
+        i === weeks - 1
+          ? 'Esta'
+          : `${d.getDate()}/${d.getMonth() + 1}`;
+      points.push({
+        label,
+        inflow: Math.round(bucket.inflow * 100) / 100,
+        outflow: Math.round(bucket.outflow * 100) / 100,
+        net: Math.round((bucket.inflow - bucket.outflow) * 100) / 100,
+      });
+      i++;
+    }
+    return points;
+  } catch {
+    return [];
+  }
+}
+
 async function loadCashForecast(tenantId: string): Promise<CashForecast | null> {
   try {
     const thirtyDaysAgo = new Date(Date.now() - 30 * 86_400_000).toISOString().slice(0, 10);
@@ -116,6 +191,7 @@ async function DashboardContent() {
   let accountingPnL: HoldedAccountingPnL | null = null;
   let verifactuSignal: IsaakVerifactuSignal | null = null;
   let cashForecast: CashForecast | null = null;
+  let cashFlow: CashFlowPoint[] = [];
 
   try {
     const session = await getHoldedSession();
@@ -186,6 +262,9 @@ async function DashboardContent() {
         forecast.forecastBalance = Math.round((forecast.currentBalance + pendingIn) * 100) / 100;
         cashForecast = forecast;
       }
+
+      // Cash flow series — weekly inflow/outflow (last 12 weeks)
+      cashFlow = await loadCashFlowSeries(session.tenantId);
 
       // Verifactu Holded signal + local stats
       const wsSignals = await loadIsaakWorkspaceSignals({
@@ -328,6 +407,18 @@ async function DashboardContent() {
           </div>
         </div>
       )}
+
+      {/* ── Cash Flow Chart (real banking data) ──────────────────────────── */}
+      {cashFlow.length > 0 &&
+        cashFlow.some((p) => p.inflow > 0 || p.outflow > 0) && (
+          <div className="mx-5 mb-4 rounded-xl border border-slate-100 bg-white p-4 shadow-sm">
+            <div className="mb-3 flex items-center justify-between">
+              <p className="text-[12px] font-semibold text-slate-500">Cash flow semanal</p>
+              <p className="text-[10px] text-slate-400">Últimas 12 semanas · datos bancarios</p>
+            </div>
+            <CashFlowChart data={cashFlow} />
+          </div>
+        )}
 
       {verifactuSignal?.checked && verifactuSignal.invoicesWithoutUuid > 0 && (
         <div className="mx-5 mb-3 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3">


### PR DESCRIPTION
## Cash Flow Chart en /resumen

Añade un gráfico de barras de cash flow semanal con datos reales de la integración bancaria (SeTransaction).

---

### Componente

**`CashFlowChart.tsx`**:
- Barras apiladas (stackOffset=sign) con inflow positivo (verde #10b981) y outflow negativo (rojo #f43f5e)
- Tooltip personalizado con entradas / salidas / neto por semana
- Formato compacto en eje Y (k€/M€)
- 12 semanas, ~14px de ancho por barra

### Data loader

**`loadCashFlowSeries(tenantId, weeks=12)`**:
- Ancla al lunes de la semana actual
- Agrega `SeTransaction.amount` por bucket semanal (status=posted, no duplicadas)
- Devuelve `CashFlowPoint[]` con `inflow`, `outflow`, `net`
- Última semana etiquetada como "Esta", resto como `dd/mm`

### Renderizado

Se muestra en `/resumen` justo después del widget de tesorería, sólo si:
- Hay >=1 semana con inflow u outflow > 0

Si no hay banca conectada o no hay actividad → no aparece (sin ruido visual).

### Por qué

Complementa el widget de tesorería numérico (saldo actual + previsión 30d) con visualización temporal: el usuario ve de un vistazo si su negocio está respirando o no.

https://claude.ai/code/session_01XEgA9ynYQxzRUipm4CeXpq