### PR TITLE
fix: incoherencias residuales — P0 ShieldCheck + P1 admin rebrand + conectores copy

### DIFF
--- a/apps/admin/app/global-error.tsx
+++ b/apps/admin/app/global-error.tsx
@@ -17,7 +17,7 @@ export default function AdminGlobalError({ error, reset }: ErrorPageProps) {
               Incidencia temporal
             </div>
             <h1 className="mt-5 text-3xl font-bold tracking-tight text-slate-950 sm:text-4xl">
-              Holded Admin necesita reiniciarse
+              Verifactu Admin necesita reiniciarse
             </h1>
             <p className="mt-4 max-w-2xl text-base leading-8 text-slate-600">
               El error se ha aislado para proteger la sesion y el estado del panel. Puedes

--- a/apps/admin/app/layout.tsx
+++ b/apps/admin/app/layout.tsx
@@ -6,14 +6,13 @@ import PwaRegistration from '@/components/pwa/PwaRegistration';
 export const dynamic = 'force-dynamic';
 
 export const metadata: Metadata = {
-  title: 'Holded Admin',
-  description:
-    'Panel interno para observar usuarios, tenants y actividad operativa del canal Holded.',
-  applicationName: 'Holded Admin',
+  title: 'Verifactu Admin',
+  description: 'Panel interno para observar usuarios, tenants y actividad operativa de Verifactu.',
+  applicationName: 'Verifactu Admin',
   manifest: '/manifest.webmanifest',
   appleWebApp: {
     capable: true,
-    title: 'Holded Admin',
+    title: 'Verifactu Admin',
     statusBarStyle: 'default',
   },
   icons: {

--- a/apps/admin/app/manifest.ts
+++ b/apps/admin/app/manifest.ts
@@ -2,10 +2,9 @@ import type { MetadataRoute } from 'next';
 
 export default function manifest(): MetadataRoute.Manifest {
   return {
-    name: 'Holded Admin',
-    short_name: 'Holded Admin',
-    description:
-      'Panel interno para observar usuarios, tenants y actividad operativa del canal Holded.',
+    name: 'Verifactu Admin',
+    short_name: 'Verifactu Admin',
+    description: 'Panel interno para observar usuarios, tenants y actividad operativa de Verifactu.',
     start_url: '/panel',
     scope: '/',
     display: 'standalone',

--- a/apps/isaak/app/(workspace)/components/IsaakSidebar.tsx
+++ b/apps/isaak/app/(workspace)/components/IsaakSidebar.tsx
@@ -29,6 +29,7 @@ import {
   Plus,
   Receipt,
   ShieldAlert,
+  ShieldCheck,
   Sparkles,
   IdCard,
   TrendingUp,

--- a/apps/isaak/app/components/IsaakPublicPhase1Landing.tsx
+++ b/apps/isaak/app/components/IsaakPublicPhase1Landing.tsx
@@ -263,10 +263,11 @@ export default function IsaakPublicPhase1Landing() {
           </div>
           <div className="mt-10 rounded-[2rem] border border-slate-200 bg-[#011c67] p-8 text-white shadow-sm">
             <h2 className="text-2xl font-semibold">
-              Conecta Holded y futuros sistemas sin convertir a Isaak en un plugin.
+              Conecta tu ERP, bancos y herramientas sin convertir a Isaak en un plugin.
             </h2>
             <p className="mt-4 max-w-3xl text-sm leading-7 text-blue-100">
-              Holded es el primer ecosistema conectado. El hub vertical vive en un dominio separado
+              Isaak orquesta varios ecosistemas conectados: ERPs (Holded), banca (Enable Banking,
+              Salt Edge), Google, Microsoft 365 y AEAT. Cada hub vertical vive en su propio dominio
               para proteger el flujo publico minimo del conector y mantener a Isaak como producto
               orquestador principal.
             </p>

--- a/apps/isaak/app/conectores/page.tsx
+++ b/apps/isaak/app/conectores/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from 'next';
 export const metadata: Metadata = {
   title: 'Isaak | Conectores y modo conectado',
   description:
-    'Modo conectado para trabajar con Holded y futuras herramientas empresariales sin convertir a Isaak en un ERP ni en un plugin aislado.',
+    'Modo conectado para trabajar con tu ERP, bancos, CRM y herramientas empresariales sin convertir a Isaak en un ERP ni en un plugin aislado.',
 };
 
 export default function IsaakConnectorsPage() {
@@ -17,15 +17,15 @@ export default function IsaakConnectorsPage() {
           Conecta herramientas empresariales sin convertir a Isaak en otro ERP.
         </h1>
         <p className="mt-5 max-w-3xl text-lg leading-8 text-slate-600">
-          Holded es el primer ecosistema conectado. Despues vendran bancos, CRM, ecommerce y otras
-          fuentes. Isaak usa conectores para interpretar y operar sobre informacion existente con
-          permisos y trazabilidad.
+          Isaak conecta ERPs, bancos (Enable Banking, Salt Edge), Google, Microsoft 365, WhatsApp y
+          la AEAT. Holded es uno de los conectores. Isaak usa conectores para interpretar y operar
+          sobre informacion existente con permisos y trazabilidad.
         </p>
         <a
           href="https://holded.verifactu.business/conectores"
           className="mt-8 inline-flex items-center justify-center rounded-full bg-[#2361d8] px-6 py-3 text-sm font-semibold text-white hover:bg-[#1f55c0]"
         >
-          Ver conectores Holded
+          Ver catalogo de conectores
         </a>
       </div>
     </main>

--- a/apps/landing/README.md
+++ b/apps/landing/README.md
@@ -1,4 +1,4 @@
-# VeriFactu Business — Landing Pública
+# Verifactu Business — Landing Pública
 
 Landing oficial de **verifactu.business**, desplegada en **Vercel** y construida con **Next.js (App Router)**.
 


### PR DESCRIPTION
## Contexto

Auditoría post-cleanup (PR #135/#136) detectó incoherencias residuales. Esta PR ataca P0 y P1 quirúrgicamente.

## Cambios

### P0 — Bug crítico
- **`IsaakSidebar.tsx`**: `ShieldCheck` se usaba en líneas 496 y 566 sin importar de `lucide-react`. Build TS rojo preexistente. Añadido al import group.
  - Isaak typecheck: 18 → 16 errores TS (-2)

### P1 — Branding admin panel
- **`apps/admin`** se llamaba **"Holded Admin"** en title, manifest y error page. Pero el panel es interno multi-producto (no específico de Holded). Renombrado a **"Verifactu Admin"** en:
  - `app/layout.tsx` (metadata.title, applicationName, appleWebApp.title, description)
  - `app/manifest.ts` (name, short_name, description)
  - `app/global-error.tsx` (h1)

### P1 — Copy /conectores y phase1 landing
- **`/conectores`** decía _"Holded es el primer ecosistema conectado"_. Tras cleanup, Holded es **uno más** entre Enable Banking, Salt Edge, Google, M365, AEAT y WhatsApp. Reescrito para listar ecosistemas como conjunto + CTA "Ver catalogo de conectores".
- **`IsaakPublicPhase1Landing`**: hero "Conecta tu ERP, bancos y herramientas" + párrafo neutral sobre múltiples hubs verticales.

### P1 — Capitalización marca
- **`apps/landing/README.md`**: "VeriFactu Business" → "Verifactu Business" en h1.
- **NOTA importante**: las 228 ocurrencias de "VeriFactu" en código fueron auditadas y son **CORRECTAS**. "VeriFactu" es el nombre oficial del **sistema AEAT** (Verificación de Facturas), distinto de nuestra marca **"Verifactu"** (verifactu.business). El auditor inicial sugirió globalizar pero sería incorrecto.

## Skipped por riesgo regulatorio

- **`localhost:3000`** en `/developers` card ChatGPT MCP: es el dev-flow con MCP Inspector + `MCP_SHARED_SECRET`. Modificarlo podría interpretarse como cambio durante **revisión OpenAI** (CLAUDE.md regla crítica: _"Nada de tools nuevas, cambios de URL, ni cambios de comportamiento hasta aprobación"_).
- **`localhost:6274`** (MCP Inspector): URL local del tool del developer, por diseño.

## Diferido (próxima tanda)

- 11 tests rotos preexistentes (`accept.test.ts`, `holded-session.test.ts`) → PR dedicada
- Crons faltantes en `vercel.json` → análisis de impacto pendiente
- TODOs antiguos → triage roadmap
- Env vars `HOLDED_FIREBASE_*` consolidación → discusión arquitectura

## Verificación

- Isaak typecheck: **16** errores (main tenía 18 — **-2** por ShieldCheck import)
- Admin typecheck: **0** errores
- Sin cambios de runtime behavior
- Sin migraciones

## Test plan

- [ ] Vercel deploy verde para isaak + admin + landing
- [ ] Verificar título de la PWA del panel admin tras instalación: muestra "Verifactu Admin"
- [ ] Visitar `/conectores` y phase1 landing: copy refleja "Holded uno más"
- [ ] IsaakSidebar renderiza icono ShieldCheck sin crash (líneas 496, 566)