### PR TITLE
refactor(isaak ui): completar cleanup Holded fuera del apartado de conectores

### DIFF
--- a/apps/isaak/app/(workspace)/contactos/ContactosClient.tsx
+++ b/apps/isaak/app/(workspace)/contactos/ContactosClient.tsx
@@ -87,7 +87,7 @@ export default function ContactosClient() {
           href="/settings/connections"
           className="rounded-lg bg-[#2361d8] px-4 py-2 text-sm font-medium text-white hover:bg-[#1a4fc4]"
         >
-          Conectar Holded
+          Conectar tu ERP
         </a>
       </div>
     );

--- a/apps/isaak/app/(workspace)/equipo/EquipoClient.tsx
+++ b/apps/isaak/app/(workspace)/equipo/EquipoClient.tsx
@@ -81,7 +81,7 @@ export default function EquipoClient() {
           href="/settings/connections"
           className="rounded-lg bg-[#2361d8] px-4 py-2 text-sm font-medium text-white hover:bg-[#1a4fc4]"
         >
-          Conectar Holded
+          Conectar tu ERP
         </a>
       </div>
     );
@@ -126,7 +126,7 @@ export default function EquipoClient() {
           employees.length === 0 ? (
             <div className="flex flex-col items-center justify-center gap-2 py-20">
               <Users2 size={32} className="text-slate-200" />
-              <p className="text-sm text-slate-400">Sin empleados en Holded.</p>
+              <p className="text-sm text-slate-400">Sin empleados registrados.</p>
             </div>
           ) : (
             <table className="w-full text-sm">
@@ -176,7 +176,7 @@ export default function EquipoClient() {
         ) : projects.length === 0 ? (
           <div className="flex flex-col items-center justify-center gap-2 py-20">
             <Briefcase size={32} className="text-slate-200" />
-            <p className="text-sm text-slate-400">Sin proyectos en Holded.</p>
+            <p className="text-sm text-slate-400">Sin proyectos registrados.</p>
           </div>
         ) : (
           <table className="w-full text-sm">

--- a/apps/isaak/app/(workspace)/fiscal/modelos/page.tsx
+++ b/apps/isaak/app/(workspace)/fiscal/modelos/page.tsx
@@ -97,21 +97,20 @@ function PlanRequiredBanner() {
   );
 }
 
-function HoldedNotConnectedBanner() {
+function ErpNotConnectedBanner() {
   return (
     <div className="rounded-xl border border-amber-200 bg-amber-50 p-5 flex gap-4 items-start">
       <Plug size={20} className="shrink-0 text-amber-500 mt-0.5" />
       <div className="flex-1">
-        <p className="font-semibold text-amber-900 text-sm">Holded no conectado</p>
+        <p className="font-semibold text-amber-900 text-sm">ERP no conectado</p>
         <p className="text-xs text-amber-700 mt-1">
-          Los modelos se calculan a partir de tus facturas en Holded. Conecta tu cuenta para
-          continuar.
+          Los modelos se calculan a partir de tus facturas. Conecta tu ERP para continuar.
         </p>
         <Link
           href="/settings?section=integrations"
           className="mt-3 inline-flex items-center gap-1.5 rounded-lg bg-amber-600 px-4 py-2 text-xs font-semibold text-white hover:bg-amber-700"
         >
-          Conectar Holded <ExternalLink size={12} />
+          Conectar tu ERP <ExternalLink size={12} />
         </Link>
       </div>
     </div>
@@ -129,7 +128,7 @@ function GenericErrorBanner({ message }: { message: string }) {
 
 function ErrorBanner({ type, message }: { type: ApiError; message: string }) {
   if (type === 'plan_required') return <PlanRequiredBanner />;
-  if (type === 'no_holded') return <HoldedNotConnectedBanner />;
+  if (type === 'no_holded') return <ErpNotConnectedBanner />;
   return <GenericErrorBanner message={message} />;
 }
 

--- a/apps/isaak/app/(workspace)/gastos/GastosClient.tsx
+++ b/apps/isaak/app/(workspace)/gastos/GastosClient.tsx
@@ -145,7 +145,7 @@ function UploadPanel({ onClose, onSuccess }: { onClose: () => void; onSuccess: (
         {step === 'done' && (
           <div className="flex flex-col items-center gap-3 py-10">
             <CheckCircle2 size={32} className="text-emerald-500" />
-            <p className="text-sm font-medium text-emerald-700">Gasto registrado en Holded</p>
+            <p className="text-sm font-medium text-emerald-700">Gasto registrado en tu ERP</p>
           </div>
         )}
 
@@ -230,7 +230,7 @@ function UploadPanel({ onClose, onSuccess }: { onClose: () => void; onSuccess: (
                 className="flex flex-1 items-center justify-center gap-1.5 rounded-xl bg-[#2361d8] py-2 text-sm font-semibold text-white hover:bg-[#1f55c0] disabled:opacity-60"
               >
                 {step === 'saving' ? <Loader2 size={14} className="animate-spin" /> : null}
-                Registrar en Holded
+                Registrar en mi ERP
               </button>
             </div>
           </div>
@@ -401,15 +401,16 @@ export default function GastosClient() {
           <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-amber-50">
             <Plug size={24} className="text-amber-500" />
           </div>
-          <p className="text-[16px] font-semibold text-[#011c67]">Holded no conectado</p>
+          <p className="text-[16px] font-semibold text-[#011c67]">ERP no conectado</p>
           <p className="mt-2 text-[13px] leading-relaxed text-slate-500">
-            Los gastos se cargan desde Holded. Conecta tu cuenta para ver tus compras y proveedores.
+            Los gastos se cargan desde tu ERP. Conecta tu contabilidad para ver tus compras y
+            proveedores.
           </p>
           <Link
             href="/settings?section=integrations"
             className="mt-4 inline-flex items-center gap-1.5 rounded-xl bg-[#2361d8] px-4 py-2 text-sm font-semibold text-white hover:bg-[#1f55c0]"
           >
-            Conectar Holded
+            Conectar tu ERP
           </Link>
         </div>
       </div>

--- a/apps/isaak/app/(workspace)/informes/InformesClient.tsx
+++ b/apps/isaak/app/(workspace)/informes/InformesClient.tsx
@@ -161,7 +161,7 @@ export default function InformesClient({ year: initYear }: { year: number }) {
               href="/settings/connections"
               className="rounded-lg bg-[#2361d8] px-4 py-2 text-sm font-medium text-white hover:bg-[#1a4fc4]"
             >
-              Conectar Holded
+              Conectar tu ERP
             </a>
           </div>
         ) : !s ? (

--- a/apps/isaak/app/(workspace)/mail/page.tsx
+++ b/apps/isaak/app/(workspace)/mail/page.tsx
@@ -124,7 +124,7 @@ export default function MailPage() {
           Gmail — Facturas de proveedores
         </h1>
         <p className="text-[12px] text-slate-500">
-          Detecta emails con facturas adjuntas y procésalos directamente como gasto en Holded
+          Detecta emails con facturas adjuntas y procésalos directamente como gasto en tu ERP
         </p>
       </div>
 

--- a/apps/isaak/app/(workspace)/resumen/page.tsx
+++ b/apps/isaak/app/(workspace)/resumen/page.tsx
@@ -529,7 +529,7 @@ export default function ResumenPage() {
       <div className="border-b border-slate-100 bg-[#fafbff] px-5 py-4">
         <h1 className="text-[16px] font-semibold text-[#011c67]">Resumen de tu empresa</h1>
         <p className="text-[12px] text-slate-500">
-          Estado general · datos en tiempo real desde Holded
+          Estado general · datos en tiempo real desde tu ERP
         </p>
       </div>
 

--- a/apps/isaak/app/asesorias/page.tsx
+++ b/apps/isaak/app/asesorias/page.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 export const metadata: Metadata = {
   title: 'Isaak | Asesorias',
   description:
-    'Isaak ayuda a asesorias a preparar resumentes, alertas y proximos pasos sobre clientes que trabajan con Excel, Holded y documentacion dispersa.',
+    'Isaak ayuda a asesorias a preparar resumentes, alertas y proximos pasos sobre clientes que trabajan con Excel, su ERP y documentacion dispersa.',
 };
 
 export default function IsaakAdvisorPage() {
@@ -19,7 +19,7 @@ export default function IsaakAdvisorPage() {
         </h1>
         <p className="mt-5 max-w-3xl text-lg leading-8 text-slate-600">
           Isaak ayuda a convertir datos dispersos en resumentes, alertas y proximos pasos para la
-          asesoria. Trabaja con clientes que operan con Excel, con Holded o con documentacion
+          asesoria. Trabaja con clientes que operan con Excel, con su ERP o con documentacion
           dispersa.
         </p>
         <div className="mt-10 flex flex-col gap-3 sm:flex-row">

--- a/apps/isaak/app/components/IsaakHomeLanding.tsx
+++ b/apps/isaak/app/components/IsaakHomeLanding.tsx
@@ -216,7 +216,7 @@ const PRICE_TEASER = [
     id: 'starter',
     name: 'Starter',
     price: '19 €',
-    tagline: 'Software sectorial · Holded · Gestión financiera en tiempo real',
+    tagline: 'Software sectorial · ERP conectado · Gestión financiera en tiempo real',
     cta: 'Empezar ahora',
     href: '/signup?plan=starter',
     highlight: false,
@@ -246,7 +246,7 @@ const PRICE_TEASER = [
 export const landingMetadata: Metadata = {
   title: 'Isaak | IA empresarial que libera el 80% de tu tiempo',
   description:
-    'Isaak es la capa de inteligencia encima del software que ya usas: HotelGest, Revo, Nubimed, Holded. Gestión fiscal, alertas proactivas y CFO digital en un chat. Empieza gratis.',
+    'Isaak es la capa de inteligencia encima del software que ya usas: HotelGest, Revo, Nubimed, tu ERP. Gestión fiscal, alertas proactivas y CFO digital en un chat. Empieza gratis.',
 };
 
 export default function IsaakHomeLanding() {
@@ -719,7 +719,7 @@ export default function IsaakHomeLanding() {
                 {[
                   { value: '-80%', label: 'Tiempo en consultas recurrentes' },
                   { value: '6+', label: 'Clientes gestionados con Isaak' },
-                  { value: '100%', label: 'Acceso a datos Holded + API' },
+                  { value: '100%', label: 'Acceso a datos del ERP + API' },
                   { value: '1ª', label: 'Asesoría beta tester en España' },
                 ].map(({ value, label }) => (
                   <div key={label} className="rounded-2xl border border-white/10 bg-white/5 p-5">
@@ -859,7 +859,7 @@ export default function IsaakHomeLanding() {
             applicationCategory: 'BusinessApplication',
             operatingSystem: 'Web',
             description:
-              'Copiloto fiscal y contable de IA para la pyme española. Capa de inteligencia encima de HotelGest, Revo, Nubimed, Holded y banca. Gestión fiscal, alertas proactivas y CFO digital en un chat.',
+              'Copiloto fiscal y contable de IA para la pyme española. Capa de inteligencia encima de HotelGest, Revo, Nubimed, tu ERP y banca. Gestión fiscal, alertas proactivas y CFO digital en un chat.',
             offers: {
               '@type': 'Offer',
               price: '0',

--- a/apps/isaak/app/components/IsaakLandingClient.tsx
+++ b/apps/isaak/app/components/IsaakLandingClient.tsx
@@ -234,7 +234,7 @@ export default function IsaakLandingClient() {
       >
         <p className="mb-5 text-sm text-slate-500">
           Habla con Isaak sin registrarte. Aquí verás su tono y criterio. Para datos reales conecta
-          tu Holded.
+          tu ERP.
         </p>
         <IsaakPublicChat />
       </Modal>
@@ -410,8 +410,8 @@ export default function IsaakLandingClient() {
               Conecta donde ya trabajas
             </h2>
             <p className="mt-3 text-base text-slate-600">
-              Isaak está disponible en Claude, ChatGPT y su propio workspace con integración nativa
-              de Holded.
+              Isaak está disponible en Claude, ChatGPT y su propio workspace con conectores nativos
+              a tu ERP y banca.
             </p>
           </div>
           <div className="grid gap-4 md:grid-cols-3">
@@ -544,13 +544,13 @@ export default function IsaakLandingClient() {
           </p>
         </div>
 
-        {/* ── Holded capabilities ── */}
+        {/* ── ERP capabilities ── */}
         <div className="mx-auto mt-6 max-w-5xl rounded-2xl border border-[#2361d8]/20 bg-[#2361d8]/5 p-6 shadow-sm">
           <h2 className="text-lg font-semibold text-[#011c67]">
-            Capacidades reales hoy con Holded
+            Capacidades reales hoy con tu ERP conectado
           </h2>
           <p className="mt-3 text-sm leading-6 text-slate-700">
-            Estas son capacidades ya disponibles en producción cuando conectas Holded.
+            Estas son capacidades ya disponibles en producción cuando conectas tu ERP.
           </p>
           <ul className="mt-4 space-y-2 text-sm leading-6 text-slate-700">
             <li className="flex items-start gap-2">

--- a/apps/isaak/app/components/IsaakPublicPhase1Landing.tsx
+++ b/apps/isaak/app/components/IsaakPublicPhase1Landing.tsx
@@ -157,7 +157,7 @@ export default function IsaakPublicPhase1Landing() {
                     Modo conectado / API
                   </div>
                   <p className="mt-3 text-sm leading-7 text-slate-600">
-                    Para empresas que ya usan Holded, bancos, CRM o ecommerce. Isaak lee, cruza y
+                    Para empresas que ya usan ERP, bancos, CRM o ecommerce. Isaak lee, cruza y
                     ayuda a ejecutar tareas con permisos configurados.
                   </p>
                 </article>

--- a/apps/isaak/app/error.tsx
+++ b/apps/isaak/app/error.tsx
@@ -28,8 +28,8 @@ export default function IsaakErrorPage({ error, reset }: Props) {
                 Isaak no ha podido abrir esta pantalla, pero tu acceso sigue a salvo
               </h1>
               <p className="mt-4 max-w-2xl text-base leading-8 text-slate-600">
-                Puede ser una incidencia temporal del servidor o un paso a medias entre Holded e
-                Isaak. Reintenta y deberias poder continuar sin perder tu contexto.
+                Puede ser una incidencia temporal del servidor o un paso a medias en el acceso.
+                Reintenta y deberias poder continuar sin perder tu contexto.
               </p>
 
               <div className="mt-7 flex flex-col gap-3 sm:flex-row">
@@ -65,7 +65,7 @@ export default function IsaakErrorPage({ error, reset }: Props) {
                 </div>
                 <ul className="mt-4 space-y-3 text-sm leading-6 text-slate-600">
                   <li>1. Pulsa reintentar. Muchas incidencias se resuelven en segundos.</li>
-                  <li>2. Si estabas entrando desde Holded, repite el ultimo paso del acceso.</li>
+                  <li>2. Si estabas entrando desde un conector, repite el ultimo paso del acceso.</li>
                   <li>3. Si el problema persiste, escribenos a soporte@verifactu.business.</li>
                 </ul>
                 {error.digest ? (

--- a/apps/isaak/app/layout.tsx
+++ b/apps/isaak/app/layout.tsx
@@ -26,7 +26,7 @@ export const metadata: Metadata = {
   metadataBase: new URL(siteUrl),
   title: 'Isaak — Libera el 80% de tu tiempo de gestión empresarial',
   description:
-    'Isaak es la IA protagonista que conecta Holded, bancos, documentos y correo para que el empresario dirija sin gestionar. 99% menos errores. Disponible 24/7.',
+    'Isaak es la IA protagonista que conecta tu ERP, bancos, documentos y correo para que el empresario dirija sin gestionar. 99% menos errores. Disponible 24/7.',
   alternates: {
     canonical: '/',
   },
@@ -34,7 +34,7 @@ export const metadata: Metadata = {
     'IA empresarial',
     'automatización gestión',
     'orquestador empresarial',
-    'holded IA',
+    'copiloto fiscal IA',
     'contabilidad automática',
     'asesor fiscal inteligente',
   ],
@@ -46,7 +46,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: 'Isaak — Libera el 80% de tu tiempo de gestión empresarial',
     description:
-      'La IA que conecta Holded, bancos, documentos y correo. 99% menos errores. 24/7. El empresario dirige, no gestiona.',
+      'La IA que conecta tu ERP, bancos, documentos y correo. 99% menos errores. 24/7. El empresario dirige, no gestiona.',
     url: siteUrl,
     siteName: 'Isaak',
     images: [{ url: avatarPath, width: 512, height: 512, alt: 'Avatar de Isaak' }],


### PR DESCRIPTION
## Contexto

Smoke test post-merge de PR #135 detectó strings residuales que escaparon. PR #135 cambió párrafos pero olvidó botones y otros strings visibles con "Holded" en 7 archivos in-app + 4 landing.

Esta PR completa el cleanup pedido: "tenemos que quitar cualquier mención a Holded, excepto el apartado de conectores. Solo es un conector más."

## Cambios

### In-app `/(workspace)/` — botones y banners

- **gastos**: empty state, banner success y CTA "Registrar"
- **fiscal/modelos**: `HoldedNotConnectedBanner` → `ErpNotConnectedBanner`
- **informes, equipo, contactos**: CTA "Conectar Holded" → "Conectar tu ERP"
- **equipo**: empty states "Sin empleados/proyectos en Holded" → sin "Holded"
- **mail**: subtítulo "como gasto en Holded" → "en tu ERP"
- **resumen**: subtítulo "datos desde Holded" → "desde tu ERP"

### Landing isaak.app — posicionamiento

- **layout.tsx**: meta description, OG, keywords SEO
- **error.tsx**: copy genérico "incidencia temporal" sin nombrar Holded
- **asesorias**: clientes que operan con "Excel, su ERP o documentación"
- **IsaakHomeLanding**: tagline Starter + meta + JSON-LD + label stat
- **IsaakLandingClient**: demo CTA + integración nativa + capacidades hoy
- **IsaakPublicPhase1Landing**: hero "ERP, bancos, CRM"

### Por diseño se mantienen Holded en:

- `/(workspace)/settings`, `/advisor`, `/integrations` (apartado conectores)
- `/conectores`, `/developers` (catálogo y docs de conectores)
- Tarjetas "Holded → Claude/ChatGPT" MCP en landing (productos específicos)
- Cross-link banner "Vienes de Holded?" en phase 1 (connector cross-promo)
- FAQ que explicita "Holded es UNA integración, Isaak es el producto"

## Verificación

- **Tests**: 917/917 verdes (56 suites)
- **Typecheck**: limpio
- **Diff**: 13 archivos, 37/37 líneas balanceadas

## Test plan

- [ ] Visitar `/gastos`, `/contactos`, `/equipo`, `/informes`, `/fiscal/modelos`, `/mail`, `/resumen` sin ERP conectado → empty states genéricos ("Conectar tu ERP" en vez de "Conectar Holded")
- [ ] Visitar landing pública `isaak.app/` → meta tags, capacidades, demo CTA sin Holded como protagonista
- [ ] Visitar `/conectores` y `/integrations` → Holded sigue visible (es el apartado)
- [ ] Confirmar que la página de error genérica no menciona Holded