### PR TITLE
refactor(isaak ui): identidad propia + sidebar auto-collapse en chat

### DIFF
--- a/apps/isaak/app/(workspace)/components/IsaakChatSection.tsx
+++ b/apps/isaak/app/(workspace)/components/IsaakChatSection.tsx
@@ -636,7 +636,7 @@ export default function IsaakChatSection({
                 onClick={() => router.push('/integrations')}
                 className="rounded-xl border border-blue-200 bg-blue-50 px-3.5 py-2 text-[13px] font-medium text-blue-700 transition hover:border-blue-300 hover:bg-blue-100"
               >
-                Conectar Holded →
+                Conectar tu contabilidad →
               </button>
             )}
           </div>

--- a/apps/isaak/app/(workspace)/components/IsaakSidebar.tsx
+++ b/apps/isaak/app/(workspace)/components/IsaakSidebar.tsx
@@ -221,10 +221,22 @@ export default function IsaakSidebar({
     };
   }, []);
 
+  // Sidebar collapse policy (Claude.ai style):
+  // 1. Si el usuario ha tocado el toggle (preferencia explícita), respetar
+  //    siempre (localStorage 'isaak-sidebar-collapsed').
+  // 2. Si NO hay preferencia explícita y la ruta es /chat/* → auto-colapsar
+  //    para dar más espacio al chat (patrón Claude.ai).
+  // 3. Si NO hay preferencia explícita y NO estamos en chat → expandida.
+  const isChatRoute = !!pathname && (pathname === '/chat' || pathname.startsWith('/chat/'));
   useEffect(() => {
     const stored = localStorage.getItem('isaak-sidebar-collapsed');
-    if (stored === 'true') setCollapsed(true);
-  }, []);
+    if (stored === 'true' || stored === 'false') {
+      setCollapsed(stored === 'true');
+      return;
+    }
+    // No preferencia explícita → autoaplicar política según ruta
+    setCollapsed(isChatRoute);
+  }, [isChatRoute]);
 
   useEffect(() => {
     if (!profileOpen) return;
@@ -272,8 +284,14 @@ export default function IsaakSidebar({
           collapsed ? 'justify-center px-2' : 'justify-between px-3'
         }`}
       >
-        <div className="flex items-center gap-2.5">
-          <div className="relative h-7 w-7 shrink-0 overflow-hidden rounded-lg">
+        {collapsed ? (
+          // Modo colapsado: logo es el toggle (click expande la sidebar)
+          <button
+            type="button"
+            onClick={toggleCollapsed}
+            title="Abrir menú"
+            className="group relative h-7 w-7 shrink-0 overflow-hidden rounded-lg transition hover:opacity-80"
+          >
             {whitelabel?.enabled && whitelabel.logoUrl ? (
               <img
                 src={whitelabel.logoUrl}
@@ -290,20 +308,43 @@ export default function IsaakSidebar({
                 priority
               />
             )}
-          </div>
-          {!collapsed && (
-            <span className="text-[14px] font-bold tracking-tight text-white">{appName}</span>
-          )}
-        </div>
-        {!collapsed && (
-          <button
-            type="button"
-            onClick={toggleCollapsed}
-            title="Plegar menú"
-            className="rounded-md p-1 text-slate-600 transition hover:bg-white/5 hover:text-slate-400"
-          >
-            <ChevronLeft size={13} />
+            {/* Indicador visual de expand al hover */}
+            <span className="absolute inset-0 flex items-center justify-center bg-slate-900/70 opacity-0 transition group-hover:opacity-100">
+              <ChevronRight size={13} className="text-white" />
+            </span>
           </button>
+        ) : (
+          <>
+            <div className="flex items-center gap-2.5">
+              <div className="relative h-7 w-7 shrink-0 overflow-hidden rounded-lg">
+                {whitelabel?.enabled && whitelabel.logoUrl ? (
+                  <img
+                    src={whitelabel.logoUrl}
+                    alt={appName}
+                    className="h-full w-full object-contain"
+                  />
+                ) : (
+                  <Image
+                    src="/Personalidad/isaak-avatar-2.png"
+                    alt="Isaak"
+                    fill
+                    sizes="28px"
+                    className="object-cover"
+                    priority
+                  />
+                )}
+              </div>
+              <span className="text-[14px] font-bold tracking-tight text-white">{appName}</span>
+            </div>
+            <button
+              type="button"
+              onClick={toggleCollapsed}
+              title="Plegar menú"
+              className="rounded-md p-1 text-slate-600 transition hover:bg-white/5 hover:text-slate-400"
+            >
+              <ChevronLeft size={13} />
+            </button>
+          </>
         )}
       </div>
 

--- a/apps/isaak/app/(workspace)/contactos/ContactosClient.tsx
+++ b/apps/isaak/app/(workspace)/contactos/ContactosClient.tsx
@@ -82,7 +82,7 @@ export default function ContactosClient() {
   if (noHolded) {
     return (
       <div className="flex flex-col items-center justify-center gap-3 py-20 text-center">
-        <p className="text-sm text-slate-500">Conecta Holded para ver tus contactos.</p>
+        <p className="text-sm text-slate-500">Conecta tu ERP para ver tus contactos.</p>
         <a
           href="/settings/connections"
           className="rounded-lg bg-[#2361d8] px-4 py-2 text-sm font-medium text-white hover:bg-[#1a4fc4]"

--- a/apps/isaak/app/(workspace)/equipo/EquipoClient.tsx
+++ b/apps/isaak/app/(workspace)/equipo/EquipoClient.tsx
@@ -76,7 +76,7 @@ export default function EquipoClient() {
   if (noHolded) {
     return (
       <div className="flex flex-col items-center justify-center gap-3 py-20 text-center">
-        <p className="text-sm text-slate-500">Conecta Holded para ver tu equipo y proyectos.</p>
+        <p className="text-sm text-slate-500">Conecta tu ERP para ver tu equipo y proyectos.</p>
         <a
           href="/settings/connections"
           className="rounded-lg bg-[#2361d8] px-4 py-2 text-sm font-medium text-white hover:bg-[#1a4fc4]"

--- a/apps/isaak/app/(workspace)/fiscal/modelos/page.tsx
+++ b/apps/isaak/app/(workspace)/fiscal/modelos/page.tsx
@@ -224,7 +224,7 @@ function ResultBadge({ value }: { value: number }) {
 function Disclaimer() {
   return (
     <p className="text-xs text-slate-400 text-center">
-      Borrador estimado a partir de los datos de Holded · No es una declaración oficial · Verifica
+      Borrador estimado a partir de tus datos contables · No es una declaración oficial · Verifica
       con tu asesor antes de presentar
     </p>
   );
@@ -738,7 +738,7 @@ export default function ModelosPage() {
       <div>
         <h1 className="text-xl font-semibold text-slate-900">Modelos AEAT</h1>
         <p className="text-sm text-slate-500 mt-1">
-          Borradores pre-rellenados con tus datos de Holded. Revisa y ajusta antes de presentar.
+          Borradores pre-rellenados desde tu contabilidad. Revisa y ajusta antes de presentar.
         </p>
       </div>
 

--- a/apps/isaak/app/(workspace)/fiscal/page.tsx
+++ b/apps/isaak/app/(workspace)/fiscal/page.tsx
@@ -158,7 +158,7 @@ export default function FiscalAlertsPage() {
           <div>
             <p className="text-[13px] font-semibold text-blue-900">Modelos AEAT — Borradores</p>
             <p className="text-[11px] text-blue-700 mt-0.5">
-              303 · 130 · 390 pre-rellenados con tus datos de Holded
+              303 · 130 · 390 pre-rellenados desde tus datos contables
             </p>
           </div>
           <ChevronDown size={16} className="rotate-[-90deg] text-blue-500 shrink-0" />

--- a/apps/isaak/app/(workspace)/informes/InformesClient.tsx
+++ b/apps/isaak/app/(workspace)/informes/InformesClient.tsx
@@ -155,7 +155,7 @@ export default function InformesClient({ year: initYear }: { year: number }) {
         ) : noHolded ? (
           <div className="flex flex-col items-center justify-center gap-3 py-16 text-center">
             <p className="text-sm text-slate-500">
-              Conecta tu cuenta de Holded para ver la cuenta de resultados en tiempo real.
+              Conecta tu ERP para ver la cuenta de resultados en tiempo real.
             </p>
             <a
               href="/settings/connections"

--- a/apps/isaak/app/(workspace)/resumen/page.tsx
+++ b/apps/isaak/app/(workspace)/resumen/page.tsx
@@ -301,7 +301,7 @@ async function DashboardContent() {
             icon: TrendingUp,
             label: 'Facturado este mes',
             value: '—',
-            sub: 'Conecta Holded para ver datos',
+            sub: 'Conecta tu ERP para ver datos',
             color: 'text-[#2361d8]',
             bg: 'bg-[#2361d8]/10',
           },

--- a/apps/isaak/app/auth/page.tsx
+++ b/apps/isaak/app/auth/page.tsx
@@ -5,7 +5,7 @@ import { buildIsaakAuthUrl, ISAAK_PUBLIC_URL } from '@/app/lib/isaak-navigation'
 
 export const metadata = {
   title: 'Acceder — Isaak',
-  description: 'Conecta tu cuenta para empezar a usar Isaak.',
+  description: 'Inicia sesión en Isaak, tu copiloto fiscal inteligente.',
 };
 
 export default function AuthPage() {
@@ -28,16 +28,16 @@ export default function AuthPage() {
           </div>
           <div className="text-center">
             <h1 className="text-2xl font-bold tracking-tight text-white">Isaak</h1>
-            <p className="mt-1 text-sm text-slate-400">Asistente fiscal inteligente</p>
+            <p className="mt-1 text-sm text-slate-400">Tu copiloto fiscal inteligente</p>
           </div>
         </div>
 
         {/* Card */}
         <div className="rounded-2xl border border-white/10 bg-white/5 p-6">
-          <h2 className="text-base font-semibold text-white">Conecta tu cuenta</h2>
+          <h2 className="text-base font-semibold text-white">Inicia sesión</h2>
           <p className="mt-2 text-sm leading-6 text-slate-400">
-            Isaak se conecta con tu contabilidad para darte respuestas con datos reales. Necesitas
-            una cuenta activa para continuar.
+            Accede para usar tu copiloto fiscal. Si es tu primera vez, crearemos la cuenta
+            automáticamente.
           </p>
 
           <Link
@@ -45,7 +45,7 @@ export default function AuthPage() {
             className="mt-5 flex w-full items-center justify-center gap-2 rounded-xl bg-[#2361d8] px-4 py-3 text-sm font-semibold text-white shadow-md transition hover:bg-[#1d55c2]"
           >
             <Sparkles className="h-4 w-4" />
-            Acceder a Isaak
+            Entrar a Isaak
           </Link>
 
           <p className="mt-4 text-center text-xs text-slate-600">


### PR DESCRIPTION
## Cambios post-merge tras smoke test en producción

Dos issues UX detectados al abrir Isaak por primera vez tras el deploy de PR #134.

### 1. Identidad propia — Holded solo es un conector más

El copy mezclaba `Isaak` con `Holded` como si fueran lo mismo. Isaak es el producto; Holded es uno de sus conectores. Limpieza de todas las menciones fuera de `/integrations`:

- **`/auth/page.tsx`**: "Conecta tu cuenta" → "Inicia sesión". Botón "Acceder a Isaak" → "Entrar a Isaak".
- **Empty state del chat**: "Conectar Holded →" → "Conectar tu contabilidad →"
- **`/fiscal`, `/fiscal/modelos`**: "datos de Holded" → "datos contables"
- **`/contactos`, `/equipo`, `/informes`, `/resumen`** estados vacíos: "Conecta Holded" → "Conecta tu ERP"

`/integrations` mantiene la mención (correcto: ahí se configura).

### 2. Sidebar auto-collapse en `/chat` (patrón Claude.ai)

Cuando estás en chat, la sidebar se aparta para dar espacio a la conversación.

**Política**:
- Preferencia explícita en localStorage → respetar siempre
- Sin preferencia + ruta `/chat/*` → auto-colapsar
- Sin preferencia + otra ruta → expandida

**Toggle en ambos estados**: ChevronLeft (expandida) o click sobre el logo (colapsada).

## Pendiente diferido

Login Firebase embebido en `apps/isaak` para no depender de `verifactu.business`. ~3-4h, otra sesión.

## Quality

- 917/917 tests verdes
- TypeScript clean
- Sin migraciones nuevas
- Sin breaking changes