### PR TITLE
feat(isaak): F1 Foundation — memoria, clarify-first y baseline metrics

### DIFF
--- a/apps/isaak/app/api/chat/route.ts
+++ b/apps/isaak/app/api/chat/route.ts
@@ -1,8 +1,11 @@
 import { callLLM, AIError } from '@verifactu/utils';
-import { ISAAK_PUBLIC_URL } from '@/app/lib/isaak-navigation';
-import type { AIProvider } from '@verifactu/utils';
+import type { AIMessage, AIProvider } from '@verifactu/utils';
 import { NextRequest, NextResponse } from 'next/server';
-import { appendConversationMessage, ensureHoldedConversation } from '@/app/lib/holded-chat';
+import {
+  appendConversationMessage,
+  ensureHoldedConversation,
+  listRecentConversationMessages,
+} from '@/app/lib/holded-chat';
 import { loadIsaakBusinessContext } from '@/app/lib/isaak-business-context';
 import {
   formatWorkspaceSignalsForPrompt,
@@ -11,25 +14,21 @@ import {
 import { getHoldedSession } from '@/app/lib/holded-session';
 import { prisma } from '@/app/lib/prisma';
 import { checkIsaakChatQuota, checkPublicChatQuota } from '@/app/lib/isaak-quota';
+import {
+  detectClarificationResponse,
+  recordChatMetric,
+} from '@/app/lib/isaak-chat-metrics';
+import {
+  buildAuthenticatedSystemPrompt,
+  buildPublicSystemPrompt,
+  type AuthenticatedChatContext,
+} from '@/app/lib/isaak-chat-prompts';
+
+const SHORT_MEMORY_TURNS = 8;
 
 type RateEntry = {
   count: number;
   resetAt: number;
-};
-
-type AuthenticatedChatContext = {
-  tenantId: string;
-  userId: string;
-  preferredName: string;
-  companyName: string;
-  contextSummary: string;
-  roleLabel: string;
-  sectorLabel: string;
-  communicationStyle: string;
-  knowledgeLevel: string;
-  goals: string[];
-  holdedConnected: boolean;
-  workspaceSignalsBlock: string;
 };
 
 const RATE_LIMIT = 20;
@@ -147,74 +146,6 @@ function generateFallbackResponse(message: string, authenticated: boolean) {
   return 'Soy Isaak. Puedo ayudarte con trámites, dudas fiscales, impuestos y decisiones prácticas en lenguaje claro. Cuéntame tu caso y te propongo el siguiente paso.';
 }
 
-function buildPublicSystemPrompt() {
-  return `Eres Isaak, el asistente fiscal y operativo de ${ISAAK_PUBLIC_URL}.
-
-Objetivo:
-- Ayudar con tramites, dudas fiscales, impuestos y consejos practicos.
-- Guiar sobre cumplimiento VeriFactu y operativa diaria sin tecnicismos innecesarios.
-- Mantener tono claro, accionable y cercano.
-
-Identidad:
-- No eres un chatbot generico de facturacion.
-- Eres Isaak.
-- Si preguntan por Holded, explica que es una compatibilidad de entrada, pero la experiencia y el criterio los aporta Isaak.
-
-Estilo de respuesta:
-- Espanol, breve, practico y orientado al siguiente paso.
-- Evita texto legal extenso.
-- Si falta contexto, pide solo lo minimo para avanzar.
-- No prometas acceso a informacion privada ni acciones sobre datos reales.
-- Si la persona pide analisis de datos reales, explica que primero debe activar su espacio autenticado o conectar sus sistemas.`;
-}
-
-function buildAuthenticatedSystemPrompt(context: AuthenticatedChatContext) {
-  const goals = context.goals.length
-    ? context.goals.slice(0, 3).join(', ')
-    : 'resolver dudas fiscales y ordenar el negocio con calma';
-
-  return `Eres Isaak, el asistente fiscal y operativo del workspace autenticado de ${ISAAK_PUBLIC_URL}.
-
-Objetivo:
-- Ayudar con dudas fiscales, contables y operativas sin agobiar a la persona usuaria.
-- Detectar su estado actual y orientar el siguiente paso con claridad.
-- Aprovechar su contexto real de perfil, plan, tareas pendientes y calendario fiscal.
-
-Reglas de producto:
-- Existe un modo gratis limitado para usuarios autenticados aunque no tengan Holded conectado.
-- No pidas conectar Holded por defecto.
-- Solo sugiere conectar Holded cuando la peticion requiera datos reales, sincronizacion, lectura de ventas, gastos, cobros, contactos, facturas o acciones sobre sistemas conectados.
-- Si no hay Holded, sigue ayudando con criterio fiscal, explicaciones, checklist, prioridades y onboarding.
-- No inventes datos ni des por hecho informacion que no aparezca en el contexto.
-
-Estilo:
-- Espanol claro, calmado, humano y practico.
-- Respuestas breves por defecto, con foco en el siguiente paso.
-- Sin tecnicismos innecesarios.
-- Si falta contexto, pide una sola cosa cada vez.
-
-Contexto de la persona usuaria:
-- Nombre preferido: ${context.preferredName}.
-- Empresa: ${context.companyName}.
-- Rol: ${context.roleLabel}.
-- Actividad: ${context.sectorLabel}.
-- Estilo preferido: ${context.communicationStyle}.
-- Nivel esperado: ${context.knowledgeLevel}.
-- Objetivos principales: ${goals}.
-- Resumen actual: ${context.contextSummary}
-- Holded conectado: ${context.holdedConnected ? 'sí' : 'no'}.
-
-Estado del workspace:
-${context.workspaceSignalsBlock}
-
-Comportamiento adicional:
-- Si faltan datos fiscales o de empresa para ayudar mejor, abre una micro-entrevista de una pregunta cada vez.
-- En cada pregunta breve ofrece siempre las opciones "Prefiero no decirlo" y "No lo sé".
-- Si la respuesta es "No lo sé", explica cómo averiguarlo y cuándo conviene revisar la Sede Electrónica de la AEAT o el certificado electronico.
-- Si la persona pregunta por campaña de renta, cierre de ejercicio o cuentas anuales, prioriza plazos, checklist y orden de trabajo.
-- Si la peticion requiere datos reales y no hay Holded, dilo con claridad y sin bloquear la ayuda general.`;
-}
-
 function logProvider(
   provider: AIProvider | 'fallback',
   model: string,
@@ -296,19 +227,30 @@ async function loadAuthenticatedChatContext() {
   };
 }
 
+type LLMResult = {
+  text: string;
+  provider: AIProvider;
+  model: string;
+  latencyMs?: number;
+  usage?: { inputTokens: number; outputTokens: number };
+};
+
 async function getLLMResponse(
   message: string,
+  history: AIMessage[],
   authenticatedContext: AuthenticatedChatContext | null,
   modelConfig: ModelConfig
-): Promise<{ text: string; provider: AIProvider; model: string } | null> {
+): Promise<LLMResult | null> {
   try {
+    const messages: AIMessage[] = [...history, { role: 'user', content: message }];
+
     const result = await callLLM({
       provider: modelConfig.provider,
       model: modelConfig.model,
       instructions: authenticatedContext
         ? buildAuthenticatedSystemPrompt(authenticatedContext)
         : buildPublicSystemPrompt(),
-      inputText: message,
+      messages,
       temperature: authenticatedContext ? 0.45 : 0.5,
       maxOutputTokens: authenticatedContext ? 550 : 450,
       feature: authenticatedContext ? 'workspace_chat_free' : 'public_chat',
@@ -392,6 +334,7 @@ export async function POST(request: NextRequest) {
     const modelConfig = resolveModelForPlan(planCode);
 
     let conversation: Awaited<ReturnType<typeof ensureHoldedConversation>> | null = null;
+    let history: AIMessage[] = [];
 
     if (authenticated) {
       conversation = await ensureHoldedConversation(authenticated.conversationScope, {
@@ -400,6 +343,12 @@ export async function POST(request: NextRequest) {
       }).catch(() => null);
 
       if (conversation) {
+        // Load short-term memory BEFORE persisting the new user message so we
+        // don't duplicate it in the prompt.
+        history = await listRecentConversationMessages(conversation.id, SHORT_MEMORY_TURNS).catch(
+          () => []
+        );
+
         await appendConversationMessage({
           conversationId: conversation.id,
           role: 'user',
@@ -408,7 +357,13 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    const result = await getLLMResponse(message, authenticated?.promptContext ?? null, modelConfig);
+    const result = await getLLMResponse(
+      message,
+      history,
+      authenticated?.promptContext ?? null,
+      modelConfig
+    );
+
     if (result) {
       logProvider(
         result.provider,
@@ -417,17 +372,44 @@ export async function POST(request: NextRequest) {
         authenticated ? 'workspace' : 'public'
       );
 
+      const isClarification = detectClarificationResponse(result.text);
+      const isFallback = result.provider !== modelConfig.provider;
+
       if (conversation) {
         await appendConversationMessage({
           conversationId: conversation.id,
           role: 'assistant',
           content: result.text,
+          metadata: {
+            provider: result.provider,
+            model: result.model,
+            latencyMs: result.latencyMs ?? null,
+            isClarification,
+            isFallback,
+          },
         }).catch(() => null);
       }
+
+      await recordChatMetric({
+        tenantId: authenticated?.session.tenantId ?? null,
+        userId: authenticated?.session.userId ?? null,
+        conversationId: conversation?.id ?? null,
+        provider: result.provider,
+        modelUsed: result.model,
+        feature: authenticated ? 'workspace_chat_free' : 'public_chat',
+        usage: result.usage,
+        latencyMs: result.latencyMs ?? null,
+        isClarification,
+        isFallback,
+        historyTurns: history.length,
+      }).catch((err) => {
+        console.error('[Isaak Chat] recordChatMetric failed', err);
+      });
 
       return NextResponse.json({
         response: result.text,
         reply: result.text,
+        isClarification,
         conversation: conversation
           ? { id: conversation.id, title: conversation.title ?? '' }
           : null,
@@ -442,8 +424,23 @@ export async function POST(request: NextRequest) {
         conversationId: conversation.id,
         role: 'assistant',
         content: fallback,
+        metadata: { provider: 'fallback', model: 'rule-based', isFallback: true },
       }).catch(() => null);
     }
+
+    await recordChatMetric({
+      tenantId: authenticated?.session.tenantId ?? null,
+      userId: authenticated?.session.userId ?? null,
+      conversationId: conversation?.id ?? null,
+      provider: 'fallback',
+      modelUsed: 'rule-based',
+      feature: authenticated ? 'workspace_chat_free' : 'public_chat',
+      isFallback: true,
+      historyTurns: history.length,
+      errorCode: 'llm_unavailable',
+    }).catch((err) => {
+      console.error('[Isaak Chat] recordChatMetric failed', err);
+    });
 
     return NextResponse.json({
       response: fallback,

--- a/apps/isaak/app/lib/__tests__/isaak-chat-metrics.test.ts
+++ b/apps/isaak/app/lib/__tests__/isaak-chat-metrics.test.ts
@@ -1,0 +1,60 @@
+import { detectClarificationResponse, estimateCostEur } from '../isaak-chat-metrics';
+
+describe('detectClarificationResponse', () => {
+  it('returns true for valid clarification JSON', () => {
+    const response = '{"clarify": true, "question": "¿Qué período?", "options": ["mes", "trimestre"]}';
+    expect(detectClarificationResponse(response)).toBe(true);
+  });
+
+  it('tolerates whitespace before braces', () => {
+    const response = '   {"clarify":true,"question":"foo","options":[]}';
+    expect(detectClarificationResponse(response)).toBe(true);
+  });
+
+  it('returns false for normal prose', () => {
+    expect(detectClarificationResponse('Las ventas de marzo fueron 12.000 €.')).toBe(false);
+  });
+
+  it('returns false for JSON without clarify=true', () => {
+    expect(detectClarificationResponse('{"reply": "hola"}')).toBe(false);
+    expect(detectClarificationResponse('{"clarify": false}')).toBe(false);
+  });
+
+  it('returns false for empty input', () => {
+    expect(detectClarificationResponse('')).toBe(false);
+  });
+
+  it('returns false when text starts with prose then JSON', () => {
+    expect(detectClarificationResponse('Aquí tienes: {"clarify": true}')).toBe(false);
+  });
+});
+
+describe('estimateCostEur', () => {
+  it('returns 0 for zero tokens', () => {
+    expect(estimateCostEur('claude-sonnet-4-6', 0, 0)).toBe(0);
+  });
+
+  it('uses Sonnet pricing for claude-sonnet-4-6', () => {
+    // 1M input * $3 + 1M output * $15 = $18 → ~€16.56
+    const cost = estimateCostEur('claude-sonnet-4-6', 1_000_000, 1_000_000);
+    expect(cost).toBeCloseTo(18 * 0.92, 2);
+  });
+
+  it('uses Haiku pricing for claude-haiku-4-5-20251001', () => {
+    // 1M input * $0.25 + 1M output * $1.25 = $1.5 → ~€1.38
+    const cost = estimateCostEur('claude-haiku-4-5-20251001', 1_000_000, 1_000_000);
+    expect(cost).toBeCloseTo(1.5 * 0.92, 2);
+  });
+
+  it('returns a reasonable cost for a typical Sonnet message', () => {
+    // ~1500 in / 400 out
+    const cost = estimateCostEur('claude-sonnet-4-6', 1500, 400);
+    expect(cost).toBeGreaterThan(0);
+    expect(cost).toBeLessThan(0.02);
+  });
+
+  it('falls back to default pricing for unknown models', () => {
+    const cost = estimateCostEur('mystery-model-xyz', 1_000_000, 1_000_000);
+    expect(cost).toBeGreaterThan(0);
+  });
+});

--- a/apps/isaak/app/lib/holded-chat.ts
+++ b/apps/isaak/app/lib/holded-chat.ts
@@ -3,6 +3,7 @@ import {
   ensureTenantConversation,
   getTenantConversation,
   getTenantMemoryContext,
+  listRecentTenantConversationMessages,
   listTenantConversations,
   storeTenantMemoryFact,
   type HoldedChatConversation,
@@ -39,6 +40,10 @@ export async function appendConversationMessage(input: {
   metadata?: Prisma.InputJsonValue;
 }) {
   return appendTenantConversationMessage(prisma, input);
+}
+
+export async function listRecentConversationMessages(conversationId: string, limit?: number) {
+  return listRecentTenantConversationMessages(prisma, conversationId, limit);
 }
 
 export async function storeSimpleMemoryFact(input: {

--- a/apps/isaak/app/lib/isaak-chat-metrics.ts
+++ b/apps/isaak/app/lib/isaak-chat-metrics.ts
@@ -1,0 +1,85 @@
+import type { AIProvider, AIUsage } from '@verifactu/utils';
+import { prisma } from './prisma';
+
+// Pricing snapshot (USD per 1M tokens) → converted to EUR.
+// Sourced from public Anthropic/OpenAI pricing pages, 2026-05-24.
+// Update when providers change prices.
+const USD_TO_EUR = 0.92;
+
+const MODEL_PRICING_USD_PER_MTOK: Record<string, { input: number; output: number }> = {
+  // Anthropic
+  'claude-sonnet-4-6': { input: 3, output: 15 },
+  'claude-opus-4-7': { input: 15, output: 75 },
+  'claude-haiku-4-5-20251001': { input: 0.25, output: 1.25 },
+  'claude-haiku-4-5': { input: 0.25, output: 1.25 },
+  // OpenAI
+  'gpt-4o': { input: 2.5, output: 10 },
+  'gpt-4o-mini': { input: 0.15, output: 0.6 },
+  'gpt-4.1': { input: 2.5, output: 10 },
+  'gpt-4.1-mini': { input: 0.15, output: 0.6 },
+};
+
+const DEFAULT_PRICING = { input: 1, output: 3 };
+
+export function estimateCostEur(model: string, inputTokens: number, outputTokens: number): number {
+  const pricing = MODEL_PRICING_USD_PER_MTOK[model] ?? DEFAULT_PRICING;
+  const usdInput = (inputTokens / 1_000_000) * pricing.input;
+  const usdOutput = (outputTokens / 1_000_000) * pricing.output;
+  return (usdInput + usdOutput) * USD_TO_EUR;
+}
+
+export type RecordChatMetricInput = {
+  tenantId?: string | null;
+  userId?: string | null;
+  conversationId?: string | null;
+  messageId?: string | null;
+  provider: AIProvider | 'fallback';
+  modelUsed: string;
+  feature?: string | null;
+  usage?: AIUsage;
+  latencyMs?: number | null;
+  firstTokenMs?: number | null;
+  toolCalls?: string[];
+  isClarification?: boolean;
+  isFallback?: boolean;
+  historyTurns?: number;
+  errorCode?: string | null;
+};
+
+export async function recordChatMetric(input: RecordChatMetricInput): Promise<void> {
+  const inputTokens = input.usage?.inputTokens ?? 0;
+  const outputTokens = input.usage?.outputTokens ?? 0;
+  const cost = estimateCostEur(input.modelUsed, inputTokens, outputTokens);
+
+  await prisma.isaakChatMetric.create({
+    data: {
+      tenantId: input.tenantId ?? null,
+      userId: input.userId ?? null,
+      conversationId: input.conversationId ?? null,
+      messageId: input.messageId ?? null,
+      provider: input.provider,
+      modelUsed: input.modelUsed,
+      feature: input.feature ?? null,
+      inputTokens,
+      outputTokens,
+      estimatedCostEur: cost,
+      latencyMs: input.latencyMs ?? 0,
+      firstTokenMs: input.firstTokenMs ?? null,
+      toolCallsCount: input.toolCalls?.length ?? 0,
+      toolNames: input.toolCalls ?? [],
+      isClarification: Boolean(input.isClarification),
+      isFallback: Boolean(input.isFallback),
+      historyTurns: input.historyTurns ?? 0,
+      errorCode: input.errorCode ?? null,
+    },
+  });
+}
+
+const CLARIFY_KEY_REGEX = /"clarify"\s*:\s*true/;
+
+export function detectClarificationResponse(text: string): boolean {
+  if (!text) return false;
+  const trimmed = text.trim();
+  if (!trimmed.startsWith('{')) return false;
+  return CLARIFY_KEY_REGEX.test(trimmed);
+}

--- a/apps/isaak/app/lib/isaak-chat-prompts.ts
+++ b/apps/isaak/app/lib/isaak-chat-prompts.ts
@@ -1,0 +1,94 @@
+import { ISAAK_PUBLIC_URL } from './isaak-navigation';
+
+export type AuthenticatedChatContext = {
+  tenantId: string;
+  userId: string;
+  preferredName: string;
+  companyName: string;
+  contextSummary: string;
+  roleLabel: string;
+  sectorLabel: string;
+  communicationStyle: string;
+  knowledgeLevel: string;
+  goals: string[];
+  holdedConnected: boolean;
+  workspaceSignalsBlock: string;
+};
+
+export function buildPublicSystemPrompt() {
+  return `Eres Isaak, el asistente fiscal y operativo de ${ISAAK_PUBLIC_URL}.
+
+Objetivo:
+- Ayudar con tramites, dudas fiscales, impuestos y consejos practicos.
+- Guiar sobre cumplimiento VeriFactu y operativa diaria sin tecnicismos innecesarios.
+- Mantener tono claro, accionable y cercano.
+
+Identidad:
+- No eres un chatbot generico de facturacion.
+- Eres Isaak.
+- Si preguntan por Holded, explica que es una compatibilidad de entrada, pero la experiencia y el criterio los aporta Isaak.
+
+Estilo de respuesta:
+- Espanol, breve, practico y orientado al siguiente paso.
+- Evita texto legal extenso.
+- Si falta contexto, pide solo lo minimo para avanzar.
+- No prometas acceso a informacion privada ni acciones sobre datos reales.
+- Si la persona pide analisis de datos reales, explica que primero debe activar su espacio autenticado o conectar sus sistemas.`;
+}
+
+export function buildAuthenticatedSystemPrompt(context: AuthenticatedChatContext) {
+  const goals = context.goals.length
+    ? context.goals.slice(0, 3).join(', ')
+    : 'resolver dudas fiscales y ordenar el negocio con calma';
+
+  return `Eres Isaak, el asistente fiscal y operativo del workspace autenticado de ${ISAAK_PUBLIC_URL}.
+
+Objetivo:
+- Ayudar con dudas fiscales, contables y operativas sin agobiar a la persona usuaria.
+- Detectar su estado actual y orientar el siguiente paso con claridad.
+- Aprovechar su contexto real de perfil, plan, tareas pendientes y calendario fiscal.
+
+Principios de respuesta (orden estricto):
+1. NO INVENTES DATOS. Nunca cifres importes, fechas o nombres concretos de clientes/facturas que no aparezcan en el contexto o en los mensajes previos. Si te falta un dato real, dilo: "no tengo ese dato accesible".
+2. PREGUNTA ANTES DE ASUMIR. Si la solicitud es ambigua en período, cliente, importe o intención, responde EXCLUSIVAMENTE con este JSON (sin texto adicional, sin markdown, sin backticks):
+   {"clarify": true, "question": "<pregunta corta en español>", "options": ["<opcion 1>", "<opcion 2>", "<opcion 3>"]}
+   Ejemplos que requieren clarificación:
+   - "cómo van las ventas" → falta período
+   - "factura al cliente" → falta cliente o importe
+   - "el IVA" → falta trimestre o año
+   - "ayúdame con esto" → falta intent
+3. USA LA MEMORIA. Lee los mensajes previos del usuario y tuyos. Si ya preguntaste algo, no lo vuelvas a preguntar. Si la persona ya te dio un dato (período, cliente, etc.), recuérdalo y úsalo.
+4. CONFIRMA ANTES DE ACTUAR. Para acciones que escriben datos (crear factura, registrar pago, enviar email), resume lo que vas a hacer y pide "sí, confirma" antes.
+
+Reglas de producto:
+- Existe un modo gratis limitado para usuarios autenticados aunque no tengan Holded conectado.
+- No pidas conectar Holded por defecto.
+- Solo sugiere conectar Holded cuando la peticion requiera datos reales, sincronizacion, lectura de ventas, gastos, cobros, contactos, facturas o acciones sobre sistemas conectados.
+- Si no hay Holded, sigue ayudando con criterio fiscal, explicaciones, checklist, prioridades y onboarding.
+
+Estilo:
+- Espanol claro, calmado, humano y practico.
+- Respuestas breves por defecto, con foco en el siguiente paso.
+- Sin tecnicismos innecesarios.
+
+Contexto de la persona usuaria:
+- Nombre preferido: ${context.preferredName}.
+- Empresa: ${context.companyName}.
+- Rol: ${context.roleLabel}.
+- Actividad: ${context.sectorLabel}.
+- Estilo preferido: ${context.communicationStyle}.
+- Nivel esperado: ${context.knowledgeLevel}.
+- Objetivos principales: ${goals}.
+- Resumen actual: ${context.contextSummary}
+- Holded conectado: ${context.holdedConnected ? 'sí' : 'no'}.
+
+Estado del workspace:
+${context.workspaceSignalsBlock}
+
+Comportamiento adicional:
+- Si faltan datos fiscales o de empresa para ayudar mejor, abre una micro-entrevista de una pregunta cada vez.
+- En cada pregunta breve ofrece siempre las opciones "Prefiero no decirlo" y "No lo sé".
+- Si la respuesta es "No lo sé", explica cómo averiguarlo y cuándo conviene revisar la Sede Electrónica de la AEAT o el certificado electronico.
+- Si la persona pregunta por campaña de renta, cierre de ejercicio o cuentas anuales, prioriza plazos, checklist y orden de trabajo.
+- Si la peticion requiere datos reales y no hay Holded, dilo con claridad y sin bloquear la ayuda general.`;
+}

--- a/apps/isaak/tests/intelligence/README.md
+++ b/apps/isaak/tests/intelligence/README.md
@@ -1,0 +1,48 @@
+# Isaak Intelligence — Golden test harness
+
+Reference set of fixtures and tests that pin Isaak's chat behaviour as it
+evolves through F1 → F8 (see `docs/engineering/ISAAK_INTELLIGENCE.md`).
+
+## Layout
+
+```
+tests/intelligence/
+  fixtures/
+    clarify/             # ambiguous queries → should ask
+    no-clarify/          # precise queries → should answer
+    no-hallucination/    # no grounding → should NOT invent
+    multi-turn/          # context across turns
+  helpers/
+    types.ts             # GoldenFixture schema
+    load-fixtures.ts     # loads .json files by category
+    llm-judge.ts         # GPT-4o-mini judge (opt-in)
+    run-isaak.ts         # invokes callLLM with the prod system prompt
+  golden/
+    clarify.test.ts
+    no-hallucination.test.ts
+    multi-turn.test.ts
+```
+
+## Running
+
+Most assertions hit the real LLM and cost tokens. They're SKIPPED by
+default. The wiring tests always run (they verify fixtures exist).
+
+```bash
+# CI / fast: only wiring + lib unit tests
+npm test -- intelligence
+
+# Live: actually run fixtures against the LLM
+ISAAK_GOLDEN_LIVE=1 npm test -- intelligence
+```
+
+Required env for live mode: `ANTHROPIC_API_KEY` (or `ISAAK_ANTHROPIC_API_KEY`)
+and `OPENAI_API_KEY` (for the judge).
+
+## Adding fixtures
+
+Drop a JSON file into the matching category directory. Schema in
+`helpers/types.ts`. Naming convention: `NN-short-slug.json`.
+
+The fixture is automatically picked up by the test runner — no test
+file changes needed.

--- a/apps/isaak/tests/intelligence/fixtures/clarify/01-sales-no-period.json
+++ b/apps/isaak/tests/intelligence/fixtures/clarify/01-sales-no-period.json
@@ -1,0 +1,13 @@
+{
+  "id": "clarify-sales-no-period-01",
+  "category": "clarify",
+  "description": "Pregunta de ventas sin período → debe pedir clarificación de período",
+  "query": "¿Cómo van las ventas?",
+  "context": { "authenticated": true, "holdedConnected": true },
+  "expected": {
+    "shouldClarify": true,
+    "ambiguityType": "period",
+    "clarificationContains": ["período", "mes", "trimestre"],
+    "minJudgeScore": 7
+  }
+}

--- a/apps/isaak/tests/intelligence/fixtures/clarify/02-invoice-no-client.json
+++ b/apps/isaak/tests/intelligence/fixtures/clarify/02-invoice-no-client.json
@@ -1,0 +1,13 @@
+{
+  "id": "clarify-invoice-no-client-02",
+  "category": "clarify",
+  "description": "Petición de factura sin cliente ni importe → debe clarificar",
+  "query": "Crea una factura",
+  "context": { "authenticated": true, "holdedConnected": true },
+  "expected": {
+    "shouldClarify": true,
+    "ambiguityType": "entity",
+    "clarificationContains": ["cliente", "importe", "concepto"],
+    "minJudgeScore": 7
+  }
+}

--- a/apps/isaak/tests/intelligence/fixtures/clarify/03-iva-no-quarter.json
+++ b/apps/isaak/tests/intelligence/fixtures/clarify/03-iva-no-quarter.json
@@ -1,0 +1,13 @@
+{
+  "id": "clarify-iva-no-quarter-03",
+  "category": "clarify",
+  "description": "Pregunta de IVA sin trimestre concreto",
+  "query": "¿Cuánto IVA tengo que pagar?",
+  "context": { "authenticated": true, "holdedConnected": true },
+  "expected": {
+    "shouldClarify": true,
+    "ambiguityType": "period",
+    "clarificationContains": ["trimestre", "período"],
+    "minJudgeScore": 7
+  }
+}

--- a/apps/isaak/tests/intelligence/fixtures/clarify/04-most-important-client.json
+++ b/apps/isaak/tests/intelligence/fixtures/clarify/04-most-important-client.json
@@ -1,0 +1,13 @@
+{
+  "id": "clarify-most-important-client-04",
+  "category": "clarify",
+  "description": "Cliente más importante: ambiguo (criterio)",
+  "query": "¿Quién es mi cliente más importante?",
+  "context": { "authenticated": true, "holdedConnected": true },
+  "expected": {
+    "shouldClarify": true,
+    "ambiguityType": "intent",
+    "clarificationContains": ["criterio", "facturación", "volumen", "recurrencia"],
+    "minJudgeScore": 6
+  }
+}

--- a/apps/isaak/tests/intelligence/fixtures/clarify/05-help-with-this.json
+++ b/apps/isaak/tests/intelligence/fixtures/clarify/05-help-with-this.json
@@ -1,0 +1,13 @@
+{
+  "id": "clarify-help-with-this-05",
+  "category": "clarify",
+  "description": "Petición vaga sin intención clara",
+  "query": "Ayúdame con esto",
+  "context": { "authenticated": true },
+  "expected": {
+    "shouldClarify": true,
+    "ambiguityType": "intent",
+    "clarificationContains": ["qué", "necesitas", "ayudarte"],
+    "minJudgeScore": 7
+  }
+}

--- a/apps/isaak/tests/intelligence/fixtures/clarify/06-expenses-no-period.json
+++ b/apps/isaak/tests/intelligence/fixtures/clarify/06-expenses-no-period.json
@@ -1,0 +1,13 @@
+{
+  "id": "clarify-expenses-no-period-06",
+  "category": "clarify",
+  "description": "Gastos sin período",
+  "query": "Resúmeme los gastos",
+  "context": { "authenticated": true, "holdedConnected": true },
+  "expected": {
+    "shouldClarify": true,
+    "ambiguityType": "period",
+    "clarificationContains": ["período", "mes", "trimestre", "año"],
+    "minJudgeScore": 7
+  }
+}

--- a/apps/isaak/tests/intelligence/fixtures/clarify/07-modelo-303-no-quarter.json
+++ b/apps/isaak/tests/intelligence/fixtures/clarify/07-modelo-303-no-quarter.json
@@ -1,0 +1,13 @@
+{
+  "id": "clarify-modelo-303-07",
+  "category": "clarify",
+  "description": "Modelo 303 sin período",
+  "query": "Quiero preparar el modelo 303",
+  "context": { "authenticated": true, "holdedConnected": true },
+  "expected": {
+    "shouldClarify": true,
+    "ambiguityType": "period",
+    "clarificationContains": ["trimestre", "período"],
+    "minJudgeScore": 7
+  }
+}

--- a/apps/isaak/tests/intelligence/fixtures/clarify/08-payment-no-target.json
+++ b/apps/isaak/tests/intelligence/fixtures/clarify/08-payment-no-target.json
@@ -1,0 +1,13 @@
+{
+  "id": "clarify-payment-no-target-08",
+  "category": "clarify",
+  "description": "Registrar pago sin importe ni factura",
+  "query": "Registra el pago",
+  "context": { "authenticated": true, "holdedConnected": true },
+  "expected": {
+    "shouldClarify": true,
+    "ambiguityType": "entity",
+    "clarificationContains": ["factura", "importe", "cliente"],
+    "minJudgeScore": 7
+  }
+}

--- a/apps/isaak/tests/intelligence/fixtures/clarify/09-send-email-no-target.json
+++ b/apps/isaak/tests/intelligence/fixtures/clarify/09-send-email-no-target.json
@@ -1,0 +1,13 @@
+{
+  "id": "clarify-send-email-no-target-09",
+  "category": "clarify",
+  "description": "Enviar email sin destinatario claro",
+  "query": "Envía un email recordando el pago",
+  "context": { "authenticated": true, "holdedConnected": true },
+  "expected": {
+    "shouldClarify": true,
+    "ambiguityType": "entity",
+    "clarificationContains": ["cliente", "factura", "destinatario"],
+    "minJudgeScore": 7
+  }
+}

--- a/apps/isaak/tests/intelligence/fixtures/clarify/10-show-clients-ambig.json
+++ b/apps/isaak/tests/intelligence/fixtures/clarify/10-show-clients-ambig.json
@@ -1,0 +1,12 @@
+{
+  "id": "clarify-show-clients-ambig-10",
+  "category": "clarify",
+  "description": "Listar clientes sin criterio: ambiguo (todos / por estado / por importe)",
+  "query": "Muéstrame los clientes",
+  "context": { "authenticated": true, "holdedConnected": true },
+  "expected": {
+    "shouldClarify": true,
+    "ambiguityType": "intent",
+    "minJudgeScore": 6
+  }
+}

--- a/apps/isaak/tests/intelligence/fixtures/multi-turn/01-period-inheritance.json
+++ b/apps/isaak/tests/intelligence/fixtures/multi-turn/01-period-inheritance.json
@@ -1,0 +1,17 @@
+{
+  "id": "multi-turn-period-inheritance-01",
+  "category": "multi-turn",
+  "description": "Establece período en turno 2, debe usarlo en turno 3 sin volver a preguntar",
+  "turns": [
+    { "user": "¿Cómo van las ventas?" },
+    { "user": "Este mes" },
+    { "user": "¿Y los gastos?" }
+  ],
+  "context": { "authenticated": true, "holdedConnected": true },
+  "expected": {
+    "turnAssertions": [
+      { "turn": 3, "excludes": ["¿qué período", "qué mes", "qué trimestre"], "shouldClarify": false }
+    ],
+    "minJudgeScore": 7
+  }
+}

--- a/apps/isaak/tests/intelligence/fixtures/multi-turn/02-name-memory.json
+++ b/apps/isaak/tests/intelligence/fixtures/multi-turn/02-name-memory.json
@@ -1,0 +1,17 @@
+{
+  "id": "multi-turn-name-memory-02",
+  "category": "multi-turn",
+  "description": "Nombre dado en turno 1 debe recordarse en turno 3",
+  "turns": [
+    { "user": "Hola, me llamo Marta y soy autónoma" },
+    { "user": "Necesito declarar el IRPF" },
+    { "user": "¿Cómo me llamaba?" }
+  ],
+  "context": { "authenticated": true },
+  "expected": {
+    "turnAssertions": [
+      { "turn": 3, "contains": ["Marta"] }
+    ],
+    "minJudgeScore": 8
+  }
+}

--- a/apps/isaak/tests/intelligence/fixtures/multi-turn/03-no-question-repeat.json
+++ b/apps/isaak/tests/intelligence/fixtures/multi-turn/03-no-question-repeat.json
@@ -1,0 +1,17 @@
+{
+  "id": "multi-turn-no-question-repeat-03",
+  "category": "multi-turn",
+  "description": "Tras responder a clarificación, no debe re-preguntar lo mismo",
+  "turns": [
+    { "user": "¿Cuánto IVA pago?" },
+    { "user": "Tercer trimestre de 2026" },
+    { "user": "¿Y de IRPF?" }
+  ],
+  "context": { "authenticated": true, "holdedConnected": true },
+  "expected": {
+    "turnAssertions": [
+      { "turn": 3, "excludes": ["qué trimestre", "qué período"] }
+    ],
+    "minJudgeScore": 7
+  }
+}

--- a/apps/isaak/tests/intelligence/fixtures/multi-turn/04-context-switch.json
+++ b/apps/isaak/tests/intelligence/fixtures/multi-turn/04-context-switch.json
@@ -1,0 +1,17 @@
+{
+  "id": "multi-turn-context-switch-04",
+  "category": "multi-turn",
+  "description": "Cambio explícito de tema en turno 3 debe re-clarificar período (no asumir el anterior)",
+  "turns": [
+    { "user": "¿Cuánto vendí este mes?" },
+    { "user": "Vale gracias" },
+    { "user": "¿Y los gastos del año pasado?" }
+  ],
+  "context": { "authenticated": true, "holdedConnected": true },
+  "expected": {
+    "turnAssertions": [
+      { "turn": 3, "shouldClarify": false }
+    ],
+    "minJudgeScore": 7
+  }
+}

--- a/apps/isaak/tests/intelligence/fixtures/multi-turn/05-consistent-numbers.json
+++ b/apps/isaak/tests/intelligence/fixtures/multi-turn/05-consistent-numbers.json
@@ -1,0 +1,17 @@
+{
+  "id": "multi-turn-consistent-numbers-05",
+  "category": "multi-turn",
+  "description": "Sin Holded, no debe dar cifras concretas distintas entre turnos",
+  "turns": [
+    { "user": "Sin conectar Holded ¿puedes calcular mi cuota de IVA?" },
+    { "user": "¿Y mi facturación neta?" }
+  ],
+  "context": { "authenticated": true, "holdedConnected": false },
+  "expected": {
+    "turnAssertions": [
+      { "turn": 1, "excludes": ["€"] },
+      { "turn": 2, "excludes": ["€"] }
+    ],
+    "minJudgeScore": 7
+  }
+}

--- a/apps/isaak/tests/intelligence/fixtures/multi-turn/06-fact-recall.json
+++ b/apps/isaak/tests/intelligence/fixtures/multi-turn/06-fact-recall.json
@@ -1,0 +1,18 @@
+{
+  "id": "multi-turn-fact-recall-06",
+  "category": "multi-turn",
+  "description": "Hecho de negocio dado en turno 1 debe usarse en turno 3 sin re-preguntar",
+  "turns": [
+    { "user": "Mi empresa es una SL, módulo general de IVA, ejercicio fiscal natural" },
+    { "user": "¿Cuántos modelos trimestrales tengo que presentar?" },
+    { "user": "¿Y cuándo termina el plazo del próximo?" }
+  ],
+  "context": { "authenticated": true },
+  "expected": {
+    "turnAssertions": [
+      { "turn": 2, "excludes": ["¿Qué tipo de empresa", "régimen"] },
+      { "turn": 3, "excludes": ["qué modelo"] }
+    ],
+    "minJudgeScore": 7
+  }
+}

--- a/apps/isaak/tests/intelligence/fixtures/no-clarify/01-greeting.json
+++ b/apps/isaak/tests/intelligence/fixtures/no-clarify/01-greeting.json
@@ -1,0 +1,12 @@
+{
+  "id": "no-clarify-greeting-01",
+  "category": "no-clarify",
+  "description": "Saludo simple no requiere clarificación",
+  "query": "Hola Isaak",
+  "context": { "authenticated": true },
+  "expected": {
+    "shouldClarify": false,
+    "responseExcludes": ["\"clarify\":true", "{\"clarify\":"],
+    "minJudgeScore": 7
+  }
+}

--- a/apps/isaak/tests/intelligence/fixtures/no-clarify/02-iva-q1-2026.json
+++ b/apps/isaak/tests/intelligence/fixtures/no-clarify/02-iva-q1-2026.json
@@ -1,0 +1,12 @@
+{
+  "id": "no-clarify-iva-q1-2026-02",
+  "category": "no-clarify",
+  "description": "IVA Q1 2026: período preciso, no debe clarificar",
+  "query": "Resume el IVA repercutido del primer trimestre de 2026",
+  "context": { "authenticated": true, "holdedConnected": true },
+  "expected": {
+    "shouldClarify": false,
+    "responseExcludes": ["\"clarify\":true"],
+    "minJudgeScore": 6
+  }
+}

--- a/apps/isaak/tests/intelligence/fixtures/no-clarify/03-explain-verifactu.json
+++ b/apps/isaak/tests/intelligence/fixtures/no-clarify/03-explain-verifactu.json
@@ -1,0 +1,12 @@
+{
+  "id": "no-clarify-explain-verifactu-03",
+  "category": "no-clarify",
+  "description": "Pregunta conceptual: no requiere clarificación",
+  "query": "¿Qué es Verifactu en una frase?",
+  "context": { "authenticated": true },
+  "expected": {
+    "shouldClarify": false,
+    "responseContains": ["facturación", "trazable"],
+    "minJudgeScore": 7
+  }
+}

--- a/apps/isaak/tests/intelligence/fixtures/no-clarify/04-sales-yesterday.json
+++ b/apps/isaak/tests/intelligence/fixtures/no-clarify/04-sales-yesterday.json
@@ -1,0 +1,12 @@
+{
+  "id": "no-clarify-sales-yesterday-04",
+  "category": "no-clarify",
+  "description": "Ventas de ayer: período claro, no clarifica",
+  "query": "¿Cuánto vendí ayer?",
+  "context": { "authenticated": true, "holdedConnected": true },
+  "expected": {
+    "shouldClarify": false,
+    "responseExcludes": ["\"clarify\":true"],
+    "minJudgeScore": 6
+  }
+}

--- a/apps/isaak/tests/intelligence/fixtures/no-clarify/05-thanks.json
+++ b/apps/isaak/tests/intelligence/fixtures/no-clarify/05-thanks.json
@@ -1,0 +1,12 @@
+{
+  "id": "no-clarify-thanks-05",
+  "category": "no-clarify",
+  "description": "Agradecimiento no requiere clarificación",
+  "query": "Gracias!",
+  "context": { "authenticated": true },
+  "expected": {
+    "shouldClarify": false,
+    "responseExcludes": ["\"clarify\":true"],
+    "minJudgeScore": 6
+  }
+}

--- a/apps/isaak/tests/intelligence/fixtures/no-clarify/06-fiscal-calendar.json
+++ b/apps/isaak/tests/intelligence/fixtures/no-clarify/06-fiscal-calendar.json
@@ -1,0 +1,12 @@
+{
+  "id": "no-clarify-fiscal-calendar-06",
+  "category": "no-clarify",
+  "description": "Pregunta general sobre fechas fiscales",
+  "query": "¿Cuándo vence el modelo 303 del primer trimestre?",
+  "context": { "authenticated": true },
+  "expected": {
+    "shouldClarify": false,
+    "responseContains": ["20 de abril"],
+    "minJudgeScore": 6
+  }
+}

--- a/apps/isaak/tests/intelligence/fixtures/no-clarify/07-march-2026-sales.json
+++ b/apps/isaak/tests/intelligence/fixtures/no-clarify/07-march-2026-sales.json
@@ -1,0 +1,12 @@
+{
+  "id": "no-clarify-march-2026-sales-07",
+  "category": "no-clarify",
+  "description": "Período preciso (marzo 2026): no debe clarificar",
+  "query": "Dame el total de ventas de marzo de 2026",
+  "context": { "authenticated": true, "holdedConnected": true },
+  "expected": {
+    "shouldClarify": false,
+    "responseExcludes": ["\"clarify\":true"],
+    "minJudgeScore": 6
+  }
+}

--- a/apps/isaak/tests/intelligence/fixtures/no-clarify/08-quarter-deadline.json
+++ b/apps/isaak/tests/intelligence/fixtures/no-clarify/08-quarter-deadline.json
@@ -1,0 +1,12 @@
+{
+  "id": "no-clarify-quarter-deadline-08",
+  "category": "no-clarify",
+  "description": "Pregunta directa de plazos sin ambigüedad",
+  "query": "¿Cuándo termina el plazo de presentación del 130 del segundo trimestre?",
+  "context": { "authenticated": true },
+  "expected": {
+    "shouldClarify": false,
+    "responseContains": ["julio"],
+    "minJudgeScore": 6
+  }
+}

--- a/apps/isaak/tests/intelligence/fixtures/no-hallucination/01-unknown-client.json
+++ b/apps/isaak/tests/intelligence/fixtures/no-hallucination/01-unknown-client.json
@@ -1,0 +1,13 @@
+{
+  "id": "no-halluc-unknown-client-01",
+  "category": "no-hallucination",
+  "description": "Cliente que no existe en el sistema → debe decir que no lo encuentra, no inventar deuda",
+  "query": "¿Cuánto me debe el cliente 'XYZTest SL'?",
+  "context": { "authenticated": true, "holdedConnected": true, "noClientWithName": "XYZTest SL" },
+  "expected": {
+    "shouldClarify": false,
+    "responseContains": ["no", "encontr"],
+    "responseExcludes": ["XYZTest SL le debe", "XYZTest SL tiene una deuda", "€"],
+    "minJudgeScore": 7
+  }
+}

--- a/apps/isaak/tests/intelligence/fixtures/no-hallucination/02-fake-tax-rate.json
+++ b/apps/isaak/tests/intelligence/fixtures/no-hallucination/02-fake-tax-rate.json
@@ -1,0 +1,12 @@
+{
+  "id": "no-halluc-fake-tax-rate-02",
+  "category": "no-hallucination",
+  "description": "Pregunta sobre tipo de IVA en sector ambiguo → no debe inventar tipos exactos",
+  "query": "Mi sector es 'venta de partituras impresas con servicio educativo' ¿qué IVA aplico?",
+  "context": { "authenticated": true },
+  "expected": {
+    "shouldClarify": false,
+    "responseContains": ["depende", "consultar"],
+    "minJudgeScore": 6
+  }
+}

--- a/apps/isaak/tests/intelligence/fixtures/no-hallucination/03-no-data-without-holded.json
+++ b/apps/isaak/tests/intelligence/fixtures/no-hallucination/03-no-data-without-holded.json
@@ -1,0 +1,13 @@
+{
+  "id": "no-halluc-no-data-without-holded-03",
+  "category": "no-hallucination",
+  "description": "Sin Holded conectado, pregunta de datos reales → debe declarar que no tiene acceso, no inventar",
+  "query": "Dime mi facturación total este mes",
+  "context": { "authenticated": true, "holdedConnected": false },
+  "expected": {
+    "shouldClarify": false,
+    "responseContains": ["Holded", "conectar"],
+    "responseExcludes": ["€", "facturado", "ingresaste"],
+    "minJudgeScore": 7
+  }
+}

--- a/apps/isaak/tests/intelligence/fixtures/no-hallucination/04-no-fake-payment-status.json
+++ b/apps/isaak/tests/intelligence/fixtures/no-hallucination/04-no-fake-payment-status.json
@@ -1,0 +1,13 @@
+{
+  "id": "no-halluc-fake-payment-status-04",
+  "category": "no-hallucination",
+  "description": "Pregunta por factura específica sin contexto → no debe inventar estado",
+  "query": "¿Está pagada la factura 2025-0042?",
+  "context": { "authenticated": true, "holdedConnected": false },
+  "expected": {
+    "shouldClarify": false,
+    "responseContains": ["no", "puedo", "consultar"],
+    "responseExcludes": ["sí, está pagada", "fue pagada el", "pendiente desde"],
+    "minJudgeScore": 7
+  }
+}

--- a/apps/isaak/tests/intelligence/fixtures/no-hallucination/05-no-fake-bank-balance.json
+++ b/apps/isaak/tests/intelligence/fixtures/no-hallucination/05-no-fake-bank-balance.json
@@ -1,0 +1,13 @@
+{
+  "id": "no-halluc-bank-balance-05",
+  "category": "no-hallucination",
+  "description": "Saldo bancario sin conexión PSD2 → no debe inventar saldo",
+  "query": "¿Cuánto dinero tengo en el banco ahora mismo?",
+  "context": { "authenticated": true, "bankConnected": false },
+  "expected": {
+    "shouldClarify": false,
+    "responseContains": ["no", "conectado", "banco"],
+    "responseExcludes": ["€ en tu cuenta", "tienes un saldo de"],
+    "minJudgeScore": 7
+  }
+}

--- a/apps/isaak/tests/intelligence/fixtures/no-hallucination/06-no-fake-deadline.json
+++ b/apps/isaak/tests/intelligence/fixtures/no-hallucination/06-no-fake-deadline.json
@@ -1,0 +1,12 @@
+{
+  "id": "no-halluc-fake-deadline-06",
+  "category": "no-hallucination",
+  "description": "No inventar deadline específico de modelo poco común sin datos concretos",
+  "query": "¿Cuándo es exactamente el plazo del modelo 720 para mis cuentas en Andorra?",
+  "context": { "authenticated": true },
+  "expected": {
+    "shouldClarify": false,
+    "responseContains": ["31 de marzo"],
+    "minJudgeScore": 6
+  }
+}

--- a/apps/isaak/tests/intelligence/golden/clarify.test.ts
+++ b/apps/isaak/tests/intelligence/golden/clarify.test.ts
@@ -1,0 +1,79 @@
+// Golden test: clarify-first behavior.
+//
+// SKIPPED unless ISAAK_GOLDEN_LIVE=1 — these tests hit the real LLM and
+// cost tokens. Run locally with:
+//   ISAAK_GOLDEN_LIVE=1 npm test -- tests/intelligence/golden/clarify
+//
+// Each fixture under fixtures/clarify and fixtures/no-clarify is asserted
+// against the Isaak system prompt + memory architecture from F1.
+
+import { detectClarificationResponse } from '../../../app/lib/isaak-chat-metrics';
+import { loadFixturesByCategory } from '../helpers/load-fixtures';
+import { runIsaakSingleTurn } from '../helpers/run-isaak';
+import { isGoldenLiveMode } from '../helpers/llm-judge';
+
+const liveMode = isGoldenLiveMode();
+const describeIf = liveMode ? describe : describe.skip;
+
+describeIf('golden / clarify-first', () => {
+  const clarifyFixtures = loadFixturesByCategory('clarify');
+  const noClarifyFixtures = loadFixturesByCategory('no-clarify');
+
+  jest.setTimeout(45_000);
+
+  describe('should clarify (ambiguous queries)', () => {
+    test.each(clarifyFixtures.map((f) => [f.id, f]))(
+      '%s',
+      async (_id, fixture) => {
+        if (!fixture.query) throw new Error(`Fixture ${fixture.id} missing query`);
+        const result = await runIsaakSingleTurn({
+          query: fixture.query,
+          context: fixture.context,
+        });
+        const looksLikeClarify = detectClarificationResponse(result.text);
+
+        expect(looksLikeClarify).toBe(true);
+
+        if (fixture.expected.clarificationContains?.length) {
+          const lower = result.text.toLowerCase();
+          const matched = fixture.expected.clarificationContains.filter((needle) =>
+            lower.includes(needle.toLowerCase())
+          );
+          expect(matched.length).toBeGreaterThan(0);
+        }
+      }
+    );
+  });
+
+  describe('should NOT clarify (precise queries)', () => {
+    test.each(noClarifyFixtures.map((f) => [f.id, f]))(
+      '%s',
+      async (_id, fixture) => {
+        if (!fixture.query) throw new Error(`Fixture ${fixture.id} missing query`);
+        const result = await runIsaakSingleTurn({
+          query: fixture.query,
+          context: fixture.context,
+        });
+        const looksLikeClarify = detectClarificationResponse(result.text);
+
+        expect(looksLikeClarify).toBe(false);
+
+        if (fixture.expected.responseContains?.length) {
+          const lower = result.text.toLowerCase();
+          const matched = fixture.expected.responseContains.filter((needle) =>
+            lower.includes(needle.toLowerCase())
+          );
+          expect(matched.length).toBeGreaterThan(0);
+        }
+      }
+    );
+  });
+});
+
+// Always-on smoke test so the test file isn't empty in CI.
+describe('golden / clarify-first wiring', () => {
+  it('finds clarify and no-clarify fixtures', () => {
+    expect(loadFixturesByCategory('clarify').length).toBeGreaterThan(0);
+    expect(loadFixturesByCategory('no-clarify').length).toBeGreaterThan(0);
+  });
+});

--- a/apps/isaak/tests/intelligence/golden/multi-turn.test.ts
+++ b/apps/isaak/tests/intelligence/golden/multi-turn.test.ts
@@ -1,0 +1,58 @@
+// Golden test: multi-turn memory + coherence.
+//
+// This is the headline F1 criterion: Isaak should not repeat questions,
+// should remember facts (names, periods) across turns, and shouldn't
+// contradict itself.
+//
+// SKIPPED unless ISAAK_GOLDEN_LIVE=1.
+
+import { detectClarificationResponse } from '../../../app/lib/isaak-chat-metrics';
+import { loadFixturesByCategory } from '../helpers/load-fixtures';
+import { runIsaakMultiTurn } from '../helpers/run-isaak';
+import { isGoldenLiveMode } from '../helpers/llm-judge';
+
+const liveMode = isGoldenLiveMode();
+const describeIf = liveMode ? describe : describe.skip;
+
+describeIf('golden / multi-turn memory', () => {
+  const fixtures = loadFixturesByCategory('multi-turn');
+
+  jest.setTimeout(120_000);
+
+  test.each(fixtures.map((f) => [f.id, f]))('%s', async (_id, fixture) => {
+    if (!fixture.turns?.length) throw new Error(`Fixture ${fixture.id} missing turns`);
+
+    const { turns } = await runIsaakMultiTurn({
+      turns: fixture.turns,
+      context: fixture.context,
+    });
+
+    for (const assertion of fixture.expected.turnAssertions ?? []) {
+      const idx = assertion.turn - 1;
+      const turn = turns[idx];
+      if (!turn) throw new Error(`Fixture ${fixture.id} missing turn ${assertion.turn}`);
+
+      const lower = turn.assistant.toLowerCase();
+
+      if (assertion.contains?.length) {
+        for (const needle of assertion.contains) {
+          expect(lower).toContain(needle.toLowerCase());
+        }
+      }
+      if (assertion.excludes?.length) {
+        for (const forbidden of assertion.excludes) {
+          expect(lower).not.toContain(forbidden.toLowerCase());
+        }
+      }
+      if (typeof assertion.shouldClarify === 'boolean') {
+        expect(detectClarificationResponse(turn.assistant)).toBe(assertion.shouldClarify);
+      }
+    }
+  });
+});
+
+describe('golden / multi-turn wiring', () => {
+  it('finds multi-turn fixtures', () => {
+    expect(loadFixturesByCategory('multi-turn').length).toBeGreaterThan(0);
+  });
+});

--- a/apps/isaak/tests/intelligence/golden/no-hallucination.test.ts
+++ b/apps/isaak/tests/intelligence/golden/no-hallucination.test.ts
@@ -1,0 +1,45 @@
+// Golden test: no hallucination — verifies Isaak doesn't invent client
+// names, amounts, or fake fiscal facts when grounding is missing.
+//
+// SKIPPED unless ISAAK_GOLDEN_LIVE=1.
+
+import { loadFixturesByCategory } from '../helpers/load-fixtures';
+import { runIsaakSingleTurn } from '../helpers/run-isaak';
+import { isGoldenLiveMode } from '../helpers/llm-judge';
+
+const liveMode = isGoldenLiveMode();
+const describeIf = liveMode ? describe : describe.skip;
+
+describeIf('golden / no-hallucination', () => {
+  const fixtures = loadFixturesByCategory('no-hallucination');
+
+  jest.setTimeout(45_000);
+
+  test.each(fixtures.map((f) => [f.id, f]))('%s', async (_id, fixture) => {
+    if (!fixture.query) throw new Error(`Fixture ${fixture.id} missing query`);
+    const result = await runIsaakSingleTurn({
+      query: fixture.query,
+      context: fixture.context,
+    });
+    const lower = result.text.toLowerCase();
+
+    if (fixture.expected.responseContains?.length) {
+      const matched = fixture.expected.responseContains.filter((needle) =>
+        lower.includes(needle.toLowerCase())
+      );
+      expect(matched.length).toBeGreaterThan(0);
+    }
+
+    if (fixture.expected.responseExcludes?.length) {
+      for (const forbidden of fixture.expected.responseExcludes) {
+        expect(lower).not.toContain(forbidden.toLowerCase());
+      }
+    }
+  });
+});
+
+describe('golden / no-hallucination wiring', () => {
+  it('finds no-hallucination fixtures', () => {
+    expect(loadFixturesByCategory('no-hallucination').length).toBeGreaterThan(0);
+  });
+});

--- a/apps/isaak/tests/intelligence/helpers/llm-judge.ts
+++ b/apps/isaak/tests/intelligence/helpers/llm-judge.ts
@@ -1,0 +1,107 @@
+// LLM-as-judge helper. Uses GPT-4o-mini to score Isaak responses against
+// expected behavior. Used by golden tests in opt-in mode (ISAAK_GOLDEN_LIVE=1).
+//
+// Like run-isaak.ts, this calls the provider directly (no @verifactu/utils
+// import) to keep Jest's module graph small.
+
+export type JudgeInput = {
+  query: string;
+  response: string;
+  expectedBehavior: string;
+};
+
+export type JudgeOutput = {
+  score: number;
+  reasoning: string;
+};
+
+const JUDGE_INSTRUCTIONS = `Eres un evaluador imparcial. Recibes una pregunta, una respuesta del asistente Isaak, y el comportamiento esperado. Devuelves un JSON con score (0-10) y reasoning.
+
+Considera para puntuar:
+- Precisión (no inventa datos)
+- Adecuación al comportamiento esperado
+- Claridad y accionabilidad
+- Si el comportamiento esperado era clarificar (preguntar antes de asumir), responder con JSON {clarify: true, ...} vale 10. Responder con prosa adivinando vale 2.
+
+Devuelve EXCLUSIVAMENTE JSON válido sin markdown ni backticks:
+{"score": <0-10>, "reasoning": "<2-3 frases>"}`;
+
+function getOpenaiKey(): string {
+  const key =
+    process.env.OPENAI_API_KEY ||
+    process.env.ISAAK_NEW_OPENAI_API_KEY ||
+    process.env.OPENAI_API_KEY_DEV;
+  if (!key) {
+    throw new Error('Missing OPENAI_API_KEY for golden judge.');
+  }
+  return key;
+}
+
+export async function judgeResponse(input: JudgeInput): Promise<JudgeOutput> {
+  const prompt = `PREGUNTA DEL USUARIO:
+${input.query}
+
+RESPUESTA DE ISAAK:
+${input.response}
+
+COMPORTAMIENTO ESPERADO:
+${input.expectedBehavior}
+
+Devuelve el JSON con score y reasoning.`;
+
+  const response = await fetch('https://api.openai.com/v1/responses', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${getOpenaiKey()}`,
+    },
+    body: JSON.stringify({
+      model: 'gpt-4o-mini',
+      instructions: JUDGE_INSTRUCTIONS,
+      input: prompt,
+      temperature: 0,
+      max_output_tokens: 200,
+      text: {
+        format: {
+          type: 'json_schema',
+          name: 'judge_output',
+          schema: {
+            type: 'object',
+            additionalProperties: false,
+            required: ['score', 'reasoning'],
+            properties: {
+              score: { type: 'number' },
+              reasoning: { type: 'string' },
+            },
+          },
+        },
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw new Error(`Judge ${response.status}: ${body.slice(0, 200)}`);
+  }
+
+  const data = (await response.json()) as {
+    output_text?: string;
+    output?: Array<{ content?: Array<{ type?: string; text?: string }> }>;
+  };
+  const text =
+    data.output_text ||
+    data.output?.[0]?.content?.find((c) => c.type === 'output_text')?.text ||
+    '';
+
+  try {
+    const parsed = JSON.parse(text) as JudgeOutput;
+    if (typeof parsed.score !== 'number') throw new Error('missing score');
+    return { score: parsed.score, reasoning: parsed.reasoning ?? '' };
+  } catch (err) {
+    throw new Error(`Judge returned invalid JSON: ${text.slice(0, 200)}`);
+  }
+}
+
+export function isGoldenLiveMode(): boolean {
+  return process.env.ISAAK_GOLDEN_LIVE === '1';
+}

--- a/apps/isaak/tests/intelligence/helpers/load-fixtures.ts
+++ b/apps/isaak/tests/intelligence/helpers/load-fixtures.ts
@@ -1,0 +1,23 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { GoldenCategory, GoldenFixture } from './types';
+
+const FIXTURES_DIR = path.join(__dirname, '..', 'fixtures');
+
+export function loadFixturesByCategory(category: GoldenCategory): GoldenFixture[] {
+  const dir = path.join(FIXTURES_DIR, category);
+  if (!fs.existsSync(dir)) return [];
+
+  return fs
+    .readdirSync(dir)
+    .filter((file) => file.endsWith('.json'))
+    .map((file) => {
+      const raw = fs.readFileSync(path.join(dir, file), 'utf8');
+      return JSON.parse(raw) as GoldenFixture;
+    });
+}
+
+export function loadAllFixtures(): GoldenFixture[] {
+  const categories: GoldenCategory[] = ['clarify', 'no-clarify', 'no-hallucination', 'multi-turn'];
+  return categories.flatMap((cat) => loadFixturesByCategory(cat));
+}

--- a/apps/isaak/tests/intelligence/helpers/run-isaak.ts
+++ b/apps/isaak/tests/intelligence/helpers/run-isaak.ts
@@ -1,0 +1,127 @@
+// Drive Isaak against a fixture using the same system prompt as production.
+// Bypasses the HTTP layer and the @verifactu/utils callLLM wrapper to keep
+// the test imports clean — calls the Anthropic API directly.
+
+import {
+  buildAuthenticatedSystemPrompt,
+  buildPublicSystemPrompt,
+  type AuthenticatedChatContext,
+} from '../../../app/lib/isaak-chat-prompts';
+import type { GoldenContext } from './types';
+
+type AIMessage = { role: 'user' | 'assistant'; content: string };
+
+const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages';
+const ANTHROPIC_VERSION = '2023-06-01';
+const DEFAULT_MODEL = 'claude-sonnet-4-6';
+
+const DEFAULT_TEST_CONTEXT: AuthenticatedChatContext = {
+  tenantId: 'test-tenant',
+  userId: 'test-user',
+  preferredName: 'Marta',
+  companyName: 'Acme SL',
+  contextSummary:
+    'Empresa pequeña en alta como SL en régimen general de IVA, ejercicio fiscal natural.',
+  roleLabel: 'autónoma',
+  sectorLabel: 'servicios profesionales',
+  communicationStyle: 'spanish_clear_non_technical',
+  knowledgeLevel: 'starter',
+  goals: ['cumplir IVA trimestral', 'evitar sustos'],
+  holdedConnected: true,
+  workspaceSignalsBlock: 'No hay alertas activas. Próximo plazo: modelo 303 Q2 (20 de julio).',
+};
+
+function buildContextForFixture(context: GoldenContext | undefined): AuthenticatedChatContext {
+  return {
+    ...DEFAULT_TEST_CONTEXT,
+    holdedConnected: context?.holdedConnected ?? DEFAULT_TEST_CONTEXT.holdedConnected,
+  };
+}
+
+function getApiKey(): string {
+  const key =
+    process.env.ANTHROPIC_API_KEY ||
+    process.env.ISAAK_ANTHROPIC_API_KEY ||
+    process.env.ANTHROPIC_API_KEY_DEV;
+  if (!key) {
+    throw new Error(
+      'Missing ANTHROPIC_API_KEY for golden tests. Set ISAAK_GOLDEN_LIVE=1 only with an API key available.'
+    );
+  }
+  return key;
+}
+
+async function callAnthropic(input: {
+  systemPrompt: string;
+  messages: AIMessage[];
+  model?: string;
+}): Promise<{ text: string }> {
+  const response = await fetch(ANTHROPIC_API_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': getApiKey(),
+      'anthropic-version': ANTHROPIC_VERSION,
+    },
+    body: JSON.stringify({
+      model: input.model ?? DEFAULT_MODEL,
+      max_tokens: 600,
+      temperature: 0.45,
+      system: input.systemPrompt,
+      messages: input.messages,
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw new Error(`Anthropic ${response.status}: ${body.slice(0, 200)}`);
+  }
+
+  const data = (await response.json()) as {
+    content?: Array<{ type: string; text?: string }>;
+  };
+  const text = data.content?.find((b) => b.type === 'text')?.text ?? '';
+  return { text };
+}
+
+export type IsaakRunResult = { text: string };
+
+export async function runIsaakSingleTurn(input: {
+  query: string;
+  context?: GoldenContext;
+  history?: AIMessage[];
+}): Promise<IsaakRunResult> {
+  const authenticated = input.context?.authenticated !== false;
+  const ctx = buildContextForFixture(input.context);
+  const systemPrompt = authenticated
+    ? buildAuthenticatedSystemPrompt(ctx)
+    : buildPublicSystemPrompt();
+
+  const messages: AIMessage[] = [
+    ...(input.history ?? []),
+    { role: 'user', content: input.query },
+  ];
+
+  return callAnthropic({ systemPrompt, messages });
+}
+
+export async function runIsaakMultiTurn(input: {
+  turns: Array<{ user: string }>;
+  context?: GoldenContext;
+}): Promise<{ turns: Array<{ user: string; assistant: string }> }> {
+  const history: AIMessage[] = [];
+  const completed: Array<{ user: string; assistant: string }> = [];
+
+  for (const turn of input.turns) {
+    const result = await runIsaakSingleTurn({
+      query: turn.user,
+      context: input.context,
+      history,
+    });
+    completed.push({ user: turn.user, assistant: result.text });
+    history.push({ role: 'user', content: turn.user });
+    history.push({ role: 'assistant', content: result.text });
+  }
+
+  return { turns: completed };
+}

--- a/apps/isaak/tests/intelligence/helpers/types.ts
+++ b/apps/isaak/tests/intelligence/helpers/types.ts
@@ -1,0 +1,39 @@
+export type GoldenCategory = 'clarify' | 'no-clarify' | 'no-hallucination' | 'multi-turn';
+
+export type GoldenTurn = {
+  user: string;
+  assistant?: string;
+};
+
+export type GoldenContext = {
+  authenticated?: boolean;
+  holdedConnected?: boolean;
+  bankConnected?: boolean;
+  noClientWithName?: string;
+};
+
+export type GoldenExpected = {
+  shouldClarify?: boolean;
+  ambiguityType?: 'period' | 'entity' | 'intent' | 'amount';
+  clarificationContains?: string[];
+  responseContains?: string[];
+  responseExcludes?: string[];
+  toolsUsed?: string[];
+  turnAssertions?: {
+    turn: number;
+    contains?: string[];
+    excludes?: string[];
+    shouldClarify?: boolean;
+  }[];
+  minJudgeScore?: number;
+};
+
+export type GoldenFixture = {
+  id: string;
+  category: GoldenCategory;
+  description?: string;
+  query?: string;
+  turns?: GoldenTurn[];
+  context?: GoldenContext;
+  expected: GoldenExpected;
+};

--- a/docs/engineering/ISAAK_INTELLIGENCE.md
+++ b/docs/engineering/ISAAK_INTELLIGENCE.md
@@ -1,0 +1,865 @@
+# Isaak Intelligence — Manifiesto técnico
+
+> Documento maestro de la inteligencia de Isaak. Define visión, arquitectura, roadmap
+> e instrumentación para evolucionar el chat actual hacia un orquestador real con
+> herramientas, memoria, criterio y aprendizaje continuo.
+>
+> Última actualización: 2026-05-24 · Estado: F1 pendiente · Owner: ingeniería Isaak
+
+---
+
+## Índice
+
+**Parte 1 — Ejecutivo**
+1. [Visión y principios](#1-visión-y-principios)
+2. [Estrategia multi-provider](#2-estrategia-multi-provider)
+3. [Pilares de inteligencia](#3-pilares-de-inteligencia)
+4. [Roadmap por fases](#4-roadmap-por-fases)
+5. [Métricas de éxito](#5-métricas-de-éxito)
+6. [Riesgos y mitigaciones](#6-riesgos-y-mitigaciones)
+7. [Modelo de costes](#7-modelo-de-costes)
+8. [Preguntas abiertas](#8-preguntas-abiertas)
+
+**Parte 2 — Apéndice técnico**
+- [A1. Arquitectura del loop](#a1-arquitectura-del-loop)
+- [A2. Esquemas de BD nuevos](#a2-esquemas-de-bd-nuevos)
+- [A3. Snippets de prompts clave](#a3-snippets-de-prompts-clave)
+- [A4. Pseudocódigo del orquestador](#a4-pseudocódigo-del-orquestador)
+- [A5. Metodología de testing](#a5-metodología-de-testing)
+- [A6. Golden set semilla](#a6-golden-set-semilla)
+- [A7. Métricas baseline — cómo medir](#a7-métricas-baseline--cómo-medir)
+
+---
+
+# Parte 1 — Ejecutivo
+
+## 1. Visión y principios
+
+### Qué entendemos por "Isaak inteligente"
+
+Isaak no es un chatbot de Q&A. Es un **orquestador con herramientas, memoria y criterio**
+que actúa como copiloto fiscal/operativo. La diferencia respecto a un GPT genérico:
+
+- Habla con **datos reales del tenant** (Holded, banca, Verifactu) — nada inventado.
+- **Recuerda** la conversación y los hechos del negocio entre sesiones.
+- **Pregunta** cuando la solicitud es ambigua, en lugar de adivinar.
+- Puede **ejecutar acciones** (emitir factura, registrar pago, crear contacto) bajo confirmación.
+- **Aprende** de los pulgares arriba/abajo de cada tenant.
+
+### Los 5 principios rectores
+
+1. **Datos reales, no alucinaciones.** Todo dato fiscal, contable o financiero proviene
+   de una tool call verificable. Si no hay tool → Isaak dice "no tengo acceso a ese dato"
+   en lugar de inventar.
+
+2. **Pregunta antes de asumir.** Ante ambigüedad de período, cliente, importe o intención,
+   Isaak responde primero con una aclaración estructurada (botones/opciones).
+
+3. **Recuerda lo que pasó.** Memoria conversacional (últimos N turnos) + memoria larga
+   (perfil, decisiones, preferencias por tenant) accesible vía RAG.
+
+4. **Multi-modelo por tarea.** Cada modelo hace lo que mejor sabe — Claude orquesta y razona,
+   GPT-4o ve imágenes y garantiza JSON, Haiku clasifica rápido.
+
+5. **Aprende de feedback.** Cada 👍 se convierte en few-shot dinámico; cada 👎 dispara
+   review humana para ajustar prompt o tool.
+
+---
+
+## 2. Estrategia multi-provider
+
+Especialización por tarea — cada modelo donde brilla, sin doblar coste salvo en operaciones críticas.
+
+### Matriz de routing
+
+| Tarea | Modelo | Razón |
+|-------|--------|-------|
+| Orquestador principal + tool-calling | **Claude Sonnet 4.6** | Mejor tool-use estructurado, contexto largo, español nativo, razonamiento multi-paso |
+| Clasificador de intent / ambigüedad | **Claude Haiku 4.5** | Latencia <500ms, coste 1/12 del Sonnet, suficiente para clasificación binaria |
+| OCR de facturas (PDF/imagen → JSON estructurado) | **GPT-4o** | Visión más madura en tablas, sellos, manuscritos |
+| Validación crítica (segundo opinion) antes de escribir en Holded | **GPT-4o-mini** | Cross-check independiente, distinto sesgo que Claude |
+| JSON estricto con schema fijo (clarify responses, action confirmations) | **GPT-4o-mini** con `response_format: json_schema` | Garantía a nivel API, evita parsing frágil |
+| Embeddings semánticos (búsqueda en histórico, RAG) | **text-embedding-3-small** | Coste imbatible, calidad >90% del large |
+| Fallback automático cuando provider primario falla | Espejo (Claude↔GPT) | Resiliencia ante outages |
+
+### Reglas de routing
+
+```
+1. Toda petición arranca por el clasificador (Haiku) → decide ruta
+2. Si la ruta requiere tools → Claude Sonnet con tools
+3. Si requiere visión → GPT-4o
+4. Si requiere acción crítica (POST a Holded, envío email) → Claude ejecuta + GPT-4o-mini valida
+5. Si Claude falla 2 veces → fallback automático a GPT-4o
+6. Si GPT falla 2 veces (modo fallback) → respuesta degradada + alerta interna
+```
+
+### Decisión consciente: NO cross-validation por defecto
+
+Validar cada respuesta en dos modelos dobla el coste sin justificación clara para queries
+informativas. La validación cruzada se reserva a **acciones que escriben datos**
+(crear factura, registrar pago, enviar email a cliente).
+
+---
+
+## 3. Pilares de inteligencia
+
+Las seis capacidades que construimos por fases. Cada pilar es independiente pero se
+refuerza con los demás.
+
+### Pilar 1 — Memoria
+
+- **Corto plazo**: últimos 8 mensajes (4 turnos) inyectados en cada llamada.
+- **Largo plazo**: hechos persistentes del negocio (CIF, plan fiscal, cuentas bancarias
+  vinculadas, preferencias del usuario) en tabla `IsaakLongTermMemory`.
+- **Episódica**: resumen de conversaciones cerradas (>24h sin actividad) en formato compacto,
+  para futuras referencias ("¿qué hablamos del IVA hace 3 semanas?").
+
+### Pilar 2 — Herramientas reales (tool-calling)
+
+Refactor de los **17 tools de Holded + 7 banca + 8 Google + 9 Microsoft + 5 Verifactu**
+de "conocimiento implícito en el prompt" a **tools de Anthropic registrados**. El LLM
+recibe el schema, decide cuándo invocar, y el código ejecuta+devuelve el resultado.
+
+### Pilar 3 — Clarificación
+
+Patrón "clarify-first":
+1. Clasificador (Haiku) detecta ambigüedad → marca con tipo (`period`, `entity`, `intent`, `confirmation`).
+2. Si ambiguo, Isaak responde con JSON estructurado: `{clarify: true, question, options}`.
+3. Frontend renderiza opciones como chips/botones → 1 clic resuelve la ambigüedad.
+4. Si la persona ignora las opciones y reescribe, el clasificador re-evalúa.
+
+### Pilar 4 — Personalización dinámica
+
+Hoy el prompt inyecta `communicationStyle: 'spanish_clear_non_technical'` igual para todos.
+Evolución:
+- **Estilo aprendido**: el `IsaakOnboardingProfile` se actualiza con cada interacción
+  (si la persona usa lenguaje técnico, Isaak sube de `starter` a `intermediate`).
+- **Tono por rol**: financiero recibe respuestas con KPIs y ratios; autónomo recibe
+  acciones simples ("haz esto: …").
+- **Contexto sector**: hostelería recibe ejemplos de su sector, no de logística.
+
+### Pilar 5 — Criterio (judge model)
+
+Antes de ejecutar acciones críticas, un segundo modelo valida:
+- "¿La factura que va a crear coincide con lo que pidió el usuario?"
+- "¿El importe es coherente con el histórico?"
+- "¿El cliente existe?"
+
+Si el judge discrepa → Isaak no ejecuta y pide confirmación explícita.
+
+### Pilar 6 — Aprendizaje continuo
+
+- **Feedback explícito** (👍/👎) ya capturado en tabla `IsaakFeedback`. Vamos a usarla.
+- **Few-shot dinámico**: los 5 mejores 👍 del tenant se inyectan como ejemplos en
+  el system prompt para preguntas similares (matching por embedding).
+- **Eval semanal**: el equipo revisa los 👎 → ajusta prompts/tools.
+- **Drift detection**: si la tasa de 👍 cae >10% semana a semana, alerta automática.
+
+---
+
+## 4. Roadmap por fases
+
+Cada fase tiene **criterios de salida** medibles y **tests obligatorios** antes de mergear.
+
+| Fase | Nombre | Foco | Duración estimada | Modelos involucrados |
+|------|--------|------|---------------------|----------------------|
+| **F1** | Foundation | Memoria + clarify + baseline + golden set | 1 sesión | Claude Sonnet |
+| **F2** | Tool-calling read | Tools Holded read + banca read registrados | 1-2 sesiones | Claude Sonnet |
+| **F3** | Multi-provider router | Haiku classifier + Sonnet main + fallback GPT | 1 sesión | Claude Haiku/Sonnet + GPT-4o |
+| **F4** | Vision + judge | OCR GPT-4o + validación GPT-mini en writes | 2 sesiones | GPT-4o + GPT-4o-mini |
+| **F5** | Streaming UX | SSE token-by-token + tool indicators en UI | 1 sesión | Claude Sonnet stream |
+| **F6** | Long-term memory | Embeddings + RAG por tenant | 2 sesiones | text-embedding-3-small + Claude |
+| **F7** | Feedback loop | Few-shot dinámico desde 👍 | 1 sesión | Embeddings + Claude |
+| **F8** | Sub-agentes | Agentes especializados (fiscal, banca, gestión) | 3 sesiones | Claude (orquestador) + agentes |
+
+### Criterios de salida por fase (resumen)
+
+| Fase | Criterio principal | Test que debe pasar |
+|------|--------------------|----------------------|
+| F1 | Isaak no se repite ni se contradice en 4 turnos | `golden/multi-turn.test.ts` ≥85% |
+| F2 | 0 alucinaciones de números/datos en 50 queries | `golden/no-hallucination.test.ts` 100% |
+| F3 | Latencia P50 baja a <2s; coste/msg baja 30% | métricas `isaak_metrics` panel |
+| F4 | OCR procesa 20 facturas reales con >95% accuracy | `golden/ocr.test.ts` ≥95% |
+| F5 | Tiempo hasta primer token <800ms | métricas streaming |
+| F6 | Isaak recupera contexto de hace >30 días con relevancia >0.8 | `golden/memory-long.test.ts` |
+| F7 | Tasa 👍 sube ≥10% en tenants con >50 mensajes | métricas semanales |
+| F8 | Sub-agente fiscal supera Sonnet plano en queries fiscales complejas | `golden/fiscal-deep.test.ts` |
+
+---
+
+## 5. Métricas de éxito
+
+KPIs continuos. Panel en `/admin/isaak-intelligence` (a construir en F1).
+
+| Métrica | Cómo se mide | Hoy (baseline a establecer) | Meta F2 | Meta F8 |
+|---------|--------------|------------------------------|---------|---------|
+| **Tasa de alucinación** | % respuestas con números/nombres no presentes en tool results | ~30% (estimado) | <10% | <2% |
+| **Clarify-rate apropiado** | (clarificaciones disparadas correctamente) / (queries ambiguas) — auditoría manual semanal de 50 muestras | 0% | >70% | >90% |
+| **Coherencia multi-turno** | % conversaciones sin contradicciones en eval LLM-as-judge | ~50% | >85% | >95% |
+| **Latencia P50 (texto)** | tiempo total response | ~3s | <2s | <1.5s |
+| **Tiempo hasta primer token** | sólo con streaming activo | N/A | <800ms | <500ms |
+| **Coste por mensaje (€)** | suma tokens × precio provider | ~€0.012 | ~€0.008 | ~€0.005 |
+| **Ratio 👍** | thumbs-up / (thumbs-up + thumbs-down) | desconocido | >60% | >80% |
+| **Tool-call success rate** | tool_use sin errores / total tool_use | N/A (no hay tools) | >95% | >98% |
+
+---
+
+## 6. Riesgos y mitigaciones
+
+| Riesgo | Severidad | Mitigación |
+|--------|-----------|------------|
+| Loop infinito de tool-calling | Alta | Hard cap 10 iteraciones, timeout 30s, alerta a Sentry |
+| Claude/GPT discrepan en validación crítica | Media | Si validator dice NO → bloqueo, pregunta explícita al usuario |
+| Costes se disparan con multi-provider | Media | Cache resultados tool 5 min, cache embeddings 24h, Haiku para clasificación barata |
+| Streaming complica error handling | Baja | Usar Vercel AI SDK (probado), fallback a JSON si stream falla |
+| Memoria larga filtra datos entre tenants | **Crítica** | Índice vectorial particionado por `tenantId`, tests de aislamiento en CI |
+| Prompts cambian y baja la calidad | Media | Versionado de prompts + regression contra golden set en cada PR |
+| Tool ejecuta acción no deseada (false positive de intent) | Alta | Todo write requiere `confirmed: true` explícito, judge model valida, UI confirma |
+| Provider outage prolongado | Media | Fallback automático Claude↔GPT, status page externo, alerta SLA |
+
+---
+
+## 7. Modelo de costes
+
+Estimación de coste mensual por escala de uso. Asumiendo precios actuales (2026-05):
+- Claude Sonnet 4.6: $3/MTok in, $15/MTok out
+- Claude Haiku 4.5: $0.25/MTok in, $1.25/MTok out
+- GPT-4o: $2.50/MTok in, $10/MTok out
+- GPT-4o-mini: $0.15/MTok in, $0.60/MTok out
+- text-embedding-3-small: $0.020/MTok
+
+### Escenarios por mensaje
+
+| Tipo de query | Tokens in/out típicos | Modelos invocados | Coste/msg |
+|---------------|------------------------|-------------------|-----------|
+| Saludo simple | 200/100 | Haiku classifier + Sonnet | €0.0008 |
+| Q&A fiscal sin tools | 800/300 | Haiku + Sonnet | €0.0048 |
+| Q&A con 1 tool call | 1500/400 | Haiku + Sonnet (2 turns) | €0.012 |
+| Q&A con 3 tool calls | 3000/600 | Haiku + Sonnet (4 turns) | €0.028 |
+| Acción crítica (write Holded) | 2000/500 + 1500/200 validator | Haiku + Sonnet + GPT-mini | €0.020 |
+| OCR factura | 50/800 (vision) + 1000/300 | GPT-4o + Sonnet | €0.012 |
+
+### Proyección mensual
+
+| Volumen | Mix típico | Coste estimado/mes |
+|---------|-----------|---------------------|
+| 1k mensajes | 60% Q&A + 30% tool + 10% crítica | ~€15 |
+| 10k mensajes | mismo mix | ~€150 |
+| 100k mensajes | mismo mix | ~€1,500 |
+
+### Optimizaciones planificadas
+
+- **Cache de tool results 5 min** → ahorro estimado 30% en queries repetidas (consultas a Holded misma sesión)
+- **Cache de embeddings 24h** → ahorro 80% en RAG (mismo perfil de tenant)
+- **Haiku para clasificación previa** → reduce llamadas Sonnet a la mitad
+- **Plan-tiered model selection** → Free/Starter siempre Haiku, Pro+ Sonnet (ya implementado parcialmente)
+
+---
+
+## 8. Preguntas abiertas
+
+Decisiones que necesitan input antes de implementación:
+
+1. **Embeddings storage**: Postgres con `pgvector` (en infraestructura existente) o
+   servicio externo (Pinecone, Turbopuffer, Qdrant)?
+   - Recomendación: empezar con pgvector (cero infra nueva), migrar si latencia o escala lo justifica.
+
+2. **Retención de memoria larga**: ¿meses o tokens?
+   - Propuesta: retener 90 días para Free/Starter, 365 días para Pro+, ilimitado para Business+.
+
+3. **OCR routing**: ¿GPT-4o directo o pasar por Mistral/Gemini para bajar coste?
+   - Propuesta: empezar con GPT-4o (calidad probada), evaluar alternativas en F4 si coste molesta.
+
+4. **Sub-agentes (F8)**: ¿en proceso (latencia OK) o background jobs (mejor para tareas largas)?
+   - Propuesta: in-proceso para queries sincronas; background jobs solo para tareas >30s (auditorías masivas).
+
+5. **Versionado de prompts**: ¿en BD para hot-swap o en código (Git)?
+   - Propuesta: prompts en código (Git, revisable en PR), variantes A/B vía feature flag de tenant.
+
+6. **Exposición del clarify a tools del chat**: ¿el LLM puede pedir aclaración aún DENTRO de un tool-calling loop, o solo al inicio?
+   - Propuesta: solo al inicio en F1-F3; permitir mid-loop a partir de F4 si vemos casos reales.
+
+---
+
+---
+
+# Parte 2 — Apéndice técnico
+
+## A1. Arquitectura del loop
+
+### Diagrama de flujo (texto)
+
+```
+[Usuario] → POST /api/chat { message, conversationId? }
+              │
+              ▼
+[1. Auth + plan check]
+              │
+              ▼
+[2. Cargar historial corto (últimos 8 msgs)]
+              │
+              ▼
+[3. Classifier (Haiku)] ──→ ¿ambigüedad?
+              │             ├─ SÍ → respond { clarify, question, options }
+              │             │          └─ devolver al frontend (sin llamar al main LLM)
+              │             └─ NO ↓
+              │
+              ▼
+[4. Cargar memoria larga relevante (RAG si F6 activo)]
+              │
+              ▼
+[5. Construir prompt: persona + ctx tenant + ctx conversación + few-shots]
+              │
+              ▼
+[6. Main LLM (Claude Sonnet) con tools]
+              │
+       ┌──────┴───────┐
+       │              │
+       ▼              ▼
+[respuesta texto]   [tool_use blocks]
+       │              │
+       │              ▼
+       │       [Ejecutar tools en paralelo, max 5 concurrent]
+       │              │
+       │              ▼
+       │       [Inyectar tool_result en messages]
+       │              │
+       │              ▼
+       │       [Volver a paso 6 — max 10 iteraciones]
+       │
+       ▼
+[7. ¿Acción crítica? → Judge (GPT-4o-mini) valida]
+              │
+              ▼
+[8. Stream respuesta al frontend (SSE)]
+              │
+              ▼
+[9. Persistir mensaje + tool calls + tokens + latencia]
+              │
+              ▼
+[10. (Async) Si feedback 👎 → registrar para review]
+```
+
+### Componentes y responsabilidades
+
+| Componente | Archivo (a crear/modificar) | Responsabilidad |
+|------------|------------------------------|------------------|
+| Endpoint chat | `apps/isaak/app/api/chat/route.ts` (refactor) | Orquesta todo el flujo |
+| Classifier | `apps/isaak/app/lib/isaak-intent-classifier.ts` (nuevo) | Detecta ambigüedad con Haiku |
+| Tools registry | `apps/isaak/app/lib/isaak-tools-registry.ts` (nuevo) | Unifica los tools de Holded/banca/Google/etc. en formato Anthropic |
+| Tool executor | `apps/isaak/app/lib/isaak-tool-executor.ts` (nuevo) | Ejecuta tool calls con timeout, cache, errores |
+| Judge | `apps/isaak/app/lib/isaak-judge.ts` (nuevo) | Valida acciones críticas con GPT-mini |
+| Memory short | `apps/isaak/app/lib/isaak-memory-short.ts` (nuevo) | Carga últimos N mensajes |
+| Memory long (RAG) | `apps/isaak/app/lib/isaak-memory-long.ts` (F6) | Embeddings + similarity search |
+| Metrics | `apps/isaak/app/lib/isaak-metrics.ts` (nuevo) | Captura tokens, latencia, costes |
+
+---
+
+## A2. Esquemas de BD nuevos
+
+### Tabla `IsaakChatMetric` (F1)
+
+Registro de cada mensaje para métricas y análisis.
+
+```prisma
+model IsaakChatMetric {
+  id              String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  tenantId        String?  @map("tenant_id") @db.Uuid
+  userId          String?  @map("user_id")
+  conversationId  String?  @map("conversation_id") @db.Uuid
+
+  modelUsed       String   @map("model_used")        // "claude-sonnet-4-6", "gpt-4o-mini", etc.
+  inputTokens     Int      @map("input_tokens")
+  outputTokens    Int      @map("output_tokens")
+  estimatedCostEur Decimal @map("estimated_cost_eur") @db.Decimal(10, 6)
+
+  latencyMs       Int      @map("latency_ms")
+  firstTokenMs    Int?     @map("first_token_ms")    // sólo con streaming
+
+  toolCallsCount  Int      @default(0) @map("tool_calls_count")
+  toolNames       String[] @default([]) @map("tool_names")
+
+  isClarification Boolean  @default(false) @map("is_clarification")
+  isFallback      Boolean  @default(false) @map("is_fallback")
+  errorCode       String?  @map("error_code")
+
+  createdAt       DateTime @default(now()) @map("created_at") @db.Timestamptz
+
+  @@index([tenantId, createdAt])
+  @@index([conversationId])
+  @@map("isaak_chat_metrics")
+}
+```
+
+### Tabla `IsaakLongTermMemory` (F6)
+
+Hechos persistentes del tenant.
+
+```prisma
+model IsaakLongTermMemory {
+  id          String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  tenantId    String   @map("tenant_id") @db.Uuid
+  fact        String                                              // texto natural
+  factType    String   @map("fact_type")                          // "preference", "history", "decision", "profile"
+  embedding   Unsupported("vector(1536)")?                        // pgvector
+  source      String                                              // "user", "tool_result", "feedback"
+  sourceMsgId String?  @map("source_msg_id")
+  confidence  Float    @default(1.0)
+  expiresAt   DateTime? @map("expires_at") @db.Timestamptz        // según plan del tenant
+  createdAt   DateTime @default(now()) @map("created_at") @db.Timestamptz
+
+  @@index([tenantId])
+  @@index([tenantId, factType])
+  @@map("isaak_long_term_memory")
+}
+```
+
+### Extensión a `IsaakFeedback` (F7)
+
+Añadir campo para indexar embeddings de queries con 👍 alto.
+
+```prisma
+model IsaakFeedback {
+  // ... campos existentes ...
+  queryEmbedding   Unsupported("vector(1536)")? @map("query_embedding")
+  fewShotEligible  Boolean @default(false) @map("few_shot_eligible")  // true si 👍 + query no sensible
+}
+```
+
+---
+
+## A3. Snippets de prompts clave
+
+### A3.1 — System prompt base (refactor en F1)
+
+```typescript
+// apps/isaak/app/lib/isaak-prompts.ts
+export function buildSystemPrompt(ctx: IsaakContext): string {
+  return `Eres Isaak, copiloto fiscal e IA de empresa (${ctx.companyName ?? 'sin empresa'}).
+
+CONTEXTO DEL TENANT
+- Persona: ${ctx.userFirstName} · Rol: ${ctx.roleLabel} · Sector: ${ctx.sectorLabel}
+- Plan: ${ctx.planCode}
+- Holded: ${ctx.holdedConnected ? 'conectado' : 'no conectado'}
+- Banca: ${ctx.bankConnected ? `${ctx.bankCount} cuenta(s) PSD2` : 'no conectada'}
+- Verifactu (AEAT): ${ctx.verifactuActive ? 'activo' : 'pendiente'}
+- Fecha actual: ${ctx.today}
+
+PRINCIPIOS DE RESPUESTA
+1. **Datos reales**: NUNCA inventes números, nombres de cliente, importes o fechas.
+   Si necesitas un dato concreto, invoca el tool correspondiente.
+   Si no hay tool disponible para ese dato, dilo: "No tengo ese dato accesible".
+
+2. **Pregunta antes de asumir**: si la pregunta es ambigua, responde EXCLUSIVAMENTE con
+   este JSON (sin texto adicional, sin markdown):
+   {"clarify": true, "question": "...", "options": ["A", "B", "C"]}
+
+   Ejemplos que requieren clarificación:
+   - "¿cómo van las ventas?" → falta período
+   - "factura a Acme" → falta importe / concepto
+   - "el IVA" → falta trimestre / año
+   - "el cliente más importante" → falta criterio (€, recurrencia, volumen)
+
+3. **Memoria**: usa los mensajes anteriores. Si ya preguntaste algo, no lo repitas.
+   Si la persona ya te dio un dato, recuérdalo.
+
+4. **Tono**: ${ctx.communicationStyle}. Nivel: ${ctx.knowledgeLevel}.
+   ${ctx.knowledgeLevel === 'starter' ? 'Evita tecnicismos, da pasos accionables.' : 'Puedes usar términos contables/fiscales precisos.'}
+
+5. **Acciones**: para operaciones que escriben datos (crear factura, registrar pago,
+   enviar email), siempre pide confirmación explícita con resumen ANTES de ejecutar.
+
+CONTEXTO RECIENTE DEL NEGOCIO
+${ctx.businessSummary}
+
+OBJETIVO ÚLTIMO
+Ayudar a ${ctx.userFirstName} a cumplir sus obligaciones fiscales sin estrés y
+optimizar su operativa diaria. Cada respuesta debe ser útil, accionable y honesta.`;
+}
+```
+
+### A3.2 — Classifier prompt (Haiku, F1)
+
+```typescript
+export const CLASSIFIER_PROMPT = `Analiza el mensaje del usuario y determina si necesita aclaración
+ANTES de responder. Considera el contexto del negocio.
+
+Devuelve EXCLUSIVAMENTE JSON con este schema:
+{
+  "ambiguous": true|false,
+  "ambiguityType": "period"|"entity"|"intent"|"amount"|"none",
+  "suggestedClarification": "..."|null,
+  "suggestedOptions": ["..."]|null
+}
+
+Reglas:
+- "ventas de ayer" → no ambiguo (período claro)
+- "ventas" → ambiguo (period: este mes/trimestre/año)
+- "factura al cliente" → ambiguo (entity: ¿cuál cliente?)
+- "el modelo 303" → ambiguo (period: ¿qué trimestre?)
+- "hola" → no ambiguo (saludo)
+- "ayúdame con esto" → ambiguo (intent: ¿qué necesitas?)
+
+Mensaje del usuario: """${userMessage}"""`;
+```
+
+### A3.3 — Judge prompt (GPT-4o-mini, F4)
+
+```typescript
+export const JUDGE_PROMPT = `Eres el validador. Otro LLM va a ejecutar la siguiente acción.
+Tu única tarea: decidir si la acción coincide con lo que el usuario pidió.
+
+Devuelve JSON:
+{ "valid": true|false, "reasoning": "...", "blockers": ["..."] }
+
+ACCIÓN PROPUESTA:
+${JSON.stringify(action, null, 2)}
+
+CONVERSACIÓN PREVIA (últimos 4 turnos):
+${formatHistory(history)}
+
+Reglas:
+- Si la acción es coherente con el último mensaje del usuario → valid: true
+- Si hay discrepancia de importe, cliente, fecha → valid: false
+- Si la acción crea algo en blanco (importe 0, sin destinatario) → valid: false
+- Sé conservador. Mejor bloquear y preguntar que ejecutar mal.`;
+```
+
+---
+
+## A4. Pseudocódigo del orquestador
+
+### F1 (memoria + clarify, single provider)
+
+```typescript
+// apps/isaak/app/api/chat/route.ts (refactor)
+export async function POST(req: NextRequest) {
+  const session = await getHoldedSession();
+  const { message, conversationId } = await req.json();
+
+  // 1. Cargar contexto + historial
+  const ctx = await loadIsaakBusinessContext(session.tenantId);
+  const history = await loadShortMemory(conversationId, limit: 8);
+
+  // 2. Classifier rápido (Haiku) — F3 onwards. En F1 puede ser regex.
+  const classification = await classifyIntent(message, history, ctx);
+
+  if (classification.ambiguous) {
+    const clarifyResponse = {
+      clarify: true,
+      question: classification.suggestedClarification,
+      options: classification.suggestedOptions,
+    };
+    await persistMessage(conversationId, 'assistant', JSON.stringify(clarifyResponse), {
+      isClarification: true,
+    });
+    return NextResponse.json({ response: clarifyResponse, isClarification: true });
+  }
+
+  // 3. Main LLM call
+  const startTime = Date.now();
+  const result = await callClaude({
+    model: 'claude-sonnet-4-6',
+    system: buildSystemPrompt(ctx),
+    messages: [
+      ...history,
+      { role: 'user', content: message }
+    ],
+    max_tokens: 1500,
+  });
+  const latency = Date.now() - startTime;
+
+  // 4. Persistir + métricas
+  await persistMessage(conversationId, 'user', message);
+  await persistMessage(conversationId, 'assistant', result.text);
+  await recordMetric({
+    tenantId: session.tenantId,
+    conversationId,
+    modelUsed: 'claude-sonnet-4-6',
+    inputTokens: result.usage.input_tokens,
+    outputTokens: result.usage.output_tokens,
+    latencyMs: latency,
+  });
+
+  return NextResponse.json({ response: result.text });
+}
+```
+
+### F2 (añadir tool-calling)
+
+```typescript
+// Loop de tool-use
+let messages = [...history, { role: 'user', content: message }];
+let response;
+let iterations = 0;
+
+while (iterations < 10) {
+  response = await callClaude({
+    model: 'claude-sonnet-4-6',
+    system: buildSystemPrompt(ctx),
+    messages,
+    tools: ISAAK_TOOLS_REGISTRY,    // unificación de todos los tools
+    max_tokens: 2000,
+  });
+
+  if (response.stop_reason !== 'tool_use') break;
+
+  const toolUses = response.content.filter(c => c.type === 'tool_use');
+  const toolResults = await Promise.all(
+    toolUses.map(tu => executeIsaakTool(tu.name, tu.input, { tenantId, userId }))
+  );
+
+  messages.push({ role: 'assistant', content: response.content });
+  messages.push({
+    role: 'user',
+    content: toolResults.map((r, i) => ({
+      type: 'tool_result',
+      tool_use_id: toolUses[i].id,
+      content: JSON.stringify(r),
+      is_error: r.error !== undefined,
+    })),
+  });
+
+  iterations++;
+}
+```
+
+---
+
+## A5. Metodología de testing
+
+### Capas de testing
+
+1. **Unit tests** (Vitest):
+   - Cada tool individual con mocks
+   - Builders de prompt (snapshot tests)
+   - Parsers de respuesta LLM
+
+2. **Integration tests** (Vitest + real Anthropic/OpenAI APIs en CI):
+   - Loop completo de chat con tenant mock
+   - Tool-calling end-to-end con Holded sandbox
+   - Clarify-first con queries ambiguas reales
+
+3. **Golden set regression** (Vitest + LLM-as-judge):
+   - 50-100 queries reales con `expected.behavior` y `expected.tools_used`
+   - Corre en cada PR
+   - Gate de mergeo si baja >5% el score promedio
+
+4. **A/B testing por tenant** (feature flag):
+   - `ISAAK_INTELLIGENCE_VERSION=v1|v2` en `Tenant.featureFlags`
+   - Métricas comparadas en `/admin/isaak-intelligence`
+
+### Estructura del repo de tests
+
+```
+apps/isaak/tests/
+  intelligence/
+    golden/
+      multi-turn.test.ts        # F1: coherencia entre turnos
+      no-hallucination.test.ts  # F2: 0 datos inventados
+      clarify.test.ts           # F1: clarifications apropiadas
+      ocr.test.ts               # F4: precisión OCR
+      memory-long.test.ts       # F6: recall a largo plazo
+      fiscal-deep.test.ts       # F8: profundidad fiscal
+    fixtures/
+      tenants/                  # tenants sintéticos con datos realistas
+      messages/                 # corpus de queries
+      expected/                 # comportamientos esperados
+    helpers/
+      llm-judge.ts              # función que llama GPT-4o como juez
+      tenant-factory.ts         # crea tenants de prueba
+```
+
+### Eval con LLM-as-judge
+
+```typescript
+// tests/intelligence/helpers/llm-judge.ts
+export async function judgeResponse(input: {
+  query: string;
+  response: string;
+  expectedBehavior: string;
+  context: IsaakContext;
+}): Promise<{ score: number; reasoning: string }> {
+  const result = await openai.chat.completions.create({
+    model: 'gpt-4o',
+    messages: [{
+      role: 'user',
+      content: `Evalúa esta respuesta de Isaak en escala 0-10.
+
+QUERY: ${input.query}
+RESPUESTA: ${input.response}
+COMPORTAMIENTO ESPERADO: ${input.expectedBehavior}
+
+Considera: precisión, claridad, accionabilidad, ausencia de alucinaciones.
+Responde JSON: { "score": <0-10>, "reasoning": "..." }`,
+    }],
+    response_format: { type: 'json_object' },
+  });
+  return JSON.parse(result.choices[0].message.content);
+}
+```
+
+---
+
+## A6. Golden set semilla
+
+Cada item es un fichero JSON en `tests/intelligence/fixtures/messages/`.
+Mínimo 30 ítems para arrancar F1.
+
+### Ejemplo 1: ambigüedad de período
+
+```json
+{
+  "id": "ambig-period-sales-001",
+  "category": "clarify",
+  "query": "¿Cómo van las ventas?",
+  "context": { "holdedConnected": true, "bankConnected": false },
+  "expected": {
+    "shouldClarify": true,
+    "ambiguityType": "period",
+    "clarificationContains": ["período", "mes", "trimestre"]
+  }
+}
+```
+
+### Ejemplo 2: query precisa, no debe clarificar
+
+```json
+{
+  "id": "precise-iva-q1-002",
+  "category": "no-clarify",
+  "query": "Calcula el IVA repercutido del primer trimestre de 2026",
+  "context": { "holdedConnected": true },
+  "expected": {
+    "shouldClarify": false,
+    "toolsUsed": ["holded_list_invoices"],
+    "responseContains": ["IVA", "trimestre", "€"]
+  }
+}
+```
+
+### Ejemplo 3: no alucinación
+
+```json
+{
+  "id": "no-halluc-client-003",
+  "category": "no-hallucination",
+  "query": "¿Cuánto me debe el cliente 'Acme SL'?",
+  "context": { "holdedConnected": true, "noClientWithName": "Acme SL" },
+  "expected": {
+    "shouldClarify": false,
+    "toolsUsed": ["holded_search_contact"],
+    "responseContains": ["no encontré", "no hay cliente"],
+    "responseExcludes": ["Acme SL le debe", "tiene una deuda"]
+  }
+}
+```
+
+### Ejemplo 4: coherencia multi-turno
+
+```json
+{
+  "id": "multi-turn-context-004",
+  "category": "multi-turn",
+  "turns": [
+    { "user": "¿Cómo van las ventas?" },
+    { "user": "Este mes" },
+    { "user": "¿Y los gastos?" }
+  ],
+  "expected": {
+    "turn3PeriodInferred": "este mes",
+    "turn3ShouldNotReAsk": ["período", "trimestre"]
+  }
+}
+```
+
+---
+
+## A7. Métricas baseline — cómo medir
+
+Antes de cambiar nada en F1, instrumentar para tener "antes" comparable.
+
+### Setup mínimo (F1.0 — primer commit)
+
+1. **Instrumentación tokens + latencia**:
+   - Wrappear `callLLM` actual con timing y captura de `usage`.
+   - Persistir en nueva tabla `IsaakChatMetric` (ver A2).
+
+2. **Eval de alucinación retroactivo**:
+   - Tomar últimos 200 mensajes con respuestas de Isaak en producción.
+   - Pasar por GPT-4o como juez con prompt: "¿Esta respuesta contiene datos numéricos o nombres de cliente que no aparecen en ningún contexto previo?"
+   - Calcular % → ese es el baseline de alucinación.
+
+3. **Eval de ambigüedad ignorada**:
+   - Mismo set de 200 mensajes.
+   - Juez: "¿La pregunta del usuario era ambigua? ¿Isaak la respondió sin pedir aclaración?"
+   - Calcular % → baseline de "missed clarifications".
+
+4. **Panel de métricas** (`/admin/isaak-intelligence`):
+   - Tabla con últimos 7d / 30d / 90d
+   - Gráficos: tokens, coste, latencia, ratio 👍, alucinación, clarify-rate
+   - Comparativa por tenant
+   - Comparativa por versión de prompt (cuando hagamos A/B)
+
+### SQL queries clave para el panel
+
+```sql
+-- Coste mensual por tenant
+SELECT tenant_id, DATE_TRUNC('month', created_at) AS month,
+       SUM(estimated_cost_eur) AS cost_eur,
+       COUNT(*) AS messages,
+       AVG(latency_ms) AS avg_latency_ms
+FROM isaak_chat_metrics
+WHERE created_at >= NOW() - INTERVAL '90 days'
+GROUP BY tenant_id, month
+ORDER BY cost_eur DESC;
+
+-- Ratio de clarificaciones disparadas
+SELECT DATE_TRUNC('day', created_at) AS day,
+       COUNT(*) FILTER (WHERE is_clarification) * 100.0 / COUNT(*) AS clarify_rate_pct
+FROM isaak_chat_metrics
+WHERE created_at >= NOW() - INTERVAL '30 days'
+GROUP BY day
+ORDER BY day;
+
+-- Tools más usados
+SELECT UNNEST(tool_names) AS tool_name, COUNT(*) AS calls
+FROM isaak_chat_metrics
+WHERE created_at >= NOW() - INTERVAL '7 days'
+  AND ARRAY_LENGTH(tool_names, 1) > 0
+GROUP BY tool_name
+ORDER BY calls DESC;
+```
+
+---
+
+## Anexos finales
+
+### Glosario
+
+- **F1, F2, …**: fases del roadmap (Foundation, Tool-calling, etc.)
+- **Golden set**: corpus de queries de prueba con comportamiento esperado.
+- **LLM-as-judge**: usar un modelo como evaluador objetivo de respuestas de otro.
+- **Tool-use**: feature de Claude/GPT para que el modelo invoque funciones registradas.
+- **RAG**: Retrieval-Augmented Generation — inyectar contexto recuperado por similitud.
+- **Few-shot**: incluir ejemplos previos en el prompt para guiar la respuesta.
+- **Judge**: modelo secundario que valida decisiones del modelo principal.
+
+### Referencias internas
+
+- `docs/engineering/ISAAK_MASTER_PLAN.md` — roadmap de producto/ingeniería general.
+- `apps/isaak/app/api/chat/route.ts` — endpoint actual a refactorizar.
+- `apps/isaak/app/lib/holded-tools.ts` — definiciones de tools de Holded existentes (17).
+- `apps/isaak/app/lib/banking-tools.ts` — definiciones de tools de banca (7).
+- `apps/isaak/app/lib/isaak-business-context.ts` — loader de contexto del tenant.
+- `packages/db/prisma/schema.prisma` — modelos `IsaakConversation`, `IsaakMessage`, `IsaakFeedback`.
+
+### Historial de cambios
+
+| Fecha | Cambio | Autor |
+|-------|--------|-------|
+| 2026-05-24 | Creación inicial del documento | Ingeniería Isaak |
+
+---
+
+*Documento vivo. Actualizar al cerrar cada fase con resultados reales (métricas, lecciones aprendidas) y revisar las "preguntas abiertas" al menos cada mes.*

--- a/packages/db/prisma/migrations/20260524000000_isaak_chat_metrics/migration.sql
+++ b/packages/db/prisma/migrations/20260524000000_isaak_chat_metrics/migration.sql
@@ -1,0 +1,43 @@
+-- F1 Foundation: per-message metrics for Isaak chat
+-- Captures tokens, latency, cost, and intelligence signals (clarification, fallback, history depth).
+-- Baseline instrument before changing prompts/loop behaviour.
+
+CREATE TABLE "isaak_chat_metrics" (
+  "id"                  UUID NOT NULL DEFAULT gen_random_uuid(),
+  "tenant_id"           UUID,
+  "user_id"             TEXT,
+  "conversation_id"     UUID,
+  "message_id"          UUID,
+
+  "provider"            TEXT NOT NULL,
+  "model_used"          TEXT NOT NULL,
+  "feature"             TEXT,
+
+  "input_tokens"        INTEGER NOT NULL DEFAULT 0,
+  "output_tokens"       INTEGER NOT NULL DEFAULT 0,
+  "estimated_cost_eur"  DECIMAL(12, 8) NOT NULL DEFAULT 0,
+
+  "latency_ms"          INTEGER NOT NULL DEFAULT 0,
+  "first_token_ms"      INTEGER,
+
+  "tool_calls_count"    INTEGER NOT NULL DEFAULT 0,
+  "tool_names"          TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+
+  "is_clarification"    BOOLEAN NOT NULL DEFAULT FALSE,
+  "is_fallback"         BOOLEAN NOT NULL DEFAULT FALSE,
+  "history_turns"       INTEGER NOT NULL DEFAULT 0,
+
+  "error_code"          TEXT,
+  "created_at"          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT "isaak_chat_metrics_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "isaak_chat_metrics_tenant_created_idx"
+  ON "isaak_chat_metrics" ("tenant_id", "created_at");
+
+CREATE INDEX "isaak_chat_metrics_conversation_created_idx"
+  ON "isaak_chat_metrics" ("conversation_id", "created_at");
+
+CREATE INDEX "isaak_chat_metrics_model_created_idx"
+  ON "isaak_chat_metrics" ("model_used", "created_at");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -540,69 +540,69 @@ model Tenant {
 
   whitelabelConfig Json? @map("whitelabel_config")
 
-  users                       Membership[]
-  userPref                    UserPreference[]
-  tenantSubscriptions         TenantSubscription[]
-  profile                     TenantProfile?
-  invoices                    Invoice[]
-  quotes                      Quote[]
-  invoiceLines                InvoiceLine[]
-  payments                    Payment[]
-  customers                   Customer[]
-  suppliers                   Supplier[]
-  articles                    Article[]
-  expenses                    ExpenseRecord[]
-  integrations                TenantIntegration[]
-  externalConnections         ExternalConnection[]
-  channelIdentities           ChannelIdentity[]
-  integrationMaps             IntegrationMap[]
-  syncConflicts               SyncConflict[]
-  syncOutboxItems             SyncOutbox[]
-  syncLogs                    SyncLog[]
-  externalConnectionAuditLogs ExternalConnectionAuditLog[]
-  externalSyncRuns            ExternalSyncRun[]
-  isaakConversations          IsaakConversation[]
-  isaakGoogleTokens           IsaakGoogleToken[]
-  isaakMicrosoftTokens        IsaakMicrosoftToken[]
-  isaakAlerts                 IsaakAlert[]
-  isaakGmailScans             IsaakGmailScan[]
-  isaakPushSubscriptions      IsaakPushSubscription[]
-  isaakPushPreferences        IsaakPushPreferences[]
-  isaakMemoryFacts            IsaakMemoryFact[]
-  isaakOnboardingProfiles     IsaakOnboardingProfile[]
-  usageEvents                 UsageEvent[]
-  demoOnboardings             UserOnboarding[]
-  supportSessions             SupportSession[]
-  orders                      Order[]
-  orderLines                  OrderLine[]
-  fulfillmentCases            FulfillmentCase[]
-  fulfillmentTasks            FulfillmentTask[]
-  supportTickets              SupportTicket[]
-  supportMessages             SupportMessage[]
-  whatsappThreads             WhatsAppThread[]
-  whatsappEvents              WhatsAppEvent[]
-  customIntegrationRequests   CustomIntegrationRequest[]
-  connectionRecipients        ConnectionRecipient[]
-  accessRequests              AccessRequest[]
-  claimCases                  ClaimCase[]
-  isaakPlatformKeys           IsaakPlatformKey[]
-  isaakApiAuditLogs           IsaakApiAuditLog[]
+  users                         Membership[]
+  userPref                      UserPreference[]
+  tenantSubscriptions           TenantSubscription[]
+  profile                       TenantProfile?
+  invoices                      Invoice[]
+  quotes                        Quote[]
+  invoiceLines                  InvoiceLine[]
+  payments                      Payment[]
+  customers                     Customer[]
+  suppliers                     Supplier[]
+  articles                      Article[]
+  expenses                      ExpenseRecord[]
+  integrations                  TenantIntegration[]
+  externalConnections           ExternalConnection[]
+  channelIdentities             ChannelIdentity[]
+  integrationMaps               IntegrationMap[]
+  syncConflicts                 SyncConflict[]
+  syncOutboxItems               SyncOutbox[]
+  syncLogs                      SyncLog[]
+  externalConnectionAuditLogs   ExternalConnectionAuditLog[]
+  externalSyncRuns              ExternalSyncRun[]
+  isaakConversations            IsaakConversation[]
+  isaakGoogleTokens             IsaakGoogleToken[]
+  isaakMicrosoftTokens          IsaakMicrosoftToken[]
+  isaakAlerts                   IsaakAlert[]
+  isaakGmailScans               IsaakGmailScan[]
+  isaakPushSubscriptions        IsaakPushSubscription[]
+  isaakPushPreferences          IsaakPushPreferences[]
+  isaakMemoryFacts              IsaakMemoryFact[]
+  isaakOnboardingProfiles       IsaakOnboardingProfile[]
+  usageEvents                   UsageEvent[]
+  demoOnboardings               UserOnboarding[]
+  supportSessions               SupportSession[]
+  orders                        Order[]
+  orderLines                    OrderLine[]
+  fulfillmentCases              FulfillmentCase[]
+  fulfillmentTasks              FulfillmentTask[]
+  supportTickets                SupportTicket[]
+  supportMessages               SupportMessage[]
+  whatsappThreads               WhatsAppThread[]
+  whatsappEvents                WhatsAppEvent[]
+  customIntegrationRequests     CustomIntegrationRequest[]
+  connectionRecipients          ConnectionRecipient[]
+  accessRequests                AccessRequest[]
+  claimCases                    ClaimCase[]
+  isaakPlatformKeys             IsaakPlatformKey[]
+  isaakApiAuditLogs             IsaakApiAuditLog[]
   holdedMcpPersonalAccessTokens HoldedMcpPersonalAccessToken[]
-  holdedMcpPatAuditLogs       HoldedMcpPatAuditLog[]
-  isaakWebhookEndpoints       IsaakWebhookEndpoint[]
-  isaakProposedActions        IsaakProposedAction[]
-  gcMandates                  GcMandate[]
-  gcPayments                  GcPayment[]
-  seCustomer                  SeCustomer?
-  seConnections               SeConnection[]
-  seAccounts                  SeAccount[]
-  seTransactions              SeTransaction[]
-  seTransactionMatchAudits    SeTransactionMatchAudit[]
-  bankReconciliationConfig    BankReconciliationConfig?
-  invoiceTemplates            InvoiceTemplate[]
-  tenantCertificates          TenantCertificate[]
-  advisorClients              AdvisorClient[]
-  erpOAuthTokens              ErpOAuthToken[]
+  holdedMcpPatAuditLogs         HoldedMcpPatAuditLog[]
+  isaakWebhookEndpoints         IsaakWebhookEndpoint[]
+  isaakProposedActions          IsaakProposedAction[]
+  gcMandates                    GcMandate[]
+  gcPayments                    GcPayment[]
+  seCustomer                    SeCustomer?
+  seConnections                 SeConnection[]
+  seAccounts                    SeAccount[]
+  seTransactions                SeTransaction[]
+  seTransactionMatchAudits      SeTransactionMatchAudit[]
+  bankReconciliationConfig      BankReconciliationConfig?
+  invoiceTemplates              InvoiceTemplate[]
+  tenantCertificates            TenantCertificate[]
+  advisorClients                AdvisorClient[]
+  erpOAuthTokens                ErpOAuthToken[]
 
   @@map("tenants")
 }
@@ -611,37 +611,37 @@ model TenantProfile {
   tenantId String @id @map("tenant_id") @db.Uuid
   tenant   Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
 
-  source                String    @default("manual")
-  sourceId              String?   @map("source_id")
-  taxId                 String?   @map("tax_id")
-  legalName             String?   @map("legal_name")
-  tradeName             String?   @map("trade_name")
-  fiscalAddress         Json?     @map("fiscal_address")
-  taxRegime             String?   @map("tax_regime")
-  defaultCurrency       String    @default("EUR") @map("default_currency")
-  adminEditHistory      Json?     @map("admin_edit_history")
-  cnae                  String?
-  cnaeCode              String?   @map("cnae_code")
-  cnaeText              String?   @map("cnae_text")
-  legalForm             String?   @map("legal_form")
-  status                String?
-  website               String?
-  capitalSocial         Decimal?  @map("capital_social")
-  incorporationDate     DateTime? @map("incorporation_date") @db.Date
-  address               String?
-  postalCode            String?   @map("postal_code")
-  city                  String?
-  province              String?
-  country               String?
-  representative        String?
-  representativeRole    String?   @map("representative_role")
-  email                 String?
-  phone                 String?
-  employees             Int?
-  sales                 Decimal?
-  salesYear             Int?      @map("sales_year")
-  lastBalanceDate       DateTime? @map("last_balance_date") @db.Date
-  updatedAt             DateTime  @updatedAt @map("updated_at") @db.Timestamptz
+  source             String    @default("manual")
+  sourceId           String?   @map("source_id")
+  taxId              String?   @map("tax_id")
+  legalName          String?   @map("legal_name")
+  tradeName          String?   @map("trade_name")
+  fiscalAddress      Json?     @map("fiscal_address")
+  taxRegime          String?   @map("tax_regime")
+  defaultCurrency    String    @default("EUR") @map("default_currency")
+  adminEditHistory   Json?     @map("admin_edit_history")
+  cnae               String?
+  cnaeCode           String?   @map("cnae_code")
+  cnaeText           String?   @map("cnae_text")
+  legalForm          String?   @map("legal_form")
+  status             String?
+  website            String?
+  capitalSocial      Decimal?  @map("capital_social")
+  incorporationDate  DateTime? @map("incorporation_date") @db.Date
+  address            String?
+  postalCode         String?   @map("postal_code")
+  city               String?
+  province           String?
+  country            String?
+  representative     String?
+  representativeRole String?   @map("representative_role")
+  email              String?
+  phone              String?
+  employees          Int?
+  sales              Decimal?
+  salesYear          Int?      @map("sales_year")
+  lastBalanceDate    DateTime? @map("last_balance_date") @db.Date
+  updatedAt          DateTime  @updatedAt @map("updated_at") @db.Timestamptz
 
   @@map("tenant_profiles")
 }
@@ -1127,15 +1127,15 @@ model WhatsAppEvent {
 }
 
 model WhatsAppTemplate {
-  id          String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  name        String   @unique
-  category    String   @default("general")
-  language    String   @default("es")
-  body        String
-  variables   Json?
-  isActive    Boolean  @default(true) @map("is_active")
-  createdAt   DateTime @default(now()) @map("created_at") @db.Timestamptz
-  updatedAt   DateTime @updatedAt @map("updated_at") @db.Timestamptz
+  id        String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  name      String   @unique
+  category  String   @default("general")
+  language  String   @default("es")
+  body      String
+  variables Json?
+  isActive  Boolean  @default(true) @map("is_active")
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz
 
   @@index([category, isActive])
   @@index([language])
@@ -1436,8 +1436,8 @@ model ExpenseRecord {
   createdAt                 DateTime  @default(now()) @map("created_at") @db.Timestamptz
   updatedAt                 DateTime  @updatedAt @map("updated_at") @db.Timestamptz
 
-  tenant   Tenant    @relation(fields: [tenantId], references: [id], onDelete: Cascade)
-  supplier Supplier? @relation(fields: [supplierId], references: [id], onDelete: SetNull)
+  tenant                   Tenant                    @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  supplier                 Supplier?                 @relation(fields: [supplierId], references: [id], onDelete: SetNull)
   seTransactionMatchAudits SeTransactionMatchAudit[]
 
   @@index([tenantId])
@@ -1498,9 +1498,9 @@ model ExternalConnection {
   createdAt               DateTime         @default(now()) @map("created_at") @db.Timestamptz
   updatedAt               DateTime         @updatedAt @map("updated_at") @db.Timestamptz
 
-  tenant                Tenant                       @relation(fields: [tenantId], references: [id], onDelete: Cascade)
-  connectedByUser       User?                        @relation("ExternalConnectionConnectedByUser", fields: [connectedByUserId], references: [id], onDelete: SetNull)
-  technicalOperatorUser User?                        @relation("ExternalConnectionTechnicalOperatorUser", fields: [technicalOperatorUserId], references: [id], onDelete: SetNull)
+  tenant                Tenant                         @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  connectedByUser       User?                          @relation("ExternalConnectionConnectedByUser", fields: [connectedByUserId], references: [id], onDelete: SetNull)
+  technicalOperatorUser User?                          @relation("ExternalConnectionTechnicalOperatorUser", fields: [technicalOperatorUserId], references: [id], onDelete: SetNull)
   auditLogs             ExternalConnectionAuditLog[]
   syncRuns              ExternalSyncRun[]
   recipients            ConnectionRecipient[]
@@ -1888,6 +1888,42 @@ model IsaakMemoryFact {
   @@map("isaak_memory_facts")
 }
 
+// ==================== ISAAK: CHAT METRICS (F1) ====================
+
+model IsaakChatMetric {
+  id             String  @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  tenantId       String? @map("tenant_id") @db.Uuid
+  userId         String? @map("user_id")
+  conversationId String? @map("conversation_id") @db.Uuid
+  messageId      String? @map("message_id") @db.Uuid
+
+  provider  String
+  modelUsed String  @map("model_used")
+  feature   String?
+
+  inputTokens      Int     @default(0) @map("input_tokens")
+  outputTokens     Int     @default(0) @map("output_tokens")
+  estimatedCostEur Decimal @default(0) @map("estimated_cost_eur") @db.Decimal(12, 8)
+
+  latencyMs    Int  @default(0) @map("latency_ms")
+  firstTokenMs Int? @map("first_token_ms")
+
+  toolCallsCount Int      @default(0) @map("tool_calls_count")
+  toolNames      String[] @default([]) @map("tool_names")
+
+  isClarification Boolean @default(false) @map("is_clarification")
+  isFallback      Boolean @default(false) @map("is_fallback")
+  historyTurns    Int     @default(0) @map("history_turns")
+
+  errorCode String?  @map("error_code")
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
+
+  @@index([tenantId, createdAt])
+  @@index([conversationId, createdAt])
+  @@index([modelUsed, createdAt])
+  @@map("isaak_chat_metrics")
+}
+
 // ==================== ISAAK: GOOGLE TOKENS ====================
 
 model IsaakGoogleToken {
@@ -2012,9 +2048,9 @@ model IsaakPushPreferences {
   id                    String   @id @default(cuid())
   tenantId              String   @map("tenant_id") @db.Uuid
   userId                String   @map("user_id") @db.Uuid
-  alertaFiscal          Boolean  @default(true)  @map("alerta_fiscal")
-  documentoSinConciliar Boolean  @default(true)  @map("documento_sin_conciliar")
-  avisoProactivoIsaak   Boolean  @default(true)  @map("aviso_proactivo_isaak")
+  alertaFiscal          Boolean  @default(true) @map("alerta_fiscal")
+  documentoSinConciliar Boolean  @default(true) @map("documento_sin_conciliar")
+  avisoProactivoIsaak   Boolean  @default(true) @map("aviso_proactivo_isaak")
   updatedAt             DateTime @updatedAt @map("updated_at") @db.Timestamptz
 
   tenant Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
@@ -2027,14 +2063,14 @@ model IsaakPushPreferences {
 // ==================== GOCARDLESS ====================
 
 model GcMandate {
-  id          String   @id          // GoCardless mandate ID (MDxxxxxxxxx)
-  tenantId    String   @map("tenant_id") @db.Uuid
-  userId      String   @map("user_id") @db.Uuid
-  gcCustomerId String  @map("gc_customer_id")
-  status      String   @default("pending_submission") @map("status")
-  scheme      String   @default("sepa_core")
-  createdAt   DateTime @default(now()) @map("created_at") @db.Timestamptz
-  updatedAt   DateTime @updatedAt  @map("updated_at") @db.Timestamptz
+  id           String   @id // GoCardless mandate ID (MDxxxxxxxxx)
+  tenantId     String   @map("tenant_id") @db.Uuid
+  userId       String   @map("user_id") @db.Uuid
+  gcCustomerId String   @map("gc_customer_id")
+  status       String   @default("pending_submission") @map("status")
+  scheme       String   @default("sepa_core")
+  createdAt    DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt    DateTime @updatedAt @map("updated_at") @db.Timestamptz
 
   tenant   Tenant      @relation(fields: [tenantId], references: [id], onDelete: Cascade)
   payments GcPayment[]
@@ -2045,17 +2081,17 @@ model GcMandate {
 }
 
 model GcPayment {
-  id          String   @id          // GoCardless payment ID (PMxxxxxxxxx)
+  id          String   @id // GoCardless payment ID (PMxxxxxxxxx)
   tenantId    String   @map("tenant_id") @db.Uuid
   mandateId   String   @map("mandate_id")
   amountCents Int      @map("amount_cents")
   currency    String   @default("EUR")
-  chargeDate  String   @map("charge_date")    // YYYY-MM-DD
+  chargeDate  String   @map("charge_date") // YYYY-MM-DD
   status      String   @default("pending_submission")
   description String?
   reference   String?
   createdAt   DateTime @default(now()) @map("created_at") @db.Timestamptz
-  updatedAt   DateTime @updatedAt  @map("updated_at") @db.Timestamptz
+  updatedAt   DateTime @updatedAt @map("updated_at") @db.Timestamptz
 
   tenant  Tenant    @relation(fields: [tenantId], references: [id], onDelete: Cascade)
   mandate GcMandate @relation(fields: [mandateId], references: [id])
@@ -2068,35 +2104,35 @@ model GcPayment {
 // ==================== SALTEDGE (Open Banking / PSD2) ====================
 
 model SeCustomer {
-  id         String   @id          // Salt Edge customer ID (customer_id en v6)
+  id         String   @id // Salt Edge customer ID (customer_id en v6)
   tenantId   String   @unique @map("tenant_id") @db.Uuid
-  identifier String   @unique      // nuestro identificador (tenant ID como string)
-  secret     String?               // deprecado en v6 — ya no se usa Customer-secret header
+  identifier String   @unique // nuestro identificador (tenant ID como string)
+  secret     String? // deprecado en v6 — ya no se usa Customer-secret header
   createdAt  DateTime @default(now()) @map("created_at") @db.Timestamptz
 
-  tenant      Tenant          @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  tenant      Tenant         @relation(fields: [tenantId], references: [id], onDelete: Cascade)
   connections SeConnection[]
 
   @@map("se_customers")
 }
 
 model SeConnection {
-  id           String   @id          // Salt Edge connection ID or GoCardless BAD requisition ID
-  tenantId     String   @map("tenant_id") @db.Uuid
-  seCustomerId String?  @map("se_customer_id")  // null for GoCardless BAD connections
-  providerCode String   @map("provider_code")
-  providerName String   @map("provider_name")
-  countryCode  String   @default("ES") @map("country_code")
-  status       String   @default("pending")
-  provider     String   @default("saltedge")  // 'saltedge' | 'gcbd' | 'enablebanking'
+  id           String    @id // Salt Edge connection ID or GoCardless BAD requisition ID
+  tenantId     String    @map("tenant_id") @db.Uuid
+  seCustomerId String?   @map("se_customer_id") // null for GoCardless BAD connections
+  providerCode String    @map("provider_code")
+  providerName String    @map("provider_name")
+  countryCode  String    @default("ES") @map("country_code")
+  status       String    @default("pending")
+  provider     String    @default("saltedge") // 'saltedge' | 'gcbd' | 'enablebanking'
   lastSyncAt   DateTime? @map("last_sync_at") @db.Timestamptz
   expiresAt    DateTime? @map("expires_at") @db.Timestamptz
-  createdAt    DateTime @default(now()) @map("created_at") @db.Timestamptz
-  updatedAt    DateTime @updatedAt  @map("updated_at") @db.Timestamptz
+  createdAt    DateTime  @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt    DateTime  @updatedAt @map("updated_at") @db.Timestamptz
 
-  tenant     Tenant        @relation(fields: [tenantId], references: [id], onDelete: Cascade)
-  customer   SeCustomer?   @relation(fields: [seCustomerId], references: [id])
-  accounts   SeAccount[]
+  tenant   Tenant      @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  customer SeCustomer? @relation(fields: [seCustomerId], references: [id])
+  accounts SeAccount[]
 
   @@index([tenantId])
   @@index([tenantId, provider])
@@ -2104,7 +2140,7 @@ model SeConnection {
 }
 
 model SeAccount {
-  id           String   @id          // Salt Edge account ID
+  id           String   @id // Salt Edge account ID
   tenantId     String   @map("tenant_id") @db.Uuid
   connectionId String   @map("connection_id")
   name         String
@@ -2114,10 +2150,10 @@ model SeAccount {
   iban         String?
   status       String   @default("active")
   createdAt    DateTime @default(now()) @map("created_at") @db.Timestamptz
-  updatedAt    DateTime @updatedAt  @map("updated_at") @db.Timestamptz
+  updatedAt    DateTime @updatedAt @map("updated_at") @db.Timestamptz
 
-  tenant       Tenant         @relation(fields: [tenantId], references: [id], onDelete: Cascade)
-  connection   SeConnection   @relation(fields: [connectionId], references: [id])
+  tenant       Tenant          @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  connection   SeConnection    @relation(fields: [connectionId], references: [id])
   transactions SeTransaction[]
 
   @@index([tenantId])
@@ -2126,25 +2162,25 @@ model SeAccount {
 }
 
 model SeTransaction {
-  id           String   @id          // Salt Edge transaction ID
-  tenantId     String   @map("tenant_id") @db.Uuid
-  accountId    String   @map("account_id")
-  status       String   @default("posted") // posted | pending
-  madeOn       String   @map("made_on")    // YYYY-MM-DD
-  amount       Decimal  @db.Decimal(18, 2) // negativo = gasto
-  currency     String   @default("EUR")
+  id           String    @id // Salt Edge transaction ID
+  tenantId     String    @map("tenant_id") @db.Uuid
+  accountId    String    @map("account_id")
+  status       String    @default("posted") // posted | pending
+  madeOn       String    @map("made_on") // YYYY-MM-DD
+  amount       Decimal   @db.Decimal(18, 2) // negativo = gasto
+  currency     String    @default("EUR")
   description  String
-  category     String   @default("uncategorized")
+  category     String    @default("uncategorized")
   payee        String?
   payer        String?
-  duplicated   Boolean  @default(false)
+  duplicated   Boolean   @default(false)
   reconciledAt DateTime? @map("reconciled_at") @db.Timestamptz
-  createdAt    DateTime @default(now()) @map("created_at") @db.Timestamptz
-  updatedAt    DateTime @updatedAt  @map("updated_at") @db.Timestamptz
+  createdAt    DateTime  @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt    DateTime  @updatedAt @map("updated_at") @db.Timestamptz
 
-  tenant        Tenant                        @relation(fields: [tenantId], references: [id], onDelete: Cascade)
-  account       SeAccount                     @relation(fields: [accountId], references: [id])
-  matchAudits   SeTransactionMatchAudit[]
+  tenant      Tenant                    @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  account     SeAccount                 @relation(fields: [accountId], references: [id])
+  matchAudits SeTransactionMatchAudit[]
 
   @@index([tenantId])
   @@index([accountId])
@@ -2155,16 +2191,16 @@ model SeTransaction {
 // ==================== BANK RECONCILIATION CONFIG ====================
 
 model BankReconciliationConfig {
-  tenantId            String  @id @map("tenant_id") @db.Uuid
-  tenant              Tenant  @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  tenantId String @id @map("tenant_id") @db.Uuid
+  tenant   Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
 
   amountToleranceEur  Decimal @default(1.00) @map("amount_tolerance_eur") @db.Decimal(10, 2)
-  dateWindowDays      Int     @default(3)    @map("date_window_days")
+  dateWindowDays      Int     @default(3) @map("date_window_days")
   confidenceThreshold Float   @default(0.85) @map("confidence_threshold")
   autoMatchEnabled    Boolean @default(true) @map("auto_match_enabled")
 
-  createdAt           DateTime @default(now()) @map("created_at") @db.Timestamptz
-  updatedAt           DateTime @updatedAt      @map("updated_at") @db.Timestamptz
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz
 
   @@map("bank_reconciliation_configs")
 }
@@ -2172,20 +2208,20 @@ model BankReconciliationConfig {
 // ==================== BANK RECONCILIATION AUDIT ====================
 
 model SeTransactionMatchAudit {
-  id                    String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  tenantId              String   @map("tenant_id") @db.Uuid
-  seTransactionId       String   @map("se_transaction_id")
-  matchedExpenseId      String?  @map("matched_expense_id") @db.Uuid
-  matchScore            Float    @map("match_score")
-  scoreComponents       Json     @map("score_components") // { amountScore, dateScore, textScore, amountMatch?, dateMatch?, textSimilarity? }
-  evidenceReasons       Json     @map("evidence_reasons") // array of reason strings
-  autoMatched           Boolean  @map("auto_matched")
-  createdAt             DateTime @default(now()) @map("created_at") @db.Timestamptz
-  updatedAt             DateTime @updatedAt @map("updated_at") @db.Timestamptz
+  id               String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  tenantId         String   @map("tenant_id") @db.Uuid
+  seTransactionId  String   @map("se_transaction_id")
+  matchedExpenseId String?  @map("matched_expense_id") @db.Uuid
+  matchScore       Float    @map("match_score")
+  scoreComponents  Json     @map("score_components") // { amountScore, dateScore, textScore, amountMatch?, dateMatch?, textSimilarity? }
+  evidenceReasons  Json     @map("evidence_reasons") // array of reason strings
+  autoMatched      Boolean  @map("auto_matched")
+  createdAt        DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt        DateTime @updatedAt @map("updated_at") @db.Timestamptz
 
-  tenant               Tenant              @relation(fields: [tenantId], references: [id], onDelete: Cascade)
-  seTransaction        SeTransaction       @relation(fields: [seTransactionId], references: [id], onDelete: Cascade)
-  matchedExpense       ExpenseRecord?      @relation(fields: [matchedExpenseId], references: [id], onDelete: SetNull)
+  tenant         Tenant         @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  seTransaction  SeTransaction  @relation(fields: [seTransactionId], references: [id], onDelete: Cascade)
+  matchedExpense ExpenseRecord? @relation(fields: [matchedExpenseId], references: [id], onDelete: SetNull)
 
   @@index([tenantId])
   @@index([seTransactionId])
@@ -2197,26 +2233,26 @@ model SeTransactionMatchAudit {
 // ==================== DEMO REQUESTS ====================
 
 model DemoRequest {
-  id          String            @id @default(cuid())
-  createdAt   DateTime          @default(now()) @map("created_at")
-  updatedAt   DateTime          @updatedAt @map("updated_at")
+  id        String   @id @default(cuid())
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
 
   name        String
   email       String
   phone       String?
-  companyName String            @map("company_name")
-  taxId       String?           @map("tax_id")
+  companyName String  @map("company_name")
+  taxId       String? @map("tax_id")
   role        String?
-  usesHolded  Boolean           @default(false) @map("uses_holded")
+  usesHolded  Boolean @default(false) @map("uses_holded")
   objective   String?
 
-  source      String?
-  consent     Boolean           @default(false)
+  source  String?
+  consent Boolean @default(false)
 
-  status      DemoRequestStatus @default(PENDING)
-  notes       String?
+  status DemoRequestStatus @default(PENDING)
+  notes  String?
 
-  metadataJson Json?            @map("metadata_json")
+  metadataJson Json? @map("metadata_json")
 
   @@index([status])
   @@index([createdAt])
@@ -2226,18 +2262,18 @@ model DemoRequest {
 // ==================== ISAAK PLATFORM ====================
 
 model IsaakProposedAction {
-  id          String    @id @default(cuid())
-  tenantId    String    @map("tenant_id") @db.Uuid
-  proposedBy  String    @map("proposed_by")
-  type        String
-  status      String    @default("pending")
-  payload     Json
-  reason      String?
-  riskLevel   String    @default("medium") @map("risk_level")
-  expiresAt   DateTime? @map("expires_at") @db.Timestamptz
-  executedAt  DateTime? @map("executed_at") @db.Timestamptz
-  createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamptz
-  updatedAt   DateTime  @updatedAt @map("updated_at") @db.Timestamptz
+  id         String    @id @default(cuid())
+  tenantId   String    @map("tenant_id") @db.Uuid
+  proposedBy String    @map("proposed_by")
+  type       String
+  status     String    @default("pending")
+  payload    Json
+  reason     String?
+  riskLevel  String    @default("medium") @map("risk_level")
+  expiresAt  DateTime? @map("expires_at") @db.Timestamptz
+  executedAt DateTime? @map("executed_at") @db.Timestamptz
+  createdAt  DateTime  @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt  DateTime  @updatedAt @map("updated_at") @db.Timestamptz
 
   tenant Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
 
@@ -2321,7 +2357,7 @@ model HoldedMcpPersonalAccessToken {
   id              String    @id @default(cuid())
   tenantId        String    @map("tenant_id") @db.Uuid
   createdByUserId String    @map("created_by_user_id")
-  connectionId   String?   @map("connection_id") @db.Uuid
+  connectionId    String?   @map("connection_id") @db.Uuid
   /// Channel this PAT was issued for. Mirrors ExternalConnection.channelKey.
   /// Allowed values: "chatgpt", "claude", "dashboard".
   channelKey      String    @default("chatgpt") @map("channel_key")
@@ -2337,8 +2373,8 @@ model HoldedMcpPersonalAccessToken {
   createdAt       DateTime  @default(now()) @map("created_at") @db.Timestamptz
   updatedAt       DateTime  @updatedAt @map("updated_at") @db.Timestamptz
 
-  tenant     Tenant              @relation(fields: [tenantId], references: [id], onDelete: Cascade)
-  connection ExternalConnection? @relation(fields: [connectionId], references: [id], onDelete: SetNull)
+  tenant     Tenant                 @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  connection ExternalConnection?    @relation(fields: [connectionId], references: [id], onDelete: SetNull)
   auditLogs  HoldedMcpPatAuditLog[]
 
   @@unique([tenantId, name])
@@ -2350,20 +2386,20 @@ model HoldedMcpPersonalAccessToken {
 /// Audit log for HoldedMcpPersonalAccessToken usage. Lightweight — captures the
 /// minimum needed for security review (created/used/revoked, IP, tool name).
 model HoldedMcpPatAuditLog {
-  id          String   @id @default(cuid())
-  tenantId    String   @map("tenant_id") @db.Uuid
-  patId       String?  @map("pat_id")
+  id        String   @id @default(cuid())
+  tenantId  String   @map("tenant_id") @db.Uuid
+  patId     String?  @map("pat_id")
   /// Event type: "created" | "used" | "revoked" | "rejected"
-  event       String
-  channel     String?
-  toolName    String?  @map("tool_name")
-  status      Int?
-  ip          String?
-  userAgent   String?  @map("user_agent")
-  meta        Json?
-  createdAt   DateTime @default(now()) @map("created_at") @db.Timestamptz
+  event     String
+  channel   String?
+  toolName  String?  @map("tool_name")
+  status    Int?
+  ip        String?
+  userAgent String?  @map("user_agent")
+  meta      Json?
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
 
-  tenant Tenant                       @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  tenant Tenant                        @relation(fields: [tenantId], references: [id], onDelete: Cascade)
   pat    HoldedMcpPersonalAccessToken? @relation(fields: [patId], references: [id], onDelete: SetNull)
 
   @@index([tenantId, createdAt])
@@ -2403,20 +2439,20 @@ model ConnectorHealthCheck {
 }
 
 model AdvisorClient {
-  id              String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  advisorTenantId String   @map("advisor_tenant_id") @db.Uuid
-  advisorTenant   Tenant   @relation(fields: [advisorTenantId], references: [id], onDelete: Cascade)
+  id              String @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  advisorTenantId String @map("advisor_tenant_id") @db.Uuid
+  advisorTenant   Tenant @relation(fields: [advisorTenantId], references: [id], onDelete: Cascade)
 
   alias           String
-  companyName     String?  @map("company_name")
+  companyName     String? @map("company_name")
   nif             String?
-  holdedApiKeyEnc String?  @map("holded_api_key_enc") @db.Text
-  holdedKeyMasked String?  @map("holded_key_masked")
-  notes           String?  @db.Text
-  isActive        Boolean  @default(true) @map("is_active")
+  holdedApiKeyEnc String? @map("holded_api_key_enc") @db.Text
+  holdedKeyMasked String? @map("holded_key_masked")
+  notes           String? @db.Text
+  isActive        Boolean @default(true) @map("is_active")
 
-  createdAt       DateTime @default(now()) @map("created_at") @db.Timestamptz
-  updatedAt       DateTime @updatedAt @map("updated_at") @db.Timestamptz
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz
 
   @@index([advisorTenantId, isActive])
   @@map("advisor_clients")

--- a/packages/integrations/index.ts
+++ b/packages/integrations/index.ts
@@ -173,6 +173,7 @@ export {
   ensureTenantConversation,
   getTenantConversation,
   getTenantMemoryContext,
+  listRecentTenantConversationMessages,
   listTenantConversations,
   storeTenantMemoryFact,
 } from './isaak/chat';

--- a/packages/integrations/isaak/chat.ts
+++ b/packages/integrations/isaak/chat.ts
@@ -145,6 +145,24 @@ export async function ensureTenantConversation(
   });
 }
 
+export async function listRecentTenantConversationMessages(
+  prisma: IsaakChatPrismaClient,
+  conversationId: string,
+  limit: number = RECENT_MESSAGE_LIMIT
+): Promise<Array<{ role: 'user' | 'assistant'; content: string }>> {
+  const safeLimit = Math.max(1, Math.min(50, limit));
+  const rows = await prisma.isaakConversationMsg.findMany({
+    where: { conversationId },
+    orderBy: { createdAt: 'desc' },
+    take: safeLimit,
+    select: { role: true, content: true },
+  });
+  return rows
+    .reverse()
+    .filter((row) => row.role === 'user' || row.role === 'assistant')
+    .map((row) => ({ role: row.role as 'user' | 'assistant', content: row.content }));
+}
+
 export async function appendTenantConversationMessage(
   prisma: IsaakChatPrismaClient,
   input: {

--- a/packages/utils/ai/anthropic-adapter.ts
+++ b/packages/utils/ai/anthropic-adapter.ts
@@ -15,6 +15,7 @@ type AnthropicMessage = {
 
 type AnthropicResponse = {
   content?: Array<{ type: string; text?: string }>;
+  usage?: { input_tokens?: number; output_tokens?: number };
   error?: { message?: string };
 };
 
@@ -85,7 +86,13 @@ export async function anthropicAdapter(
   }
 
   const text = data.content?.find((b) => b.type === 'text')?.text ?? null;
-  return normalizeResponse(text, 'anthropic', model, data);
+  const usage = data.usage
+    ? {
+        inputTokens: data.usage.input_tokens ?? 0,
+        outputTokens: data.usage.output_tokens ?? 0,
+      }
+    : undefined;
+  return normalizeResponse(text, 'anthropic', model, data, usage);
 }
 
 registerAdapter('anthropic', anthropicAdapter);

--- a/packages/utils/ai/gateway-adapter.ts
+++ b/packages/utils/ai/gateway-adapter.ts
@@ -19,6 +19,10 @@ type GatewayChatResponse = {
       content?: string | null;
     };
   }>;
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+  };
   error?: {
     message?: string;
   };
@@ -91,7 +95,13 @@ export async function gatewayAdapter(
   }
 
   const text = data.choices?.[0]?.message?.content ?? null;
-  return normalizeResponse(text, 'gateway', model, data);
+  const usage = data.usage
+    ? {
+        inputTokens: data.usage.prompt_tokens ?? 0,
+        outputTokens: data.usage.completion_tokens ?? 0,
+      }
+    : undefined;
+  return normalizeResponse(text, 'gateway', model, data, usage);
 }
 
 registerAdapter('gateway', gatewayAdapter);

--- a/packages/utils/ai/index.ts
+++ b/packages/utils/ai/index.ts
@@ -9,6 +9,7 @@ export type {
   AIProvider,
   AIMessage,
   AIResponseFormat,
+  AIUsage,
   CallLLMParams,
   NormalizedLLMResponse,
 } from './types';

--- a/packages/utils/ai/normalize-response.ts
+++ b/packages/utils/ai/normalize-response.ts
@@ -1,14 +1,15 @@
-import type { AIProvider, NormalizedLLMResponse } from './types';
+import type { AIProvider, AIUsage, NormalizedLLMResponse } from './types';
 import { AIError } from './errors';
 
 export function normalizeResponse(
   text: string | null | undefined,
   provider: AIProvider,
   model: string,
-  raw?: unknown
+  raw?: unknown,
+  usage?: AIUsage
 ): NormalizedLLMResponse {
   if (!text?.trim()) {
     throw new AIError('Provider returned empty response', provider, 'empty_response');
   }
-  return { text: text.trim(), provider, model, raw };
+  return { text: text.trim(), provider, model, raw, usage };
 }

--- a/packages/utils/ai/openai-adapter.ts
+++ b/packages/utils/ai/openai-adapter.ts
@@ -13,6 +13,10 @@ type OpenAIResponsesApiOutput = {
       text?: string;
     }>;
   }>;
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+  };
   error?: {
     message?: string;
   };
@@ -102,7 +106,13 @@ export async function openaiAdapter(
     throw new AIError(data.error.message, 'openai', 'unknown');
   }
 
-  return normalizeResponse(extractText(data), 'openai', model, data);
+  const usage = data.usage
+    ? {
+        inputTokens: data.usage.input_tokens ?? 0,
+        outputTokens: data.usage.output_tokens ?? 0,
+      }
+    : undefined;
+  return normalizeResponse(extractText(data), 'openai', model, data, usage);
 }
 
 registerAdapter('openai', openaiAdapter);

--- a/packages/utils/ai/types.ts
+++ b/packages/utils/ai/types.ts
@@ -21,10 +21,16 @@ export type CallLLMParams = {
   enableFallback?: boolean;
 };
 
+export type AIUsage = {
+  inputTokens: number;
+  outputTokens: number;
+};
+
 export type NormalizedLLMResponse = {
   text: string;
   provider: AIProvider;
   model: string;
   latencyMs?: number;
+  usage?: AIUsage;
   raw?: unknown;
 };


### PR DESCRIPTION
Primera fase del manifiesto `docs/engineering/ISAAK_INTELLIGENCE.md` (mergeado en #122).

## Lo que entra en F1

### 1. Memoria multi-turno (`/api/chat`)
El endpoint pasa de stateless por request a **inyectar los últimos 8 mensajes** de la conversación antes de cada llamada al LLM. Isaak ya recuerda el período, el cliente o el dato que la persona le acaba de dar en el turno anterior.

### 2. Clarify-first en el system prompt
Nuevo bloque "Principios de respuesta" instruye a Isaak a responder con JSON estructurado `{clarify, question, options}` cuando la query es ambigua en período/cliente/intent/importe. El detector `detectClarificationResponse` marca esos mensajes en BD y en la respuesta JSON para que el frontend renderice opciones como chips.

En F1 esta capa es **vía prompt** (no hay clasificador separado). El classifier Haiku independiente llega en F3.

### 3. Baseline metrics — nueva tabla `IsaakChatMetric`
Capturamos por cada mensaje:
- `provider`, `model_used`, `feature`
- `input_tokens`, `output_tokens`, `estimated_cost_eur`
- `latency_ms`, `first_token_ms` (para F5 streaming)
- `tool_calls_count`, `tool_names[]` (para F2 tool-use)
- `is_clarification`, `is_fallback`, `history_turns`
- `error_code`

Índices preparados para el panel `/admin/isaak-intelligence` (queries SQL en el doc maestro). Pricing snapshot de Anthropic/OpenAI 2026-05-24 en la lib `isaak-chat-metrics`.

La extensión a `NormalizedLLMResponse` añade `usage` opcional a todos los adapters (Anthropic / OpenAI Responses / Vercel Gateway) — backwards compatible.

### 4. Golden test harness
**30 fixtures JSON** organizados en `apps/isaak/tests/intelligence/fixtures/`:
- 10 clarify (ambigüedad de período, entidad, intent, importe)
- 8 no-clarify (queries precisas, saludos, plazos)
- 6 no-hallucination (cliente inexistente, sin Holded, sin banca)
- 6 multi-turn (herencia de período, memoria de nombre, no repetir preguntas)

Los 30 corren en modo opt-in con `ISAAK_GOLDEN_LIVE=1` (consume tokens reales contra Anthropic). En CI quedan SKIP — el wiring se valida con 3 tests offline. README explica la mecánica.

## Verificación

- `npm test` (isaak): ✅ 30 passed + 30 skipped (golden live off)
- `npx tsc --noEmit -p tsconfig.json`: ✅ clean
- Unit tests de `detectClarificationResponse` y `estimateCostEur`: ✅ 11/11
- Schema Prisma: ✅ valida, generate OK

## Lo que NO entra (por diseño, llega en fases siguientes)

- Tool-calling real (Holded/banca/Google) — F2
- Classifier Haiku separado — F3
- Visión + judge cross-validation — F4
- Streaming SSE — F5
- Memoria larga con embeddings/RAG — F6
- Few-shot dinámico desde 👍 — F7

## Migraciones

Nueva: `20260524000000_isaak_chat_metrics`. Aplicada automáticamente en build de Vercel vía `prisma migrate deploy`.

https://claude.ai/code/session_01XEgA9ynYQxzRUipm4CeXpq