### PR TITLE
feat(developers): doc hub interactivo — Scalar OpenAPI + errors + rate limits + webhooks

### DIFF
--- a/apps/landing/app/developers/api/ScalarClient.tsx
+++ b/apps/landing/app/developers/api/ScalarClient.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { ApiReferenceReact } from '@scalar/api-reference-react';
+import '@scalar/api-reference-react/style.css';
+
+export default function ScalarClient() {
+  return (
+    <ApiReferenceReact
+      configuration={{
+        url: '/openapi/isaak-v1.yaml',
+        theme: 'default',
+        hideClientButton: false,
+        showSidebar: true,
+        hideDownloadButton: false,
+        layout: 'modern',
+        defaultHttpClient: { targetKey: 'shell', clientKey: 'curl' },
+        metaData: {
+          title: 'Isaak Platform API — Referencia',
+          description:
+            'Referencia interactiva de la API REST de Isaak Platform v1 con autenticación, scopes y ejemplos ejecutables.',
+        },
+      }}
+    />
+  );
+}

--- a/apps/landing/app/developers/api/page.tsx
+++ b/apps/landing/app/developers/api/page.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from 'next';
+import ScalarClient from './ScalarClient';
+
+export const metadata: Metadata = {
+  title: 'API Reference | Isaak Platform — Verifactu Business',
+  description:
+    'Referencia interactiva de la API REST de Isaak Platform v1. OpenAPI 3.1, autenticación Bearer, scopes y ejemplos curl ejecutables.',
+  openGraph: {
+    title: 'Isaak Platform API — Referencia interactiva',
+    description:
+      'Documentación completa de los endpoints REST de Isaak. Prueba peticiones directamente desde el navegador.',
+    type: 'website',
+    locale: 'es_ES',
+    url: 'https://verifactu.business/developers/api',
+    siteName: 'Verifactu Business',
+  },
+  alternates: {
+    canonical: '/developers/api',
+  },
+};
+
+export default function ApiReferencePage() {
+  return (
+    <main className="min-h-screen bg-white">
+      <ScalarClient />
+    </main>
+  );
+}

--- a/apps/landing/app/developers/errors/page.tsx
+++ b/apps/landing/app/developers/errors/page.tsx
@@ -1,0 +1,252 @@
+import { AlertCircle, ArrowLeft } from 'lucide-react';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import Header from '../../components/Header';
+import { Container, Footer } from '../../lib/home/ui';
+
+export const metadata: Metadata = {
+  title: 'Error codes | Isaak Platform API — Verifactu Business',
+  description:
+    'Referencia de códigos de error de la API REST de Isaak Platform. Códigos HTTP, formato del envelope y guía de manejo.',
+  alternates: { canonical: '/developers/errors' },
+};
+
+const navLinks = [
+  { label: 'VeriFactu', href: '/verifactu/que-es' },
+  { label: 'Que es Isaak', href: '/que-es-isaak' },
+  { label: 'Conectores', href: '/conectores' },
+  { label: 'Precios', href: '/precios' },
+  { label: 'Developers', href: '/developers' },
+];
+
+const ERROR_ENVELOPE = `{
+  "ok": false,
+  "error": {
+    "code": "scope_insufficient",
+    "message": "El token no tiene scope 'isaak.invoices.write'."
+  },
+  "requestId": "req_2026_01_15_abc123"
+}`;
+
+const HTTP_STATUS = [
+  {
+    status: 400,
+    code: 'bad_request',
+    when: 'Body o query string mal formado (JSON inválido, parámetros incompatibles).',
+    fix: 'Validar el payload contra el OpenAPI spec antes de enviar.',
+  },
+  {
+    status: 401,
+    code: 'unauthorized',
+    when: 'Token ausente, mal formado, expirado o revocado.',
+    fix: 'Comprobar el header Authorization. Renovar la API key desde el dashboard.',
+  },
+  {
+    status: 403,
+    code: 'scope_insufficient',
+    when: 'El token es válido pero no tiene el scope requerido para esa ruta.',
+    fix: 'Crear una nueva API key con el scope correcto (ej. isaak.invoices.write).',
+  },
+  {
+    status: 404,
+    code: 'not_found',
+    when: 'El recurso solicitado (factura, contacto, etc.) no existe o no pertenece a tu tenant.',
+    fix: 'Verificar el ID. Recursos de otros tenants devuelven 404 (no 403) por seguridad.',
+  },
+  {
+    status: 409,
+    code: 'conflict',
+    when: 'Estado del recurso incompatible con la acción (ej. emitir factura ya emitida).',
+    fix: 'Releer el estado actual con GET antes de reintentar.',
+  },
+  {
+    status: 422,
+    code: 'validation_error',
+    when: 'Datos válidos sintácticamente pero no semánticamente (NIF inválido, fecha futura, etc.).',
+    fix: 'El campo `error.message` indica qué falla. Corregir y reintentar.',
+  },
+  {
+    status: 428,
+    code: 'confirmation_required',
+    when: 'La acción es irreversible (emisión AEAT). Se requiere un segundo POST con el confirmationToken.',
+    fix: 'Mostrar el `preview` al usuario, capturar consentimiento, reenviar con el token.',
+  },
+  {
+    status: 429,
+    code: 'rate_limit_exceeded',
+    when: 'Has superado el límite de peticiones por minuto.',
+    fix: 'Respetar el header Retry-After. Implementar backoff exponencial.',
+  },
+  {
+    status: 500,
+    code: 'internal_error',
+    when: 'Error inesperado en Isaak. Si persiste, reportar el `requestId`.',
+    fix: 'Reintentar con backoff. Si pasa varias veces, escribir a soporte@verifactu.business.',
+  },
+  {
+    status: 502,
+    code: 'aeat_unavailable',
+    when: 'AEAT no responde o devuelve error temporal en el SOAP.',
+    fix: 'Reintentar a los 30s. Isaak no marca la factura como fallida hasta varios intentos.',
+  },
+  {
+    status: 503,
+    code: 'maintenance',
+    when: 'Mantenimiento programado. Verifactu publica avisos en status.verifactu.business.',
+    fix: 'Reintentar pasada la ventana. Esperar el header Retry-After si lo hay.',
+  },
+];
+
+const APP_CODES = [
+  { code: 'aeat_rejected', desc: 'AEAT rechazó el registro VeriFactu por validación oficial.' },
+  { code: 'aeat_duplicate', desc: 'Hash VeriFactu ya presente. Implica reenvío de factura emitida.' },
+  { code: 'confirmation_token_expired', desc: 'El token de confirmación caducó (TTL 5 min).' },
+  { code: 'plan_required', desc: 'La ruta requiere un plan superior (típicamente Business).' },
+  { code: 'tenant_blocked', desc: 'El tenant está suspendido. Contactar a soporte.' },
+  { code: 'key_revoked', desc: 'La API key fue revocada manualmente desde el dashboard.' },
+  { code: 'certificate_missing', desc: 'No hay certificado mTLS configurado para emitir a AEAT.' },
+  { code: 'idempotency_replay', desc: 'Idempotency-Key ya usada con un payload distinto.' },
+];
+
+export default function ErrorsPage() {
+  return (
+    <div className="min-h-screen bg-white text-slate-900">
+      <Header navLinks={navLinks} />
+
+      <section className="border-b border-slate-200 bg-[linear-gradient(180deg,#fff8f4_0%,#ffffff_70%)] py-14 sm:py-16">
+        <Container>
+          <div className="max-w-4xl">
+            <Link
+              href="/developers"
+              className="inline-flex items-center gap-1.5 text-sm font-medium text-[#2361d8] hover:underline"
+            >
+              <ArrowLeft className="h-4 w-4" />
+              Volver a Developers
+            </Link>
+            <div className="mt-6 inline-flex items-center gap-2 rounded-full border border-amber-200 bg-amber-50 px-4 py-1.5 text-xs font-semibold uppercase tracking-[0.16em] text-amber-700">
+              <AlertCircle className="h-3.5 w-3.5" />
+              Error codes · Referencia
+            </div>
+            <h1 className="mt-5 text-4xl font-bold tracking-tight text-[#011c67] sm:text-5xl">
+              Manejo de errores
+            </h1>
+            <p className="mt-4 max-w-3xl text-lg leading-8 text-slate-600">
+              Toda la API REST de Isaak devuelve errores con el mismo envelope. Los códigos HTTP
+              indican la familia; el campo <code className="rounded bg-slate-100 px-1 py-0.5 text-sm">error.code</code> identifica el motivo exacto.
+            </p>
+          </div>
+        </Container>
+      </section>
+
+      <section className="border-t border-slate-100 py-12">
+        <Container>
+          <div className="max-w-4xl">
+            <h2 className="text-2xl font-bold text-[#011c67]">Formato del envelope</h2>
+            <p className="mt-3 text-slate-600">
+              Cuando <code className="rounded bg-slate-100 px-1 py-0.5 text-sm">ok = false</code>, la respuesta sigue siempre este shape. El campo{' '}
+              <code className="rounded bg-slate-100 px-1 py-0.5 text-sm">requestId</code> permite correlacionar con nuestros logs si abres un ticket.
+            </p>
+            <div className="mt-6 overflow-hidden rounded-2xl border border-slate-200">
+              <div className="flex items-center gap-2 border-b border-slate-200 bg-slate-800 px-4 py-3">
+                <div className="h-2.5 w-2.5 rounded-full bg-red-500" />
+                <div className="h-2.5 w-2.5 rounded-full bg-amber-400" />
+                <div className="h-2.5 w-2.5 rounded-full bg-emerald-500" />
+                <span className="ml-2 text-xs font-medium text-slate-400">application/json</span>
+              </div>
+              <pre className="overflow-x-auto bg-slate-900 p-6 text-sm leading-7 text-slate-200">
+                <code>{ERROR_ENVELOPE}</code>
+              </pre>
+            </div>
+          </div>
+        </Container>
+      </section>
+
+      <section className="border-t border-slate-100 py-12">
+        <Container>
+          <div className="max-w-5xl">
+            <h2 className="text-2xl font-bold text-[#011c67]">Códigos HTTP</h2>
+            <p className="mt-3 text-slate-600">
+              El status HTTP indica la familia del error. Usa <code className="rounded bg-slate-100 px-1 py-0.5 text-sm">error.code</code> para discriminar dentro de cada familia.
+            </p>
+            <div className="mt-6 overflow-hidden rounded-2xl border border-slate-200">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-slate-200 bg-slate-50">
+                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-slate-500">Status</th>
+                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-slate-500">error.code</th>
+                    <th className="hidden px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-slate-500 sm:table-cell">Cuándo</th>
+                    <th className="hidden px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-slate-500 lg:table-cell">Acción recomendada</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-100">
+                  {HTTP_STATUS.map((row) => (
+                    <tr key={row.status} className="align-top hover:bg-slate-50/50">
+                      <td className="px-4 py-3">
+                        <span className="inline-block rounded-md bg-amber-100 px-2 py-0.5 text-xs font-bold text-amber-800">
+                          {row.status}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3">
+                        <code className="text-xs font-mono text-slate-800">{row.code}</code>
+                      </td>
+                      <td className="hidden px-4 py-3 text-slate-600 sm:table-cell">{row.when}</td>
+                      <td className="hidden px-4 py-3 text-slate-500 lg:table-cell">{row.fix}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </Container>
+      </section>
+
+      <section className="border-t border-slate-100 py-12">
+        <Container>
+          <div className="max-w-5xl">
+            <h2 className="text-2xl font-bold text-[#011c67]">Códigos de aplicación</h2>
+            <p className="mt-3 text-slate-600">
+              Valores específicos del campo <code className="rounded bg-slate-100 px-1 py-0.5 text-sm">error.code</code> que conviene
+              tratar de forma explícita en el cliente.
+            </p>
+            <div className="mt-6 grid gap-3 sm:grid-cols-2">
+              {APP_CODES.map((row) => (
+                <div key={row.code} className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+                  <code className="text-xs font-mono font-semibold text-[#011c67]">{row.code}</code>
+                  <p className="mt-1 text-sm text-slate-600">{row.desc}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </Container>
+      </section>
+
+      <section className="border-t border-slate-100 py-12">
+        <Container>
+          <div className="max-w-3xl">
+            <h2 className="text-2xl font-bold text-[#011c67]">Retry y backoff</h2>
+            <ul className="mt-4 space-y-3 text-slate-600">
+              <li>
+                <strong className="text-slate-900">5xx, 429, 502</strong> son <em>safe to retry</em>{' '}
+                con backoff exponencial. Empieza en 1s y duplica hasta un máximo de 30s.
+              </li>
+              <li>
+                <strong className="text-slate-900">4xx</strong> (excepto 429) requieren cambio en el
+                cliente — no reintentar el mismo payload.
+              </li>
+              <li>
+                Para idempotencia en escrituras, envía un header{' '}
+                <code className="rounded bg-slate-100 px-1 py-0.5 text-sm">Idempotency-Key</code> único por intento lógico.
+              </li>
+              <li>
+                Honra siempre el header{' '}
+                <code className="rounded bg-slate-100 px-1 py-0.5 text-sm">Retry-After</code> en 429 y 503.
+              </li>
+            </ul>
+          </div>
+        </Container>
+      </section>
+
+      <Footer />
+    </div>
+  );
+}

--- a/apps/landing/app/developers/page.tsx
+++ b/apps/landing/app/developers/page.tsx
@@ -269,9 +269,9 @@ export default function DevelopersPage() {
               {
                 icon: <Terminal className="h-5 w-5 text-[#2361d8]" />,
                 title: 'REST API',
-                body: '10 endpoints REST. Autenticación Bearer. Respuestas JSON consistentes. Compatible con cualquier lenguaje.',
-                href: '#endpoints',
-                cta: 'Ver endpoints',
+                body: '10 endpoints REST. Referencia interactiva con OpenAPI 3.1 — prueba peticiones directamente desde el navegador.',
+                href: '/developers/api',
+                cta: 'Abrir referencia',
               },
               {
                 icon: <MessageSquare className="h-5 w-5 text-[#2361d8]" />,
@@ -403,6 +403,96 @@ export default function DevelopersPage() {
               </a>{' '}
               para ver todos los parámetros disponibles.
             </p>
+          </div>
+        </Container>
+      </section>
+
+      {/* ── Documentación detallada ─────────────────────────────────────────── */}
+      <section id="docs-hub" className="border-t border-slate-100 bg-slate-50/50 py-14">
+        <Container>
+          <div className="max-w-5xl">
+            <div className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.16em] text-[#2361d8]">
+              <BookOpen className="h-4 w-4" />
+              Documentación detallada
+            </div>
+            <h2 className="mt-4 text-2xl font-bold text-[#011c67] sm:text-3xl">
+              Referencia, errores, límites y eventos
+            </h2>
+            <p className="mt-3 text-slate-600">
+              Todo lo que necesitas para construir integraciones robustas con Isaak. La referencia
+              interactiva te deja ejecutar peticiones reales; las páginas dedicadas profundizan en
+              casos límite.
+            </p>
+
+            <div className="mt-8 grid gap-4 sm:grid-cols-2">
+              <Link
+                href="/developers/api"
+                className="group rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition hover:border-[#2361d8]/30 hover:shadow-md"
+              >
+                <div className="text-xs font-semibold uppercase tracking-widest text-[#2361d8]">
+                  Interactivo
+                </div>
+                <h3 className="mt-2 text-lg font-semibold text-[#011c67]">API Reference</h3>
+                <p className="mt-2 text-sm leading-6 text-slate-600">
+                  OpenAPI 3.1 renderizado con Scalar. Esquemas, ejemplos por lenguaje, peticiones
+                  ejecutables con tu propia API key.
+                </p>
+                <span className="mt-4 inline-flex items-center gap-1 text-sm font-medium text-[#2361d8] group-hover:underline">
+                  Abrir referencia <ArrowRight className="h-3.5 w-3.5" />
+                </span>
+              </Link>
+
+              <Link
+                href="/developers/errors"
+                className="group rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition hover:border-[#2361d8]/30 hover:shadow-md"
+              >
+                <div className="text-xs font-semibold uppercase tracking-widest text-amber-700">
+                  Referencia
+                </div>
+                <h3 className="mt-2 text-lg font-semibold text-[#011c67]">Error codes</h3>
+                <p className="mt-2 text-sm leading-6 text-slate-600">
+                  Códigos HTTP, error.code de aplicación, formato del envelope y guía de retry con
+                  backoff exponencial.
+                </p>
+                <span className="mt-4 inline-flex items-center gap-1 text-sm font-medium text-[#2361d8] group-hover:underline">
+                  Ver códigos <ArrowRight className="h-3.5 w-3.5" />
+                </span>
+              </Link>
+
+              <Link
+                href="/developers/rate-limits"
+                className="group rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition hover:border-[#2361d8]/30 hover:shadow-md"
+              >
+                <div className="text-xs font-semibold uppercase tracking-widest text-[#2361d8]">
+                  Política
+                </div>
+                <h3 className="mt-2 text-lg font-semibold text-[#011c67]">Rate limits</h3>
+                <p className="mt-2 text-sm leading-6 text-slate-600">
+                  Límites por plan y por familia de endpoint. Headers de inspección. Recetario de
+                  burst y fairness.
+                </p>
+                <span className="mt-4 inline-flex items-center gap-1 text-sm font-medium text-[#2361d8] group-hover:underline">
+                  Ver política <ArrowRight className="h-3.5 w-3.5" />
+                </span>
+              </Link>
+
+              <Link
+                href="/developers/webhooks"
+                className="group rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition hover:border-[#2361d8]/30 hover:shadow-md"
+              >
+                <div className="text-xs font-semibold uppercase tracking-widest text-emerald-700">
+                  Beta cerrada
+                </div>
+                <h3 className="mt-2 text-lg font-semibold text-[#011c67]">Webhooks</h3>
+                <p className="mt-2 text-sm leading-6 text-slate-600">
+                  Eventos en tiempo real: factura emitida, validación AEAT, certificado a caducar.
+                  Firmas HMAC, reintentos, dead-letter.
+                </p>
+                <span className="mt-4 inline-flex items-center gap-1 text-sm font-medium text-[#2361d8] group-hover:underline">
+                  Ver eventos <ArrowRight className="h-3.5 w-3.5" />
+                </span>
+              </Link>
+            </div>
           </div>
         </Container>
       </section>

--- a/apps/landing/app/developers/rate-limits/page.tsx
+++ b/apps/landing/app/developers/rate-limits/page.tsx
@@ -1,0 +1,202 @@
+import { ArrowLeft, Gauge } from 'lucide-react';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import Header from '../../components/Header';
+import { Container, Footer } from '../../lib/home/ui';
+
+export const metadata: Metadata = {
+  title: 'Rate limits | Isaak Platform API — Verifactu Business',
+  description:
+    'Límites de peticiones por minuto en la API de Isaak. Política por scope, plan y endpoint. Headers de rate limit y backoff recomendado.',
+  alternates: { canonical: '/developers/rate-limits' },
+};
+
+const navLinks = [
+  { label: 'VeriFactu', href: '/verifactu/que-es' },
+  { label: 'Que es Isaak', href: '/que-es-isaak' },
+  { label: 'Conectores', href: '/conectores' },
+  { label: 'Precios', href: '/precios' },
+  { label: 'Developers', href: '/developers' },
+];
+
+const LIMITS = [
+  { plan: 'Free', read: '60 / min', write: '10 / min', aeat: '5 / min', mcp: '30 / min' },
+  { plan: 'Starter', read: '120 / min', write: '30 / min', aeat: '15 / min', mcp: '60 / min' },
+  { plan: 'Pro', read: '300 / min', write: '90 / min', aeat: '60 / min', mcp: '180 / min' },
+  { plan: 'Business', read: '600 / min', write: '300 / min', aeat: '120 / min', mcp: '360 / min' },
+];
+
+const HEADERS_BLOCK = `# Headers que la API devuelve en cada respuesta 2xx
+X-RateLimit-Limit:     300
+X-RateLimit-Remaining: 287
+X-RateLimit-Reset:     1759320000   # epoch seconds
+
+# Cuando devolvemos 429 Too Many Requests
+Retry-After: 23                     # segundos hasta que se libera un slot`;
+
+const BACKOFF_BLOCK = `// Backoff exponencial con jitter
+async function withRetry(fn, attempt = 0) {
+  try {
+    return await fn();
+  } catch (err) {
+    if (err.status !== 429 && err.status < 500) throw err;
+    if (attempt >= 5) throw err;
+    const baseMs = Math.min(30_000, 1000 * 2 ** attempt);
+    const jitter = Math.random() * 500;
+    const wait = err.retryAfter ? err.retryAfter * 1000 : baseMs + jitter;
+    await new Promise(r => setTimeout(r, wait));
+    return withRetry(fn, attempt + 1);
+  }
+}`;
+
+export default function RateLimitsPage() {
+  return (
+    <div className="min-h-screen bg-white text-slate-900">
+      <Header navLinks={navLinks} />
+
+      <section className="border-b border-slate-200 bg-[linear-gradient(180deg,#f4f8ff_0%,#ffffff_70%)] py-14 sm:py-16">
+        <Container>
+          <div className="max-w-4xl">
+            <Link
+              href="/developers"
+              className="inline-flex items-center gap-1.5 text-sm font-medium text-[#2361d8] hover:underline"
+            >
+              <ArrowLeft className="h-4 w-4" />
+              Volver a Developers
+            </Link>
+            <div className="mt-6 inline-flex items-center gap-2 rounded-full border border-[#2361d8]/15 bg-[#2361d8]/5 px-4 py-1.5 text-xs font-semibold uppercase tracking-[0.16em] text-[#2361d8]">
+              <Gauge className="h-3.5 w-3.5" />
+              Rate limits · Política
+            </div>
+            <h1 className="mt-5 text-4xl font-bold tracking-tight text-[#011c67] sm:text-5xl">
+              Rate limits
+            </h1>
+            <p className="mt-4 max-w-3xl text-lg leading-8 text-slate-600">
+              Isaak aplica límites por token y por familia de endpoint para proteger AEAT y la
+              experiencia compartida. Los límites escalan con el plan del tenant.
+            </p>
+          </div>
+        </Container>
+      </section>
+
+      <section className="border-t border-slate-100 py-12">
+        <Container>
+          <div className="max-w-5xl">
+            <h2 className="text-2xl font-bold text-[#011c67]">Límites por plan</h2>
+            <p className="mt-3 text-slate-600">
+              Por token y por minuto. Las llamadas dentro del mismo tenant se suman entre todas las
+              keys activas.
+            </p>
+            <div className="mt-6 overflow-hidden rounded-2xl border border-slate-200">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-slate-200 bg-slate-50">
+                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-slate-500">Plan</th>
+                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-slate-500">Read</th>
+                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-slate-500">Write</th>
+                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-slate-500">AEAT</th>
+                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-slate-500">MCP</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-100">
+                  {LIMITS.map((row) => (
+                    <tr key={row.plan} className="hover:bg-slate-50/50">
+                      <td className="px-4 py-3 font-semibold text-[#011c67]">{row.plan}</td>
+                      <td className="px-4 py-3 text-slate-700">{row.read}</td>
+                      <td className="px-4 py-3 text-slate-700">{row.write}</td>
+                      <td className="px-4 py-3 text-slate-700">{row.aeat}</td>
+                      <td className="px-4 py-3 text-slate-700">{row.mcp}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <p className="mt-4 text-sm text-slate-500">
+              <strong>Read</strong> = GETs sobre facturas, contactos, fiscal.{' '}
+              <strong>Write</strong> = POST/PATCH sobre borradores.{' '}
+              <strong>AEAT</strong> = emisiones VeriFactu / validaciones contra AEAT.{' '}
+              <strong>MCP</strong> = llamadas tools/call al servidor MCP.
+            </p>
+          </div>
+        </Container>
+      </section>
+
+      <section className="border-t border-slate-100 py-12">
+        <Container>
+          <div className="max-w-4xl">
+            <h2 className="text-2xl font-bold text-[#011c67]">Headers de rate limit</h2>
+            <p className="mt-3 text-slate-600">
+              La API expone tres headers de inspección y un header de retry. Úsalos para evitar 429
+              proactivamente en lugar de reactivamente.
+            </p>
+            <div className="mt-6 overflow-hidden rounded-2xl border border-slate-200">
+              <div className="flex items-center gap-2 border-b border-slate-200 bg-slate-800 px-4 py-3">
+                <div className="h-2.5 w-2.5 rounded-full bg-red-500" />
+                <div className="h-2.5 w-2.5 rounded-full bg-amber-400" />
+                <div className="h-2.5 w-2.5 rounded-full bg-emerald-500" />
+                <span className="ml-2 text-xs font-medium text-slate-400">HTTP</span>
+              </div>
+              <pre className="overflow-x-auto bg-slate-900 p-6 text-sm leading-7 text-slate-200">
+                <code>{HEADERS_BLOCK}</code>
+              </pre>
+            </div>
+          </div>
+        </Container>
+      </section>
+
+      <section className="border-t border-slate-100 py-12">
+        <Container>
+          <div className="max-w-4xl">
+            <h2 className="text-2xl font-bold text-[#011c67]">Backoff exponencial</h2>
+            <p className="mt-3 text-slate-600">
+              Recomendamos backoff exponencial con jitter para errores <code className="rounded bg-slate-100 px-1 py-0.5 text-sm">429</code>{' '}
+              y <code className="rounded bg-slate-100 px-1 py-0.5 text-sm">5xx</code>. Respeta siempre el header{' '}
+              <code className="rounded bg-slate-100 px-1 py-0.5 text-sm">Retry-After</code> cuando esté presente.
+            </p>
+            <div className="mt-6 overflow-hidden rounded-2xl border border-slate-200">
+              <div className="flex items-center gap-2 border-b border-slate-200 bg-slate-800 px-4 py-3">
+                <div className="h-2.5 w-2.5 rounded-full bg-red-500" />
+                <div className="h-2.5 w-2.5 rounded-full bg-amber-400" />
+                <div className="h-2.5 w-2.5 rounded-full bg-emerald-500" />
+                <span className="ml-2 text-xs font-medium text-slate-400">JavaScript</span>
+              </div>
+              <pre className="overflow-x-auto bg-slate-900 p-6 text-sm leading-7 text-slate-200">
+                <code>{BACKOFF_BLOCK}</code>
+              </pre>
+            </div>
+          </div>
+        </Container>
+      </section>
+
+      <section className="border-t border-slate-100 py-12">
+        <Container>
+          <div className="max-w-3xl">
+            <h2 className="text-2xl font-bold text-[#011c67]">Burst y fairness</h2>
+            <ul className="mt-4 space-y-3 text-slate-600">
+              <li>
+                Permitimos burst de hasta <strong className="text-slate-900">2× el límite</strong>{' '}
+                durante 10 segundos, después se aplica el ratio sostenido.
+              </li>
+              <li>
+                AEAT tiene su propio ratio compartido entre todos los tenants. En picos
+                concurrentes, una emisión puede esperar en cola interna hasta 60s.
+              </li>
+              <li>
+                Si necesitas límites superiores (ej. integración batch nocturna) escribe a{' '}
+                <a
+                  href="mailto:soporte@verifactu.business?subject=Ampliar%20rate%20limit%20API"
+                  className="text-[#2361d8] hover:underline"
+                >
+                  soporte@verifactu.business
+                </a>
+                . Ampliamos cuotas caso por caso para Pro y Business.
+              </li>
+            </ul>
+          </div>
+        </Container>
+      </section>
+
+      <Footer />
+    </div>
+  );
+}

--- a/apps/landing/app/developers/webhooks/page.tsx
+++ b/apps/landing/app/developers/webhooks/page.tsx
@@ -1,0 +1,264 @@
+import { ArrowLeft, Webhook } from 'lucide-react';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import Header from '../../components/Header';
+import { Container, Footer } from '../../lib/home/ui';
+
+export const metadata: Metadata = {
+  title: 'Webhooks | Isaak Platform API — Verifactu Business',
+  description:
+    'Eventos en tiempo real desde Isaak: factura emitida, validación AEAT, certificado a punto de caducar. Firmas HMAC, reintentos y catálogo de eventos.',
+  alternates: { canonical: '/developers/webhooks' },
+};
+
+const navLinks = [
+  { label: 'VeriFactu', href: '/verifactu/que-es' },
+  { label: 'Que es Isaak', href: '/que-es-isaak' },
+  { label: 'Conectores', href: '/conectores' },
+  { label: 'Precios', href: '/precios' },
+  { label: 'Developers', href: '/developers' },
+];
+
+const EVENT_PAYLOAD = `{
+  "id": "evt_2026_05_27_abc123",
+  "type": "invoice.issued",
+  "createdAt": "2026-05-27T10:23:45.000Z",
+  "tenantId": "tnt_xxx",
+  "data": {
+    "invoiceId": "inv_2026_0042",
+    "number": "2026/0042",
+    "amount": 1210.00,
+    "verifactuHash": "a1b2c3d4...",
+    "aeatStatus": "registered"
+  }
+}`;
+
+const SIGNATURE_BLOCK = `// Verificación de firma HMAC (Node.js)
+import crypto from 'node:crypto';
+
+function verifyWebhook(req, secret) {
+  const signature = req.headers['x-isaak-signature'];
+  const timestamp = req.headers['x-isaak-timestamp'];
+  const body = req.rawBody; // ¡el cuerpo crudo, NO parseado!
+
+  // Rechazar si la firma tiene más de 5 minutos (anti-replay)
+  if (Math.abs(Date.now() / 1000 - Number(timestamp)) > 300) {
+    throw new Error('Timestamp fuera de ventana');
+  }
+
+  const payload = \`\${timestamp}.\${body}\`;
+  const expected = crypto
+    .createHmac('sha256', secret)
+    .update(payload)
+    .digest('hex');
+
+  if (!crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expected))) {
+    throw new Error('Firma inválida');
+  }
+}`;
+
+const EVENTS = [
+  {
+    type: 'invoice.draft.created',
+    when: 'Un borrador de factura ha sido creado (vía API, MCP o dashboard).',
+    scope: 'invoices.read',
+  },
+  {
+    type: 'invoice.issued',
+    when: 'Factura emitida y registrada con éxito en AEAT (VeriFactu).',
+    scope: 'invoices.read',
+  },
+  {
+    type: 'invoice.rejected',
+    when: 'AEAT rechazó el registro. El campo `data.reason` indica el motivo.',
+    scope: 'invoices.read',
+  },
+  {
+    type: 'invoice.cancelled',
+    when: 'Factura rectificativa emitida sobre una previa.',
+    scope: 'invoices.read',
+  },
+  {
+    type: 'verifactu.status.changed',
+    when: 'Cambio en el estado de comunicación con AEAT (alta, baja, mantenimiento).',
+    scope: 'verifactu.read',
+  },
+  {
+    type: 'certificate.expiring',
+    when: 'Certificado mTLS a 30, 15 o 7 días de caducar. Aviso recurrente hasta renovar.',
+    scope: 'company.read',
+  },
+  {
+    type: 'banking.transaction.matched',
+    when: 'Una transacción bancaria se ha conciliado automáticamente con una factura.',
+    scope: 'fiscal.read',
+  },
+  {
+    type: 'api_key.created',
+    when: 'Nueva API key creada en el tenant. Útil para auditoría.',
+    scope: 'audit.read',
+  },
+  {
+    type: 'api_key.revoked',
+    when: 'API key revocada (manual o por rotación automática).',
+    scope: 'audit.read',
+  },
+];
+
+export default function WebhooksPage() {
+  return (
+    <div className="min-h-screen bg-white text-slate-900">
+      <Header navLinks={navLinks} />
+
+      <section className="border-b border-slate-200 bg-[linear-gradient(180deg,#f4fff8_0%,#ffffff_70%)] py-14 sm:py-16">
+        <Container>
+          <div className="max-w-4xl">
+            <Link
+              href="/developers"
+              className="inline-flex items-center gap-1.5 text-sm font-medium text-[#2361d8] hover:underline"
+            >
+              <ArrowLeft className="h-4 w-4" />
+              Volver a Developers
+            </Link>
+            <div className="mt-6 inline-flex items-center gap-2 rounded-full border border-emerald-200 bg-emerald-50 px-4 py-1.5 text-xs font-semibold uppercase tracking-[0.16em] text-emerald-700">
+              <Webhook className="h-3.5 w-3.5" />
+              Webhooks · Beta cerrada
+            </div>
+            <h1 className="mt-5 text-4xl font-bold tracking-tight text-[#011c67] sm:text-5xl">
+              Eventos en tiempo real
+            </h1>
+            <p className="mt-4 max-w-3xl text-lg leading-8 text-slate-600">
+              Isaak puede enviar eventos POST a tu URL cuando algo cambia: factura emitida,
+              validación AEAT, certificado a punto de caducar. La beta de webhooks está abierta
+              caso por caso —{' '}
+              <a
+                href="mailto:soporte@verifactu.business?subject=Acceso%20beta%20Webhooks%20Isaak"
+                className="text-[#2361d8] hover:underline"
+              >
+                pide acceso a soporte@verifactu.business
+              </a>
+              .
+            </p>
+          </div>
+        </Container>
+      </section>
+
+      <section className="border-t border-slate-100 py-12">
+        <Container>
+          <div className="max-w-4xl">
+            <h2 className="text-2xl font-bold text-[#011c67]">Formato del payload</h2>
+            <p className="mt-3 text-slate-600">
+              Todos los eventos comparten la misma envoltura. El campo{' '}
+              <code className="rounded bg-slate-100 px-1 py-0.5 text-sm">type</code> identifica el
+              evento y <code className="rounded bg-slate-100 px-1 py-0.5 text-sm">data</code> contiene
+              el snapshot relevante.
+            </p>
+            <div className="mt-6 overflow-hidden rounded-2xl border border-slate-200">
+              <div className="flex items-center gap-2 border-b border-slate-200 bg-slate-800 px-4 py-3">
+                <div className="h-2.5 w-2.5 rounded-full bg-red-500" />
+                <div className="h-2.5 w-2.5 rounded-full bg-amber-400" />
+                <div className="h-2.5 w-2.5 rounded-full bg-emerald-500" />
+                <span className="ml-2 text-xs font-medium text-slate-400">application/json</span>
+              </div>
+              <pre className="overflow-x-auto bg-slate-900 p-6 text-sm leading-7 text-slate-200">
+                <code>{EVENT_PAYLOAD}</code>
+              </pre>
+            </div>
+          </div>
+        </Container>
+      </section>
+
+      <section className="border-t border-slate-100 py-12">
+        <Container>
+          <div className="max-w-4xl">
+            <h2 className="text-2xl font-bold text-[#011c67]">Firma HMAC</h2>
+            <p className="mt-3 text-slate-600">
+              Cada petición incluye un header{' '}
+              <code className="rounded bg-slate-100 px-1 py-0.5 text-sm">X-Isaak-Signature</code> con HMAC-SHA256
+              del cuerpo crudo concatenado con el timestamp. Verifica siempre la firma antes de
+              confiar en el payload.
+            </p>
+            <div className="mt-6 overflow-hidden rounded-2xl border border-slate-200">
+              <div className="flex items-center gap-2 border-b border-slate-200 bg-slate-800 px-4 py-3">
+                <div className="h-2.5 w-2.5 rounded-full bg-red-500" />
+                <div className="h-2.5 w-2.5 rounded-full bg-amber-400" />
+                <div className="h-2.5 w-2.5 rounded-full bg-emerald-500" />
+                <span className="ml-2 text-xs font-medium text-slate-400">Node.js</span>
+              </div>
+              <pre className="overflow-x-auto bg-slate-900 p-6 text-sm leading-7 text-slate-200">
+                <code>{SIGNATURE_BLOCK}</code>
+              </pre>
+            </div>
+          </div>
+        </Container>
+      </section>
+
+      <section className="border-t border-slate-100 py-12">
+        <Container>
+          <div className="max-w-5xl">
+            <h2 className="text-2xl font-bold text-[#011c67]">Catálogo de eventos</h2>
+            <p className="mt-3 text-slate-600">
+              Selecciona los eventos a los que quieres suscribirte al crear el endpoint. Los scopes
+              de la API key que firma el webhook controlan qué eventos puedes recibir.
+            </p>
+            <div className="mt-6 overflow-hidden rounded-2xl border border-slate-200">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-slate-200 bg-slate-50">
+                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-slate-500">Evento</th>
+                    <th className="hidden px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-slate-500 sm:table-cell">Disparador</th>
+                    <th className="hidden px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-slate-500 lg:table-cell">Scope requerido</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-100">
+                  {EVENTS.map((ev) => (
+                    <tr key={ev.type} className="align-top hover:bg-slate-50/50">
+                      <td className="px-4 py-3">
+                        <code className="text-xs font-mono font-semibold text-[#011c67]">{ev.type}</code>
+                      </td>
+                      <td className="hidden px-4 py-3 text-slate-600 sm:table-cell">{ev.when}</td>
+                      <td className="hidden px-4 py-3 lg:table-cell">
+                        <code className="rounded bg-slate-100 px-1.5 py-0.5 text-xs font-mono text-slate-600">
+                          isaak.{ev.scope}
+                        </code>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </Container>
+      </section>
+
+      <section className="border-t border-slate-100 py-12">
+        <Container>
+          <div className="max-w-3xl">
+            <h2 className="text-2xl font-bold text-[#011c67]">Entrega y reintentos</h2>
+            <ul className="mt-4 space-y-3 text-slate-600">
+              <li>
+                Esperamos un <strong className="text-slate-900">2xx en menos de 10s</strong>. Si tu
+                endpoint tarda más, devuelve 200 de inmediato y procesa de forma asíncrona.
+              </li>
+              <li>
+                Si la respuesta no es 2xx, reintentamos con backoff exponencial: <strong>1m, 5m, 30m, 2h, 12h</strong>.
+                Tras 5 intentos fallidos, el evento se marca como <em>dead-letter</em> y queda
+                disponible en el dashboard de Isaak para reenvío manual.
+              </li>
+              <li>
+                Los eventos pueden llegar <strong className="text-slate-900">duplicados</strong>. Usa
+                el campo <code className="rounded bg-slate-100 px-1 py-0.5 text-sm">id</code> para deduplicar.
+              </li>
+              <li>
+                Los eventos pueden llegar <strong className="text-slate-900">desordenados</strong>.
+                Confía en <code className="rounded bg-slate-100 px-1 py-0.5 text-sm">createdAt</code>, no en el orden de recepción.
+              </li>
+            </ul>
+          </div>
+        </Container>
+      </section>
+
+      <Footer />
+    </div>
+  );
+}

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -14,6 +14,7 @@
     "@genkit-ai/firebase": "^1.27.0",
     "@genkit-ai/googleai": "^1.27.0",
     "@google/generative-ai": "^0.24.1",
+    "@scalar/api-reference-react": "^0.9.41",
     "@stripe/stripe-js": "^4.1.0",
     "@vercel/analytics": "^1.6.1",
     "@verifactu/db": "file:../../packages/db",

--- a/apps/landing/public/openapi/isaak-v1.yaml
+++ b/apps/landing/public/openapi/isaak-v1.yaml
@@ -1,0 +1,779 @@
+openapi: '3.1.0'
+
+info:
+  title: Isaak Platform API
+  version: '1.0.0'
+  description: |
+    API REST de Isaak Platform para facturación VeriFactu, gestión empresarial y auditoría.
+    Accesible desde cualquier aplicación con una API key (`isk_live_*` / `isk_test_*`)
+    o desde el dashboard con sesión autenticada.
+
+    **Base URL:** `https://app.verifactu.business/api/v1`
+
+    ## Autenticación
+
+    ### API Key (partners / integraciones)
+    ```
+    Authorization: Bearer isk_live_<token>
+    Authorization: Bearer isk_test_<token>
+    ```
+    Las API keys se generan en el dashboard en **Ajustes → API Keys**.
+    Cada key tiene scopes asignados en el momento de creación.
+
+    ### Sesión de dashboard (cookie)
+    Para llamadas desde el dashboard del tenant.
+    Se envía automáticamente por el navegador via cookie `__session`.
+
+    ## Scopes
+
+    | Scope | Descripción |
+    |-------|-------------|
+    | `isaak.company.read` | Leer contexto de empresa |
+    | `isaak.invoices.read` | Listar y leer facturas |
+    | `isaak.invoices.write` | Crear borradores de factura |
+    | `isaak.verifactu.validate` | Validar factura (sin enviar) |
+    | `isaak.verifactu.submit` | Emitir factura a AEAT |
+    | `isaak.fiscal.read` | Leer resumen fiscal |
+    | `isaak.audit.read` | Leer log de auditoría |
+    | `isaak.keys.manage` | Gestionar API keys propias |
+
+  contact:
+    name: Equipo Isaak
+    url: https://verifactu.business/contacto
+
+servers:
+  - url: https://app.verifactu.business/api/v1
+    description: Producción
+
+security:
+  - BearerApiKey: []
+
+# ─── Paths ─────────────────────────────────────────────────────────────────────
+
+paths:
+  /companies/current:
+    get:
+      summary: Obtener contexto de la empresa activa
+      description: Devuelve nombre, NIF, plan, conexiones activas y KPIs básicos del tenant autenticado.
+      operationId: getCompanyCurrent
+      tags: [company]
+      security:
+        - BearerApiKey: [isaak.company.read]
+        - SessionCookie: [isaak.company.read]
+      responses:
+        '200':
+          description: Contexto de empresa
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/OkEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/CompanyContext'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /invoices:
+    get:
+      summary: Listar facturas
+      description: Devuelve facturas emitidas del tenant con paginación y filtros opcionales.
+      operationId: listInvoices
+      tags: [invoices]
+      security:
+        - BearerApiKey: [isaak.invoices.read]
+        - SessionCookie: [isaak.invoices.read]
+      parameters:
+        - name: page
+          in: query
+          schema: { type: integer, default: 1, minimum: 1 }
+        - name: limit
+          in: query
+          schema: { type: integer, default: 20, minimum: 1, maximum: 100 }
+        - name: status
+          in: query
+          schema:
+            type: string
+            enum: [draft, issued, paid, cancelled, all]
+        - name: from
+          in: query
+          description: Fecha inicio YYYY-MM-DD
+          schema: { type: string, format: date }
+        - name: to
+          in: query
+          description: Fecha fin YYYY-MM-DD
+          schema: { type: string, format: date }
+        - name: customer
+          in: query
+          description: Filtro por nombre o NIF del cliente
+          schema: { type: string }
+      responses:
+        '200':
+          description: Lista paginada de facturas
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/OkListEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/InvoiceSummary'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+    post:
+      summary: Crear borrador de factura
+      description: |
+        Crea un borrador de factura. No la envía a AEAT.
+        Para emitirla usa `POST /invoices/{id}/issue`.
+      operationId: createInvoiceDraft
+      tags: [invoices]
+      security:
+        - BearerApiKey: [isaak.invoices.write]
+        - SessionCookie: [isaak.invoices.write]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateInvoiceDraftRequest'
+      responses:
+        '201':
+          description: Borrador creado
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/OkEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/InvoiceDetail'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '422':
+          $ref: '#/components/responses/ValidationError'
+
+  /invoices/{id}:
+    get:
+      summary: Obtener factura
+      description: Devuelve el detalle completo de una factura incluyendo estado VeriFactu.
+      operationId: getInvoice
+      tags: [invoices]
+      security:
+        - BearerApiKey: [isaak.invoices.read]
+        - SessionCookie: [isaak.invoices.read]
+      parameters:
+        - $ref: '#/components/parameters/InvoiceId'
+      responses:
+        '200':
+          description: Detalle de factura
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/OkEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/InvoiceDetail'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /invoices/{id}/validate:
+    post:
+      summary: Validar factura para VeriFactu
+      description: |
+        Valida los datos de una factura borrador antes de enviarla a AEAT.
+        No envía nada. Devuelve errores de validación si los hay.
+      operationId: validateInvoice
+      tags: [invoices, verifactu]
+      security:
+        - BearerApiKey: [isaak.verifactu.validate]
+        - SessionCookie: [isaak.verifactu.validate]
+      parameters:
+        - $ref: '#/components/parameters/InvoiceId'
+      responses:
+        '200':
+          description: Resultado de validación
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/OkEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/ValidationResult'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /invoices/{id}/issue:
+    post:
+      summary: Emitir factura a VeriFactu (AEAT)
+      description: |
+        Registra la factura ante AEAT mediante VeriFactu.
+        **Operación irreversible.**
+
+        Implementa confirmación de 2 pasos:
+
+        **Paso 1** — Llamada sin body (o body vacío):
+        - Responde `202` con `confirmationToken` (TTL 5 min) y un preview de los datos.
+
+        **Paso 2** — Llamada con `{ confirmationToken }`:
+        - Ejecuta el registro real ante AEAT.
+        - Responde `200` con el resultado.
+      operationId: issueInvoice
+      tags: [invoices, verifactu]
+      security:
+        - BearerApiKey: [isaak.verifactu.submit]
+        - SessionCookie: [isaak.verifactu.submit]
+      parameters:
+        - $ref: '#/components/parameters/InvoiceId'
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IssueInvoiceRequest'
+      responses:
+        '200':
+          description: Factura emitida ante AEAT
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/OkEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/IssueInvoiceResult'
+        '202':
+          description: Confirmación requerida — devuelve preview y confirmationToken
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConfirmationRequired'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /invoices/{id}/verifactu-status:
+    get:
+      summary: Estado VeriFactu de una factura
+      description: Devuelve el estado de registro de la factura en VeriFactu.
+      operationId: getInvoiceVerifactuStatus
+      tags: [invoices, verifactu]
+      security:
+        - BearerApiKey: [isaak.invoices.read]
+        - SessionCookie: [isaak.invoices.read]
+      parameters:
+        - $ref: '#/components/parameters/InvoiceId'
+      responses:
+        '200':
+          description: Estado VeriFactu
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/OkEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/VerifactuStatus'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /invoices/{id}/pdf:
+    get:
+      summary: Descargar PDF de factura
+      description: Genera y devuelve el PDF de la factura con QR AEAT.
+      operationId: getInvoicePdf
+      tags: [invoices]
+      security:
+        - BearerApiKey: [isaak.invoices.read]
+        - SessionCookie: [isaak.invoices.read]
+      parameters:
+        - $ref: '#/components/parameters/InvoiceId'
+      responses:
+        '200':
+          description: PDF generado
+          content:
+            application/pdf:
+              schema:
+                type: string
+                format: binary
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /audit/events:
+    get:
+      summary: Log de auditoría
+      description: Devuelve el historial de operaciones del tenant con paginación y filtros.
+      operationId: listAuditEvents
+      tags: [audit]
+      security:
+        - BearerApiKey: [isaak.audit.read]
+        - SessionCookie: [isaak.audit.read]
+      parameters:
+        - name: page
+          in: query
+          schema: { type: integer, default: 1 }
+        - name: limit
+          in: query
+          schema: { type: integer, default: 20, maximum: 100 }
+        - name: from
+          in: query
+          schema: { type: string, format: date-time }
+        - name: to
+          in: query
+          schema: { type: string, format: date-time }
+        - name: channel
+          in: query
+          description: 'dashboard | chatgpt | api | mcp'
+          schema: { type: string }
+        - name: action
+          in: query
+          description: Filtro por nombre de herramienta o acción
+          schema: { type: string }
+      responses:
+        '200':
+          description: Log de auditoría paginado
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/OkListEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/AuditEvent'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /keys:
+    get:
+      summary: Listar API keys del tenant
+      description: |
+        Devuelve las API keys del tenant autenticado.
+        Solo accesible desde sesión de dashboard; las API keys no pueden listar otras API keys.
+      operationId: listApiKeys
+      tags: [keys]
+      security:
+        - SessionCookie: [isaak.keys.manage]
+      responses:
+        '200':
+          description: Lista de API keys
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/OkListEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/ApiKeySummary'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+    post:
+      summary: Crear API key
+      description: |
+        Crea una nueva API key para el tenant.
+        **La key completa se devuelve una única vez** en la respuesta de creación.
+        Guárdala inmediatamente — no se puede recuperar después.
+      operationId: createApiKey
+      tags: [keys]
+      security:
+        - SessionCookie: [isaak.keys.manage]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateApiKeyRequest'
+      responses:
+        '201':
+          description: API key creada (incluye la key completa, solo esta vez)
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/OkEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/ApiKeyCreated'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+
+  /keys/{id}:
+    delete:
+      summary: Revocar API key
+      description: Revoca una API key. La operación es irreversible.
+      operationId: deleteApiKey
+      tags: [keys]
+      security:
+        - SessionCookie: [isaak.keys.manage]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: API key revocada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OkEnvelope'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+# ─── Components ────────────────────────────────────────────────────────────────
+
+components:
+  securitySchemes:
+    BearerApiKey:
+      type: http
+      scheme: bearer
+      description: API key en formato `isk_live_*` o `isk_test_*`
+    SessionCookie:
+      type: apiKey
+      in: cookie
+      name: __session
+      description: Cookie de sesión del dashboard (JWT firmado)
+
+  parameters:
+    InvoiceId:
+      name: id
+      in: path
+      required: true
+      description: ID interno de la factura
+      schema: { type: string }
+
+  responses:
+    Unauthorized:
+      description: Token ausente o inválido
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorEnvelope'
+    Forbidden:
+      description: Scope insuficiente
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorEnvelope'
+    NotFound:
+      description: Recurso no encontrado
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorEnvelope'
+    ValidationError:
+      description: Datos de entrada inválidos
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorEnvelope'
+    TooManyRequests:
+      description: Rate limit superado
+      headers:
+        Retry-After:
+          schema: { type: integer }
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorEnvelope'
+
+  schemas:
+    OkEnvelope:
+      type: object
+      required: [ok, data]
+      properties:
+        ok:
+          type: boolean
+          example: true
+        requestId:
+          type: string
+        tenantId:
+          type: string
+        data:
+          type: object
+
+    OkListEnvelope:
+      type: object
+      required: [ok, data, pagination]
+      properties:
+        ok:
+          type: boolean
+          example: true
+        requestId:
+          type: string
+        tenantId:
+          type: string
+        data:
+          type: array
+          items: {}
+        pagination:
+          type: object
+          properties:
+            page: { type: integer }
+            limit: { type: integer }
+            total: { type: integer }
+
+    ErrorEnvelope:
+      type: object
+      required: [ok, error]
+      properties:
+        ok:
+          type: boolean
+          example: false
+        error:
+          type: object
+          properties:
+            code: { type: string }
+            message: { type: string }
+        requestId:
+          type: string
+
+    ConfirmationRequired:
+      type: object
+      required: [requiresConfirmation, confirmationToken, preview]
+      properties:
+        requiresConfirmation: { type: boolean, example: true }
+        confirmationToken: { type: string }
+        expiresAt: { type: string, format: date-time }
+        preview: { type: object }
+
+    CompanyContext:
+      type: object
+      properties:
+        tenantId: { type: string }
+        name: { type: string }
+        nif: { type: string }
+        plan: { type: string }
+        connections:
+          type: array
+          items:
+            type: object
+            properties:
+              provider: { type: string }
+              status: { type: string }
+        kpis:
+          type: object
+          properties:
+            invoicesThisMonth: { type: integer }
+            pendingVeriFactu: { type: integer }
+
+    InvoiceSummary:
+      type: object
+      properties:
+        id: { type: string }
+        number: { type: string }
+        status: { type: string, enum: [draft, issued, paid, cancelled] }
+        customerName: { type: string }
+        customerNif: { type: string }
+        issueDate: { type: string, format: date }
+        totalAmount: { type: number }
+        currency: { type: string, example: EUR }
+        verifactuStatus: { type: string, nullable: true }
+
+    InvoiceDetail:
+      allOf:
+        - $ref: '#/components/schemas/InvoiceSummary'
+        - type: object
+          properties:
+            description: { type: string }
+            amountNet: { type: number }
+            taxRate: { type: number }
+            taxAmount: { type: number }
+            lines:
+              type: array
+              items:
+                type: object
+                properties:
+                  description: { type: string }
+                  quantity: { type: number }
+                  unitPrice: { type: number }
+                  taxRate: { type: number }
+                  total: { type: number }
+            verifactuHash: { type: string, nullable: true }
+            verifactuQrUrl: { type: string, nullable: true }
+            createdAt: { type: string, format: date-time }
+            updatedAt: { type: string, format: date-time }
+
+    CreateInvoiceDraftRequest:
+      type: object
+      required: [customerName, description, amountNet, taxRate]
+      properties:
+        customerName: { type: string }
+        customerNif: { type: string }
+        description: { type: string }
+        amountNet: { type: number, minimum: 0 }
+        taxRate:
+          type: number
+          description: '0.21 para 21%, 0.10 para 10%, 0 para exento'
+          example: 0.21
+        issueDate:
+          type: string
+          format: date
+          description: Por defecto hoy si se omite
+        lines:
+          type: array
+          items:
+            type: object
+            properties:
+              description: { type: string }
+              quantity: { type: number }
+              unitPrice: { type: number }
+              taxRate: { type: number }
+
+    IssueInvoiceRequest:
+      type: object
+      properties:
+        confirmationToken:
+          type: string
+          description: Token del paso 1. Si se omite, se inicia el flujo de confirmación.
+
+    IssueInvoiceResult:
+      type: object
+      properties:
+        invoiceId: { type: string }
+        number: { type: string }
+        verifactuHash: { type: string }
+        aeatResponse: { type: object }
+        issuedAt: { type: string, format: date-time }
+
+    ValidationResult:
+      type: object
+      properties:
+        valid: { type: boolean }
+        errors:
+          type: array
+          items:
+            type: object
+            properties:
+              field: { type: string }
+              message: { type: string }
+
+    VerifactuStatus:
+      type: object
+      properties:
+        invoiceId: { type: string }
+        status:
+          type: string
+          enum: [not_submitted, pending, accepted, rejected, error]
+        hash: { type: string, nullable: true }
+        submittedAt: { type: string, format: date-time, nullable: true }
+        aeatCode: { type: string, nullable: true }
+        aeatMessage: { type: string, nullable: true }
+
+    AuditEvent:
+      type: object
+      properties:
+        id: { type: string }
+        tenantId: { type: string }
+        channel: { type: string }
+        toolOrAction: { type: string }
+        status: { type: integer }
+        riskLevel: { type: string, enum: [low, medium, high] }
+        confirmationRequired: { type: boolean }
+        requestId: { type: string }
+        createdAt: { type: string, format: date-time }
+
+    ApiKeySummary:
+      type: object
+      properties:
+        id: { type: string }
+        name: { type: string }
+        keyPrefix: { type: string, example: 'isk_live_abc1...' }
+        scopes: { type: array, items: { type: string } }
+        environment: { type: string, enum: [live, test] }
+        lastUsedAt: { type: string, format: date-time, nullable: true }
+        createdAt: { type: string, format: date-time }
+
+    CreateApiKeyRequest:
+      type: object
+      required: [name, scopes]
+      properties:
+        name: { type: string, maxLength: 80 }
+        scopes:
+          type: array
+          items: { type: string }
+          example:
+            - isaak.invoices.read
+            - isaak.invoices.write
+        environment:
+          type: string
+          enum: [live, test]
+          default: live
+
+    ApiKeyCreated:
+      allOf:
+        - $ref: '#/components/schemas/ApiKeySummary'
+        - type: object
+          required: [key]
+          properties:
+            key:
+              type: string
+              description: La API key completa. Se muestra UNA SOLA VEZ.
+              example: 'isk_live_abc123...'
+
+tags:
+  - name: company
+    description: Contexto de la empresa activa
+  - name: invoices
+    description: Gestión de facturas y emisión VeriFactu
+  - name: verifactu
+    description: Operaciones específicas de VeriFactu y AEAT
+  - name: audit
+    description: Log de auditoría
+  - name: keys
+    description: Gestión de API keys

--- a/docs/engineering/ISAAK_MASTER_PLAN.md
+++ b/docs/engineering/ISAAK_MASTER_PLAN.md
@@ -520,3 +520,44 @@ Detalle completo por módulos en `docs/engineering/ISAAK_ROADMAP_POST_MANIFESTO.
 - **Bridge CI → Inspector R017**: ✅ Implementado en F11 fase 5a. R017 pasa de warning a error si VIES dice no válido.
 - **UI integrada en /contactos**: ⏳ Pendiente. Cuando se cree contacto, llamar `buildProfile()` para auto-fill + diff visual.
 - **Onboarding R000**: ✅ Wizard en `/perfil-fiscal` con prefill CI. Pendiente: enlazar al onboarding inicial del tenant.
+
+---
+
+## Track D — Developer Portal y API pública
+
+**Objetivo**: que un developer externo pueda integrar con Isaak Platform en menos de 1 hora.
+
+### Estado actual (2026-05-27)
+
+| Componente | Estado | Ubicación |
+| ---------- | ------ | --------- |
+| OpenAPI 3.1 spec | ✅ | `docs/isaak/ISAAK_API_V1_OPENAPI.yaml` (10 endpoints REST, 8 scopes) |
+| Página developer hub | ✅ | `apps/landing/app/developers/page.tsx` + `apps/isaak/app/developers/page.tsx` |
+| API keys management | ✅ | Settings → API keys (`isk_live_*` / `isk_test_*`) |
+| MCP server spec | ✅ | `docs/engineering/isaak-platform/ISAAK_MCP_SERVER_SPEC_2026.md` (9 tools Isaak) |
+| Compliance docs MCP | ✅ | `docs/openai-submission/` + `docs/anthropic-submission/` |
+| **Swagger UI interactivo** | ✅ **2026-05-27** | `/developers/api` con Scalar (OpenAPI 3.1 ejecutable) |
+| **Error codes reference** | ✅ **2026-05-27** | `/developers/errors` (HTTP + error.code de aplicación + retry guide) |
+| **Rate limits policy** | ✅ **2026-05-27** | `/developers/rate-limits` (límites por plan, headers, backoff) |
+| **Webhook spec (beta cerrada)** | ✅ **2026-05-27** | `/developers/webhooks` (9 eventos, firma HMAC, reintentos) |
+
+### Pendiente (orden recomendado)
+
+| Prioridad | Tarea | Notas |
+| --------- | ----- | ----- |
+| D1 | Implementar emisor real de webhooks | Hoy es solo docs. Build cola con dead-letter + reintentos según spec. |
+| D2 | SDK TypeScript (`@verifactu/isaak-sdk`) | Auto-generado desde OpenAPI con `openapi-typescript-fetch`. Publicar en npm. |
+| D3 | Postman/Bruno collection | Generar desde OpenAPI con `openapi-to-postmanv2`. Hostar en `/developers/postman`. |
+| D4 | Guías por caso de uso | `/developers/guides/{emitir-verifactu, conectar-erp, importar-banking, oauth-flow}`. MDX. |
+| D5 | API changelog público | `/developers/changelog` con breaking changes anotados. Versionar en spec. |
+| D6 | Idempotency-Key header | Implementar en el servidor para todos los POST de escritura. Documentado en errors page. |
+| D7 | SDK Python | Caso de uso secundario. Auto-gen desde OpenAPI con `openapi-python-client`. |
+| D8 | Status page público | `status.verifactu.business` con histórico de incidencias y uptime AEAT. |
+
+### Convenciones para el API
+
+- **Envelope estándar**: `{ ok, data, meta: { requestId, timestamp } }` en 2xx, `{ ok: false, error: { code, message }, requestId }` en !2xx.
+- **Versionado**: prefijo `/api/v1` en URL. Breaking changes solo en `/api/v2`. Soporte mínimo 12 meses tras deprecation.
+- **Idempotencia**: header `Idempotency-Key` opcional en POST/PATCH. TTL 24h.
+- **Trazas**: cada respuesta incluye `meta.requestId` (o `error.requestId`). Logs internos correlacionables.
+- **Confirmation flow**: acciones AEAT requieren 2 POST — primero devuelve `confirmationToken` (TTL 5min), segundo confirma con ese token.

--- a/docs/product/ISAAK_MASTER_PLAN.md
+++ b/docs/product/ISAAK_MASTER_PLAN.md
@@ -303,3 +303,41 @@ Usuario en ChatGPT/Claude → conecta Holded → usa conector gratis
 | `docs/product/CONNECTOR_ACQUISITION_FUNNEL_PLAN_2026.md`         | Estrategia funnel conector → Isaak                      |
 | `docs/engineering/ADMIN_PANEL_CONNECTORS_AUDIT_AND_PLAN_2026.md` | Auditoría y plan del panel de administración            |
 | `docs/openai-submission/WEB_MOBILE_REVIEW_CHECKLIST.md`          | Checklist QA manual para resubmisión OpenAI             |
+
+---
+
+## Developer Portal — propuesta de valor para devs externos
+
+Isaak no es solo un producto final; es también una **plataforma API** para devs que quieren
+integrar facturación VeriFactu, contabilidad y MCP en sus propias aplicaciones.
+
+**Audiencias objetivo**:
+
+- **Software vertical** (gestores hoteleros, ERPs sectoriales) que quiere ofrecer VeriFactu a sus
+  clientes sin construir el SOAP AEAT desde cero.
+- **Asesorías técnicas** que automatizan flujos contables sobre sus tenants.
+- **Agentes IA** (Claude, ChatGPT, n8n, Make) que necesitan datos fiscales en tiempo real.
+
+**Stack documental público** (`verifactu.business/developers`):
+
+| URL | Contenido | Estado |
+|-----|-----------|--------|
+| `/developers` | Hub: quickstart, endpoints, MCP, Inspector | ✅ Operativo |
+| `/developers/api` | Referencia interactiva OpenAPI 3.1 con Scalar | ✅ **2026-05-27** |
+| `/developers/errors` | Códigos HTTP + error.code + retry guide | ✅ **2026-05-27** |
+| `/developers/rate-limits` | Política por plan + headers + backoff | ✅ **2026-05-27** |
+| `/developers/webhooks` | 9 eventos + firma HMAC + reintentos (beta cerrada) | ✅ **2026-05-27** |
+| `/developers/guides/*` | Recetario por caso de uso | ⏳ Roadmap |
+| `/developers/changelog` | API changelog público | ⏳ Roadmap |
+
+**Modelo comercial**:
+
+- API keys gratuitas en cualquier plan. Rate limits escalan con el plan del tenant.
+- Plan Business: rate limit alto + webhooks + SLA.
+- Plan Partner (futuro): revenue share para integradores que traen volumen.
+
+**Métricas de éxito**:
+
+- Time-to-first-call para developer externo: < 5 min desde landing → API key → curl funcionando.
+- % de integraciones que usan SDK vs curl directo (target SDK: >40% una vez publicado).
+- Volumen tools/call MCP / mes (proxy de adopción del protocolo).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,7 +120,7 @@ importers:
         version: 9.1.7
       jest:
         specifier: ^30.2.0
-        version: 30.2.0(@types/node@24.8.1)
+        version: 30.2.0(@types/node@20.19.30)
       jest-environment-jsdom:
         specifier: ^30.2.0
         version: 30.2.0
@@ -138,7 +138,7 @@ importers:
     dependencies:
       '@next-auth/prisma-adapter':
         specifier: ^1.0.7
-        version: 1.0.7(@prisma/client@5.22.0(prisma@5.22.0))(next-auth@4.24.13(next@15.5.18(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+        version: 1.0.7(@prisma/client@5.22.0(prisma@5.22.0))(next-auth@4.24.13(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       '@verifactu/auth':
         specifier: workspace:*
         version: link:../../packages/auth
@@ -251,7 +251,7 @@ importers:
         version: 30.2.0(@babel/core@7.28.6)
       jest:
         specifier: ^30.2.0
-        version: 30.2.0(@types/node@20.19.30)
+        version: 30.2.0(@types/node@24.8.1)
       nodemon:
         specifier: ^3.1.0
         version: 3.1.11
@@ -308,7 +308,7 @@ importers:
         version: file:packages/db(@react-email/render@1.1.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/node@20.19.30)(prisma@5.22.0)
       '@verifactu/ui':
         specifier: file:../../packages/ui
-        version: file:packages/ui(@types/react@18.3.27)(next@15.5.18(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
+        version: file:packages/ui(@types/react@18.3.27)(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
       '@verifactu/utils':
         specifier: file:../../packages/utils
         version: link:../../packages/utils
@@ -389,7 +389,7 @@ importers:
         version: 2.6.0
       workflow:
         specifier: 4.2.0-beta.64
-        version: 4.2.0-beta.64(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.18))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.18))(@swc/helpers@0.5.18)(next@15.5.18(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router@7.13.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.9.3)
+        version: 4.2.0-beta.64(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.18))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.18))(@swc/helpers@0.5.18)(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router@7.13.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.9.3)
       zod:
         specifier: ^4.3.5
         version: 4.3.6
@@ -498,7 +498,7 @@ importers:
         version: file:packages/db(@react-email/render@1.1.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/node@20.19.30)(prisma@5.22.0)
       '@verifactu/ui':
         specifier: file:../../packages/ui
-        version: file:packages/ui(@types/react@18.3.27)(next@15.5.18(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
+        version: file:packages/ui(@types/react@18.3.27)(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
       '@verifactu/utils':
         specifier: file:../../packages/utils
         version: link:../../packages/utils
@@ -857,12 +857,15 @@ importers:
       '@google/generative-ai':
         specifier: ^0.24.1
         version: 0.24.1
+      '@scalar/api-reference-react':
+        specifier: ^0.9.41
+        version: 0.9.41(axios@1.16.0)(qrcode@1.5.4)(react@18.2.0)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))(typescript@5.9.3)(zod@4.3.6)
       '@stripe/stripe-js':
         specifier: ^4.1.0
         version: 4.10.0
       '@vercel/analytics':
         specifier: ^1.6.1
-        version: 1.6.1(next@15.5.18(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
+        version: 1.6.1(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(vue@3.5.35(typescript@5.9.3))
       '@verifactu/db':
         specifier: file:../../packages/db
         version: link:../../packages/db
@@ -1114,6 +1117,12 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
+  '@ai-sdk/gateway@3.0.13':
+    resolution: {integrity: sha512-g7nE4PFtngOZNZSy1lOPpkC+FAiHxqBJXqyRMEG7NUrEVZlz5goBdtHg1YgWRJIX776JTXAmbOI5JreAKVAsVA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/gateway@3.0.22':
     resolution: {integrity: sha512-NgnlY73JNuooACHqUIz5uMOEWvqR1MMVbb2soGLMozLY1fgwEIF5iJFDAGa5/YArlzw2ATVU7zQu7HkR/FUjgA==}
     engines: {node: '>=18'}
@@ -1126,15 +1135,31 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@4.0.5':
+    resolution: {integrity: sha512-Ow/X/SEkeExTTc1x+nYLB9ZHK2WUId8+9TlkamAx7Tl9vxU+cKzWx2dwjgMHeCN6twrgwkLrrtqckQeO4mxgVA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider-utils@4.0.9':
     resolution: {integrity: sha512-bB4r6nfhBOpmoS9mePxjRoCy+LnzP3AfhyMGCkGL4Mn9clVNlqEeKj26zEKEtB6yoSVcT1IQ0Zh9fytwMCDnow==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider@3.0.2':
+    resolution: {integrity: sha512-HrEmNt/BH/hkQ7zpi2o6N3k1ZR1QTb7z85WYhYygiTxOQuaml4CMtHCWRbric5WPU+RNsYI7r1EpyVQMKO1pYw==}
+    engines: {node: '>=18'}
+
   '@ai-sdk/provider@3.0.5':
     resolution: {integrity: sha512-2Xmoq6DBJqmSl80U6V9z5jJSJP7ehaJJQMy2iFUqTay06wdCqTnPVBBQbtEL8RCChenL+q5DC5H5WzU3vV3v8w==}
     engines: {node: '>=18'}
+
+  '@ai-sdk/vue@3.0.33':
+    resolution: {integrity: sha512-czM9Js3a7f+Eo35gjEYEeJYUoPvMg5Dfi4bOLyDBghLqn0gaVg8yTmTaSuHCg+3K/+1xPjyXd4+2XcQIohWWiQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      vue: ^3.3.4
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -1328,8 +1353,16 @@ packages:
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.27.1':
@@ -1346,6 +1379,11 @@ packages:
 
   '@babel/parser@7.28.6':
     resolution: {integrity: sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1869,6 +1907,10 @@ packages:
     resolution: {integrity: sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
@@ -1907,6 +1949,42 @@ packages:
 
   '@cfworker/json-schema@4.1.1':
     resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
+
+  '@codemirror/autocomplete@6.20.2':
+    resolution: {integrity: sha512-G5FPkgIiLjOgZMjqVjvuKQ1rGPtHogLldJr33eFJdVLtmwY+giGrlv/ewljLz6b9BSQLkjxuwBc6g6omDM+YxQ==}
+
+  '@codemirror/commands@6.10.3':
+    resolution: {integrity: sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==}
+
+  '@codemirror/lang-css@6.3.1':
+    resolution: {integrity: sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==}
+
+  '@codemirror/lang-html@6.4.11':
+    resolution: {integrity: sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==}
+
+  '@codemirror/lang-javascript@6.2.5':
+    resolution: {integrity: sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==}
+
+  '@codemirror/lang-json@6.0.2':
+    resolution: {integrity: sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==}
+
+  '@codemirror/lang-xml@6.1.0':
+    resolution: {integrity: sha512-3z0blhicHLfwi2UgkZYRPioSgVTo9PV5GP5ducFH6FaHy0IAJRg+ixj5gTR1gnT/glAIC8xv4w2VL1LoZfs+Jg==}
+
+  '@codemirror/lang-yaml@6.1.3':
+    resolution: {integrity: sha512-AZ8DJBuXGVHybpBQhmZtgew5//4hv3tdkXnr3vDmOUMJRuB6vn/uuwtmTOTlqEaQFg3hQSVeA90NmvIQyUV6FQ==}
+
+  '@codemirror/language@6.12.3':
+    resolution: {integrity: sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==}
+
+  '@codemirror/lint@6.9.6':
+    resolution: {integrity: sha512-6Kp7r6XfCi/D/5sdXieMfg9pJU1bUEx96WITuLU6ESaKizCz0QHFMjY/TaFSbigDdEAIgi93itLBIUETP4oK+A==}
+
+  '@codemirror/state@6.6.0':
+    resolution: {integrity: sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==}
+
+  '@codemirror/view@6.43.0':
+    resolution: {integrity: sha512-V7ZCLQO3Jus9hzh2jVCCPW3mO4IBMr43O37PqSUYautJSnnJF41YlgLw21x0fLJTYvJ+Vkm6Gp+qKGH9pltgXA==}
 
   '@colors/colors@1.6.0':
     resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
@@ -2508,6 +2586,21 @@ packages:
   '@firebase/webchannel-wrapper@1.0.5':
     resolution: {integrity: sha512-+uGNN7rkfn41HLO0vekTFhTxk61eKa8mTpRGLO0QSqlQdKvIoGAvLp3ppdVIWbTGYJWM6Kp0iN+PjMIOcnVqTw==}
 
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/utils@0.2.10':
+    resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@floating-ui/vue@1.1.9':
+    resolution: {integrity: sha512-BfNqNW6KA83Nexspgb9DZuz578R7HT8MZw1CfK9I6Ah4QReNWEJsXWHN+SdmOVLNGmTPDi+fDT535Df5PzMLbQ==}
+
   '@fullcalendar/core@6.1.20':
     resolution: {integrity: sha512-1cukXLlePFiJ8YKXn/4tMKsy0etxYLCkXk8nUCFi11nRONF2Ba2CD5b21/ovtOO2tL6afTJfwmc1ed3HG7eB1g==}
 
@@ -2659,6 +2752,18 @@ packages:
     resolution: {integrity: sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==}
     engines: {node: '>=6'}
     hasBin: true
+
+  '@headlessui/tailwindcss@0.2.2':
+    resolution: {integrity: sha512-xNe42KjdyA4kfUKLLPGzME9zkH7Q3rOZ5huFihWNWOQFxnItxPB3/67yBI8/qBfY8nwBRx5GHn4VprsoluVMGw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      tailwindcss: ^3.0 || ^4.0
+
+  '@headlessui/vue@1.7.23':
+    resolution: {integrity: sha512-JzdCNqurrtuu0YW6QaDtR2PIYCKPUWq28csDyMvN4zmGccmE7lz40Is6hc3LA4HFeCI7sekZ/PQMTNmn9I/4Wg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      vue: ^3.2.0
 
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
@@ -2816,6 +2921,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@internationalized/date@3.12.1':
+    resolution: {integrity: sha512-6IedsVWXyq4P9Tj+TxuU8WGWM70hYLl12nbYU8jkikVpa6WXapFazPUcHUMDMoWftIDE2ILDkFFte6W2nFCkRQ==}
+
+  '@internationalized/number@3.6.6':
+    resolution: {integrity: sha512-iFgmQaXHE0vytNfpLZWOC2mEJCBRzcUxt53Xf/yCXG93lRvqas237i3r7X4RKMwO3txiyZD4mQjKAByFv6UGSQ==}
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -2946,6 +3057,33 @@ packages:
   '@keyv/serialize@1.1.1':
     resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
 
+  '@lezer/common@1.5.2':
+    resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
+
+  '@lezer/css@1.3.3':
+    resolution: {integrity: sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg==}
+
+  '@lezer/highlight@1.2.3':
+    resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
+
+  '@lezer/html@1.3.13':
+    resolution: {integrity: sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==}
+
+  '@lezer/javascript@1.5.4':
+    resolution: {integrity: sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==}
+
+  '@lezer/json@1.0.3':
+    resolution: {integrity: sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==}
+
+  '@lezer/lr@1.4.10':
+    resolution: {integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==}
+
+  '@lezer/xml@1.0.6':
+    resolution: {integrity: sha512-CdDwirL0OEaStFue/66ZmFSeppuL6Dwjlk8qk153mSQwiSH/Dlri4GNymrNWnUmPl2Um7QfV1FO9KFUyX3Twww==}
+
+  '@lezer/yaml@1.0.4':
+    resolution: {integrity: sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw==}
+
   '@lukeed/csprng@1.1.0':
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
     engines: {node: '>=8'}
@@ -2953,6 +3091,9 @@ packages:
   '@mapbox/node-pre-gyp@1.0.11':
     resolution: {integrity: sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==}
     hasBin: true
+
+  '@marijn/find-cluster-break@1.0.2':
+    resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
   '@mjackson/node-fetch-server@0.2.0':
     resolution: {integrity: sha512-EMlH1e30yzmTpGLQjlFmaDAjyOeZhng1/XCd7DExR8PNAnG/G1tyruZxEoUe11ClnwGhGrtsdnyyUx1frSzjng==}
@@ -3668,6 +3809,9 @@ packages:
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
 
+  '@phosphor-icons/core@2.1.1':
+    resolution: {integrity: sha512-v4ARvrip4qBCImOE5rmPUylOEK4iiED9ZyKjcvzuezqMaiRASCHKcRIuvvxL/twvLpkfnEODCOJp5dM4eZilxQ==}
+
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
@@ -3799,11 +3943,111 @@ packages:
       react-redux:
         optional: true
 
+  '@replit/codemirror-css-color-picker@6.3.0':
+    resolution: {integrity: sha512-19biDANghUm7Fz7L1SNMIhK48tagaWuCOHj4oPPxc7hxPGkTVY2lU/jVZ8tsbTKQPVG7BO2CBDzs7CBwb20t4A==}
+    peerDependencies:
+      '@codemirror/language': ^6.0.0
+      '@codemirror/state': ^6.0.0
+      '@codemirror/view': ^6.0.0
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
   '@rushstack/eslint-patch@1.15.0':
     resolution: {integrity: sha512-ojSshQPKwVvSMR8yT2L/QtUkV5SXi/IfDiJ4/8d6UbTPjiHVmxZzUAzGD8Tzks1b9+qQkZa0isUOvYObedITaw==}
+
+  '@scalar/agent-chat@0.12.5':
+    resolution: {integrity: sha512-FS/v/GCc0H8d1s5wLOI0iz+4aAMR8eTJxl+cdVMCnhCAZYSQUf2bfwRRu9AxmK8htLHTZC7C5gPIPxItQnVelg==}
+    engines: {node: '>=22'}
+
+  '@scalar/api-client@3.8.5':
+    resolution: {integrity: sha512-9zBFENlFark9tCThwHNiKTYLVHxcMm4Wg9jgYI1iG2hr1s0gmX5XlHHovObSn6JVyEuU8si42Eqnkg6LUrnWRQ==}
+    engines: {node: '>=22'}
+
+  '@scalar/api-reference-react@0.9.41':
+    resolution: {integrity: sha512-7L8UjFj9KboSGlbe/pJAc+S5Qezi4IuUtOVdN1F6COCTF26paEiR9sZ0I+WNIkqsiTjmQouG8wFrQvwsAABfvA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+
+  '@scalar/api-reference@1.57.5':
+    resolution: {integrity: sha512-1T0rXEtG2XfbHuvyphlZsMr3VXUGCTDxybknMSUykl/5j1WoW9Goz16fVspf5fBLtkw5FUw2+a3DgVJKHU7vXQ==}
+    engines: {node: '>=22'}
+
+  '@scalar/code-highlight@0.3.4':
+    resolution: {integrity: sha512-gGr3D8bfInwZDHsxamYIaG72Wr+kRNX8d4zcOflAfQJ0ZfvqoVbYhhkiSd6K+DLySItK9lWl/cgjJdtKWlT2ig==}
+    engines: {node: '>=22'}
+
+  '@scalar/components@0.26.0':
+    resolution: {integrity: sha512-hCSwedkIaJAngu4G+GnsF7BeuCV8a4dnE+7VL/HN1wYrnx3SwE94zt/LC++VB0l+GsGPdsN0gyuS6brmmtzi5A==}
+    engines: {node: '>=22'}
+
+  '@scalar/helpers@0.8.0':
+    resolution: {integrity: sha512-gmOC6VravNB9VDl6wnt/GOj4K/hn48tj5bpW4AM4MhH8Ubil6uu7g1DSoKHwltu8Ks79KEtR6JmOrROi9R7jaQ==}
+    engines: {node: '>=22'}
+
+  '@scalar/icons@0.7.2':
+    resolution: {integrity: sha512-21L2y/D6oU7wZHHa9i6FK98cZ+XH4HX9+e69uNpvlp4awRUpz6ifNHOLlxI607bq+Yz4G313gnV0uyUHwZ/pig==}
+    engines: {node: '>=22'}
+
+  '@scalar/json-magic@0.12.14':
+    resolution: {integrity: sha512-dWrCy3ew1r7OQ1pu2r4ZjiKEVy0yVd66kXdmsl41bteOG2F2I2IBlPjmPV6p8ckjImQHxtNBIntFaQfNrdBhJg==}
+    engines: {node: '>=22'}
+
+  '@scalar/oas-utils@0.17.3':
+    resolution: {integrity: sha512-L9S3f1fRTdERL/bV/vBAJNL57OJcRnFifP8Zvy/Yjj0GJEDbs+32hmAc1YxqfRfy2+QtWq1Q2VfV2CN3R66Xkw==}
+    engines: {node: '>=22'}
+
+  '@scalar/openapi-types@0.9.0':
+    resolution: {integrity: sha512-XGuYegItO8iJbEy5hHxS04vyxoFIuERy3D/twt1hGPya6KJljg9iO0geZ/X5vjDKmSKYAuMNkGqYO5Jjp4NLUA==}
+    engines: {node: '>=22'}
+
+  '@scalar/openapi-upgrader@0.2.8':
+    resolution: {integrity: sha512-/SDb3+SIFuScKwrNRTFd7bklGDkayo81cHZlajXfUaT22Oc4VUlOUvyMXBLPa0miOfZTExYTM1I0BWW7Nujugw==}
+    engines: {node: '>=22'}
+
+  '@scalar/schemas@0.3.2':
+    resolution: {integrity: sha512-iadXBgJ02XUU5C5s6/xh/PmGLzUPd7X8upXIvPWBXDcQ4FHACNgkG8PPZ/beYM8UPDDkTUPM3ygEs0G6jKwGjQ==}
+    engines: {node: '>=22'}
+
+  '@scalar/sidebar@0.9.17':
+    resolution: {integrity: sha512-VppIBTv2EWVi/Ux5MI5FB1zRr1qvY10scYVNAVo+VwzsNyBeuOoCySKpJ61fHu2y45sYtTLuN80EHH8UfJ0S9A==}
+    engines: {node: '>=22'}
+
+  '@scalar/snippetz@0.9.11':
+    resolution: {integrity: sha512-n6zLzaCanvBWFQfR108jvu14m2JrDYRd9VMbQPOyjfU/QdraigQRctVcUOhjEUyb8O3d2Jye9V4KC5xmU47piA==}
+    engines: {node: '>=22'}
+
+  '@scalar/themes@0.15.5':
+    resolution: {integrity: sha512-ku8MPNBEXigx/ES0Wm7Mf8Ns+QMePEcMHraDZoA5Ab/UO97yTZIrvuo/gy143QB+NftnQ83vgeDYcCRi6I95tQ==}
+    engines: {node: '>=22'}
+
+  '@scalar/typebox@0.1.3':
+    resolution: {integrity: sha512-lU055AUccECZMIfGA0z/C1StYmboAYIPJLDFBzOO81yXBi35Pxdq+I4fWX6iUZ8qcoHneiLGk9jAUM1rA93iEg==}
+
+  '@scalar/types@0.12.2':
+    resolution: {integrity: sha512-EzLkubCb7xioiTm9eYnmn/032akaq4kkrrdclgV2uezwtniR8ErQICjhMl2AjBWL6nstHiFZ9RnPZm2Z2/KM0Q==}
+    engines: {node: '>=22'}
+
+  '@scalar/use-codemirror@0.14.11':
+    resolution: {integrity: sha512-5wtC4pUjzhy72j3aAueJg+fh9KflevJvXMn0YscsxiDTvqwIzeZcHe1N9VNtvzDXgLblEeBT6D0+Vs+boyExxg==}
+    engines: {node: '>=22'}
+
+  '@scalar/use-hooks@0.4.6':
+    resolution: {integrity: sha512-WhsTBk3e7R31yHWQWrrr/RVPGpqwY22RPHN3i4zdEv6llxrloDbkHTpwXCDHTnX92v2A7hKESR6JrGsXcKqrQw==}
+    engines: {node: '>=22'}
+
+  '@scalar/use-toasts@0.10.2':
+    resolution: {integrity: sha512-1iHQFbDXv0YQRp13aa63S5EcTJ5K8T0ocnLxk+nziloPrLjKt6jdRt6vOHsLSv5sm9kFKcVKNQTQgialmKCOGA==}
+    engines: {node: '>=22'}
+
+  '@scalar/validation@0.6.0':
+    resolution: {integrity: sha512-tpmmG+/xRE2Kn9RpflU3AIyZv08v10+E1ZrJCx7z6+/91zHVxy0M73kC1LT4/8PbYNt85ywyC8+n+D99JdMcGA==}
+    engines: {node: '>=20'}
+
+  '@scalar/workspace-store@0.52.0':
+    resolution: {integrity: sha512-8hlFKZ/Ubd8Wy8EYEdMLy04LG+QpaYdpnNjw8UWr27hB4mxANdBo38Vnkwk9yWb4KP2vlJoR4BA/tPIn3t4aFg==}
+    engines: {node: '>=22'}
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
@@ -4215,6 +4459,14 @@ packages:
     peerDependencies:
       tailwindcss: '>=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20 || >= 4.0.0-beta.1'
 
+  '@tanstack/virtual-core@3.16.0':
+    resolution: {integrity: sha512-Er2N7q3WOiH6y2JLxsxNX+u2/sLqSsL0bxFgDjuiPiA7vKhZRm+IzcS17vRee3GNXr64UsesA5CAp9yTiIYw9A==}
+
+  '@tanstack/vue-virtual@3.13.26':
+    resolution: {integrity: sha512-4TmREKi8rKiQC8E2XVEMMgzWbrgHNYolkBgYTXVK1kqXmXRGz6xPWgBq20GUYWUDDhit94+g0ricUQKpZhWRmg==}
+    peerDependencies:
+      vue: ^2.7.0 || ^3.0.0
+
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
@@ -4357,6 +4609,9 @@ packages:
   '@types/express@4.17.25':
     resolution: {integrity: sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==}
 
+  '@types/har-format@1.2.16':
+    resolution: {integrity: sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==}
+
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
@@ -4493,6 +4748,12 @@ packages:
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
+  '@types/web-bluetooth@0.0.20':
+    resolution: {integrity: sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==}
+
+  '@types/web-bluetooth@0.0.21':
+    resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
+
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
 
@@ -4561,6 +4822,11 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
     deprecated: Potential CWE-502 - Update to 1.3.1 or higher
+
+  '@unhead/vue@2.1.15':
+    resolution: {integrity: sha512-SSByXfEjhzPn8gXdEdgpYqpLMPSkLUH2HVE0GxZfOtNsJ0GgOHQs0g9T67ZZ1z0kTELLKdtOtYrzrbv9+ffF7g==}
+    peerDependencies:
+      vue: '>=3.5.18'
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -4723,6 +4989,99 @@ packages:
 
   '@verifactu/utils@file:packages/utils':
     resolution: {directory: packages/utils, type: directory}
+
+  '@vue/compiler-core@3.5.35':
+    resolution: {integrity: sha512-BUmHaR1J+O+CKZ9uJucdVTEr1LHsdyvv7vG3eNRhK3CczEHeMd/LtsHAuD7PbrxvI2envCY2v7HI1vC1aBRzKw==}
+
+  '@vue/compiler-dom@3.5.35':
+    resolution: {integrity: sha512-k+bprkXxuqhVajgTx5mUHuir7TwQzUKOWR40ng1ncAqQRPnrLngGGgqVEEhOnTMlc8btHYVKmrP8s5Qyg0hvYA==}
+
+  '@vue/compiler-sfc@3.5.35':
+    resolution: {integrity: sha512-G5VPMcXTSywXBgtFOZOnHKBxKSrwXUcvY1iaF5/hRcy7t0J6CH/d8ha9F4nzi00Fax1eLV0QHM7v4mQu68jydw==}
+
+  '@vue/compiler-ssr@3.5.35':
+    resolution: {integrity: sha512-rGhAeXgdM7/ffTJGXT69rCCdTmjDewnFuUZfBQQHTdcEBeWdT5HCGY60y2ytLJr9/Dsu7IntUi5z/w0h6Rjnzw==}
+
+  '@vue/reactivity@3.5.35':
+    resolution: {integrity: sha512-tVc+SsHConvh/Lz64qq1pP3rYArBmK42xonovEcxY74SQtvctZodG/zhq54P5dr38cVuw25d27cPNRdlMidpGQ==}
+
+  '@vue/runtime-core@3.5.35':
+    resolution: {integrity: sha512-A/xFNX9loIcWDygeQuNCfKuh0CoYBzxhqEMNah5TSFg9Z53DrFYEN2qi5CU9necjM1OWYegYREUTHmXTmhfXtg==}
+
+  '@vue/runtime-dom@3.5.35':
+    resolution: {integrity: sha512-odrJ1C391dbGnyDRh8U+rnP7J2amIEzfmRk5vXy7xi3aZhEXofTvpi0T4HJb6jlNqQZTNPR5MPHSB3RHNkIORA==}
+
+  '@vue/server-renderer@3.5.35':
+    resolution: {integrity: sha512-NkebSOYdB97wi8OQcO3HqzZSlymJi/aWsN/7h74OSVhRTm6qGs3Jp3e0rCXynmWwSlKeRrnlIug+ilYoHBmQDA==}
+    peerDependencies:
+      vue: 3.5.35
+
+  '@vue/shared@3.5.35':
+    resolution: {integrity: sha512-zSbjL7gRXwks2ZQLRGCajBtBXEOXW9Ddhn/HvSdrGkE2dqGnumzW8XtusRrxrE9LvqtiqDXQ+A60Hp6mvdYxfA==}
+
+  '@vueuse/core@10.11.1':
+    resolution: {integrity: sha512-guoy26JQktXPcz+0n3GukWIy/JDNKti9v6VEMu6kV2sYBsWuGiTU8OWdg+ADfUbHg3/3DlqySDe7JmdHrktiww==}
+
+  '@vueuse/core@13.9.0':
+    resolution: {integrity: sha512-ts3regBQyURfCE2BcytLqzm8+MmLlo5Ln/KLoxDVcsZ2gzIwVNnQpQOL/UKV8alUqjSZOlpFZcRNsLRqj+OzyA==}
+    peerDependencies:
+      vue: ^3.5.0
+
+  '@vueuse/integrations@13.9.0':
+    resolution: {integrity: sha512-SDobKBbPIOe0cVL7QxMzGkuUGHvWTdihi9zOrrWaWUgFKe15cwEcwfWmgrcNzjT6kHnNmWuTajPHoIzUjYNYYQ==}
+    peerDependencies:
+      async-validator: ^4
+      axios: ^1.16.0
+      change-case: ^5
+      drauu: ^0.4
+      focus-trap: ^7
+      fuse.js: ^7
+      idb-keyval: ^6
+      jwt-decode: ^4
+      nprogress: ^0.2
+      qrcode: ^1.5
+      sortablejs: ^1
+      universal-cookie: ^7 || ^8
+      vue: ^3.5.0
+    peerDependenciesMeta:
+      async-validator:
+        optional: true
+      axios:
+        optional: true
+      change-case:
+        optional: true
+      drauu:
+        optional: true
+      focus-trap:
+        optional: true
+      fuse.js:
+        optional: true
+      idb-keyval:
+        optional: true
+      jwt-decode:
+        optional: true
+      nprogress:
+        optional: true
+      qrcode:
+        optional: true
+      sortablejs:
+        optional: true
+      universal-cookie:
+        optional: true
+
+  '@vueuse/metadata@10.11.1':
+    resolution: {integrity: sha512-IGa5FXd003Ug1qAZmyE8wF3sJ81xGLSqTqtQ6jaVfkeZ4i5kS2mwQF61yhVqojRnenVew5PldLyRgvdl4YYuSw==}
+
+  '@vueuse/metadata@13.9.0':
+    resolution: {integrity: sha512-1AFRvuiGphfF7yWixZa0KwjYH8ulyjDCC0aFgrGRz8+P4kvDFSdXLVfTk5xAN9wEuD1J6z4/myMoYbnHoX07zg==}
+
+  '@vueuse/shared@10.11.1':
+    resolution: {integrity: sha512-LHpC8711VFZlDaYUXEBbFBCQ7GS3dVU9mjOhhMhXP6txTV4EhYQg/KGnQuvt/sPAtoUKq7VVUnL6mVtFoL42sA==}
+
+  '@vueuse/shared@13.9.0':
+    resolution: {integrity: sha512-e89uuTLMh0U5cZ9iDpEI2senqPGfbPRTHM/0AaQkcxnpqjkZqDYP8rpfm7edOz8s+pOCOROEy1PIveSW8+fL5g==}
+    peerDependencies:
+      vue: ^3.5.0
 
   '@workflow/astro@4.0.0-beta.38':
     resolution: {integrity: sha512-Lm+eU9elzELvhM2DSJqMoeV/KkwE+pmM2G/qqBbOGN0ySZb5ekb3pqF+KsfagbezxoD78u+tfFpyGvnhi6S/rg==}
@@ -4910,6 +5269,12 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
+  ai@6.0.33:
+    resolution: {integrity: sha512-bVokbmy2E2QF6Efl+5hOJx5MRWoacZ/CZY/y1E+VcewknvGlgaiCzMu8Xgddz6ArFJjiMFNUPHKxAhIePE4rmg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   ai@6.0.49:
     resolution: {integrity: sha512-LABniBX/0R6Tv+iUK5keUZhZLaZUe4YjP5M2rZ4wAdZ8iKV3EfTAoJxuL1aaWTSJKIilKa9QUEkCgnp89/32bw==}
     engines: {node: '>=18'}
@@ -5009,6 +5374,10 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
 
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
@@ -5633,6 +6002,9 @@ packages:
     resolution: {integrity: sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==}
     engines: {node: '>= 10'}
 
+  crelt@1.0.6:
+    resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
+
   cross-env@10.1.0:
     resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
     engines: {node: '>=20'}
@@ -5675,6 +6047,14 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  cva@1.0.0-beta.4:
+    resolution: {integrity: sha512-F/JS9hScapq4DBVQXcK85l9U91M6ePeXoBMSp7vypzShoefUBxjQTo3g3935PUHgQd+IW77DjbPRIxugy4/GCQ==}
+    peerDependencies:
+      typescript: '>= 4.5.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   d3-array@3.2.4:
     resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
@@ -6032,6 +6412,10 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
@@ -6252,6 +6636,9 @@ packages:
 
   estree-util-is-identifier-name@3.0.0:
     resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -6503,6 +6890,9 @@ packages:
   fn.name@1.1.0:
     resolution: {integrity: sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==}
 
+  focus-trap@7.8.0:
+    resolution: {integrity: sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==}
+
   follow-redirects@1.16.0:
     resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
@@ -6628,6 +7018,10 @@ packages:
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
+  fuse.js@7.3.0:
+    resolution: {integrity: sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w==}
+    engines: {node: '>=10'}
+
   gauge@3.0.2:
     resolution: {integrity: sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==}
     engines: {node: '>=10'}
@@ -6675,6 +7069,10 @@ packages:
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
+
+  get-own-enumerable-keys@1.0.0:
+    resolution: {integrity: sha512-PKsK2FSrQCyxcGHsGrLDcK0lx+0Ke+6e8KFFozA9/fIQLhQzPaRvJFdcz7+Axg3jUH/Mq+NI4xa5u/UT2tQskA==}
+    engines: {node: '>=14.16'}
 
   get-package-type@0.1.0:
     resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
@@ -6805,6 +7203,10 @@ packages:
     resolution: {integrity: sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==}
     engines: {node: '>=18'}
 
+  guess-json-indent@3.0.1:
+    resolution: {integrity: sha512-LWZ3Vr8BG7DHE3TzPYFqkhjNRw4vYgFSsv2nfMuHklAlOfiy54/EwiDQuQfFVLxENCVv20wpbjfTayooQHrEhQ==}
+    engines: {node: '>=18.18.0'}
+
   handlebars@4.7.9:
     resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
     engines: {node: '>=0.4.7'}
@@ -6848,11 +7250,59 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hast-util-embedded@3.0.0:
+    resolution: {integrity: sha512-naH8sld4Pe2ep03qqULEtvYr7EjrLK2QHY8KJR6RJkTUjPGObe1vnx585uzem2hGra+s1q08DZZpfgDVYRbaXA==}
+
+  hast-util-format@1.1.0:
+    resolution: {integrity: sha512-yY1UDz6bC9rDvCWHpx12aIBGRG7krurX0p0Fm6pT547LwDIZZiNr8a+IHDogorAdreULSEzP82Nlv5SZkHZcjA==}
+
+  hast-util-from-html@2.0.3:
+    resolution: {integrity: sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==}
+
+  hast-util-from-parse5@8.0.3:
+    resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
+
+  hast-util-has-property@3.0.0:
+    resolution: {integrity: sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA==}
+
+  hast-util-is-body-ok-link@3.0.1:
+    resolution: {integrity: sha512-0qpnzOBLztXHbHQenVB8uNuxTnm/QBFUOmdOSsEn7GnBtyY07+ENTWVFBAnXd/zEgd9/SUG3lRY7hSIBWRgGpQ==}
+
+  hast-util-is-element@3.0.0:
+    resolution: {integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==}
+
+  hast-util-minify-whitespace@1.0.1:
+    resolution: {integrity: sha512-L96fPOVpnclQE0xzdWb/D12VT5FabA7SnZOUMtL1DbXmYiHJMXZvFkIZfiMmTCNJHUeO2K9UYNXoVyfz+QHuOw==}
+
+  hast-util-parse-selector@4.0.0:
+    resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
+
+  hast-util-phrasing@3.0.1:
+    resolution: {integrity: sha512-6h60VfI3uBQUxHqTyMymMZnEbNl1XmEGtOxxKYL7stY2o601COo62AWAYBQR9lZbYXYSBoxag8UpPRXK+9fqSQ==}
+
+  hast-util-raw@9.1.0:
+    resolution: {integrity: sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==}
+
+  hast-util-sanitize@5.0.2:
+    resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
+
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
+  hast-util-to-parse5@8.0.1:
+    resolution: {integrity: sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==}
+
+  hast-util-to-text@4.0.2:
+    resolution: {integrity: sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==}
+
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  hastscript@9.0.1:
+    resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
@@ -6870,12 +7320,19 @@ packages:
     engines: {node: '>= 0.10.x'}
     hasBin: true
 
+  highlight.js@11.11.1:
+    resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
+    engines: {node: '>=12.0.0'}
+
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
   hono@4.12.18:
     resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
     engines: {node: '>=16.9.0'}
+
+  hookable@6.1.1:
+    resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
 
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
@@ -6893,6 +7350,12 @@ packages:
 
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  html-whitespace-sensitive-tag-names@3.0.1:
+    resolution: {integrity: sha512-q+310vW8zmymYHALr1da4HyXUQ0zgiIwIicEfotYPWGN0OJVEN/58IJ3A4GBYcEq3LGAZqKb+ugvP0GNB9CEAA==}
 
   htmlparser2@8.0.2:
     resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
@@ -6958,6 +7421,10 @@ packages:
 
   idb@7.1.1:
     resolution: {integrity: sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==}
+
+  identifier-regex@1.0.1:
+    resolution: {integrity: sha512-ZrYyM0sozNPZlvBvE7Oq9Bn44n0qKGrYu5sQ0JzMUnjIhpgWYE2JB6aBoFwEYdPjqj7jPyxXTMJiHDOxDfd8yw==}
+    engines: {node: '>=18'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -7029,6 +7496,10 @@ packages:
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
+
+  is-absolute-url@4.0.1:
+    resolution: {integrity: sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -7122,6 +7593,10 @@ packages:
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
+  is-identifier@1.0.1:
+    resolution: {integrity: sha512-HQ5v4rEJ7REUV54bCd2l5FaD299SGDEn2UPoVXaTHAyGviLq2menVUD2udi3trQ32uvB6LdAh/0ck2EuizrtpA==}
+    engines: {node: '>=18'}
+
   is-inside-container@1.0.0:
     resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
     engines: {node: '>=14.16'}
@@ -7151,6 +7626,10 @@ packages:
     resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
     engines: {node: '>=8'}
 
+  is-obj@3.0.0:
+    resolution: {integrity: sha512-IlsXEHOjtKhpN8r/tRFj2nDyTmHvcfNeu/nrRIcXE17ROeatXchkojffa1SpdqW4cr/Fj6QkEf/Gn4zf6KKvEQ==}
+    engines: {node: '>=12'}
+
   is-path-inside@3.0.3:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
     engines: {node: '>=8'}
@@ -7176,6 +7655,10 @@ packages:
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
+
+  is-regexp@3.1.0:
+    resolution: {integrity: sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==}
+    engines: {node: '>=12'}
 
   is-set@2.0.3:
     resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
@@ -7459,6 +7942,9 @@ packages:
   jquery@3.7.1:
     resolution: {integrity: sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==}
 
+  js-base64@3.7.8:
+    resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
+
   js-beautify@1.15.4:
     resolution: {integrity: sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==}
     engines: {node: '>=14'}
@@ -7535,6 +8021,9 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
@@ -7753,6 +8242,9 @@ packages:
     resolution: {integrity: sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  lowlight@3.3.0:
+    resolution: {integrity: sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -7881,6 +8373,9 @@ packages:
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
     engines: {node: '>= 0.6'}
+
+  microdiff@1.5.0:
+    resolution: {integrity: sha512-Drq+/THMvDdzRYrK0oxJmOKiC24ayUV8ahrt8l3oRK51PWt6gdtrIGrlIH3pT/lFh1z93FbAcidtsHcWbnRz8Q==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -8133,6 +8628,11 @@ packages:
 
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+
+  neverpanic@0.0.7:
+    resolution: {integrity: sha512-GFRTSX2JAEATOCQYlyFkR+9FJPl0pD24toE1foqYAsL6aPLlRKn6L0UFOtJhZCxEbDv+SUsiW4AcPs9cIFwkFw==}
+    peerDependencies:
+      typescript: '5'
 
   next-auth@4.24.13:
     resolution: {integrity: sha512-sgObCfcfL7BzIK76SS5TnQtc3yo2Oifp/yIpfv6fMfeBOiBJkDWF3A2y9+yqnmJ4JKc2C+nMjSjmgDeTwgN1rQ==}
@@ -8805,6 +9305,11 @@ packages:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
 
+  radix-vue@1.9.17:
+    resolution: {integrity: sha512-mVCu7I2vXt1L2IUYHTt0sZMz7s1K2ZtqKeTIxG3yC5mMFfLBG4FtE1FDeRMpDd+Hhg/ybi9+iXmAP1ISREndoQ==}
+    peerDependencies:
+      vue: '>= 3.2.0'
+
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
@@ -9002,6 +9507,24 @@ packages:
     resolution: {integrity: sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==}
     hasBin: true
 
+  rehype-external-links@3.0.0:
+    resolution: {integrity: sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==}
+
+  rehype-format@5.0.1:
+    resolution: {integrity: sha512-zvmVru9uB0josBVpr946OR8ui7nJEdzZobwLOOqHb/OOD88W0Vk2SqLwoVOj0fM6IPCCO6TaV9CvQvJMWwukFQ==}
+
+  rehype-parse@9.0.1:
+    resolution: {integrity: sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==}
+
+  rehype-raw@7.0.0:
+    resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
+
+  rehype-sanitize@6.0.0:
+    resolution: {integrity: sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==}
+
+  rehype-stringify@10.0.1:
+    resolution: {integrity: sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==}
+
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
 
@@ -9048,6 +9571,10 @@ packages:
     peerDependenciesMeta:
       '@react-email/render':
         optional: true
+
+  reserved-identifiers@1.2.0:
+    resolution: {integrity: sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==}
+    engines: {node: '>=18'}
 
   resolve-alpn@1.2.1:
     resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
@@ -9246,6 +9773,9 @@ packages:
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
+  set-cookie-parser@3.1.0:
+    resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
+
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
@@ -9395,6 +9925,14 @@ packages:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
     engines: {node: '>=0.6.19'}
 
+  string-byte-length@3.0.1:
+    resolution: {integrity: sha512-yJ8vP0HMwZ54CcA8S8mKoXbkezpZHANFtmafFo8lGxZThCQcAwRHjdFabuSLgOzxj9OFJcmssmiAvmcOK4O2Hw==}
+    engines: {node: '>=18.18.0'}
+
+  string-byte-slice@3.0.1:
+    resolution: {integrity: sha512-GWv2K4lYyd2+AhmKH3BV+OVx62xDX+99rSLfKpaqFiQU7uOMaUY1tDjdrRD4gsrCr9lTyjMgjna7tZcCOw+Smg==}
+    engines: {node: '>=18.18.0'}
+
   string-length@4.0.2:
     resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
     engines: {node: '>=10'}
@@ -9449,6 +9987,10 @@ packages:
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
+  stringify-object@6.0.0:
+    resolution: {integrity: sha512-6f94vIED6vmJJfh3lyVsVWxCYSfI5uM+16ntED/Ql37XIyV6kj0mRAAiTeMMc/QLYIaizC3bUprQ8pQnDDrKfA==}
+    engines: {node: '>=20'}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -9515,6 +10057,9 @@ packages:
 
   stubs@3.0.0:
     resolution: {integrity: sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==}
+
+  style-mod@4.1.3:
+    resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
 
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
@@ -9591,6 +10136,11 @@ packages:
     resolution: {integrity: sha512-4gILrI3vXZqoZh71I1PALqukCFgk+gpOwe1tOvz5uE9kHtl2gTDzmYflYCwWvR4LOvCrJi6UEEU+gnuW5BtkgQ==}
     engines: {node: '>= 4.7.0'}
 
+  swrv@1.2.0:
+    resolution: {integrity: sha512-lH/g4UcNyj+7lzK4eRGT4C68Q4EhQ6JtM9otPRIASfhhzfLWtbZPHcMuhuba7S9YVYuxkMUGImwMyGpfbkH07A==}
+    peerDependencies:
+      vue: '>=3.2.26 < 4'
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -9598,8 +10148,18 @@ packages:
     resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
+  tabbable@6.4.0:
+    resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
+
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   tailwind-merge@2.6.0:
     resolution: {integrity: sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==}
+
+  tailwind-merge@3.5.0:
+    resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
 
   tailwindcss@3.4.19:
     resolution: {integrity: sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==}
@@ -9739,6 +10299,10 @@ packages:
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
+  truncate-json@3.0.1:
+    resolution: {integrity: sha512-QVsbr1WhGLq2F0oDyYbqtOXcf3gcnL8C9H5EX8bBwAr8ZWvWGJzukpPrDrWgJMrNtgDbo74BIjI4kJu3q2xQWw==}
+    engines: {node: '>=18.18.0'}
+
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
@@ -9785,6 +10349,10 @@ packages:
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
+
+  type-fest@5.6.0:
+    resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
+    engines: {node: '>=20'}
 
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
@@ -9858,6 +10426,9 @@ packages:
     resolution: {integrity: sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==}
     engines: {node: '>=18.17'}
 
+  unhead@2.1.15:
+    resolution: {integrity: sha512-MCt5T90mCWyr3Z6pUCdM9lVRXoMoVBlL7z7U4CYVIiaDiuzad/UCfLuMqz5MeNmpZUgoBCQnrucJimU7EZR+XA==}
+
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
     engines: {node: '>=4'}
@@ -9890,6 +10461,9 @@ packages:
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-find-after@5.0.0:
+    resolution: {integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==}
 
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
@@ -9967,6 +10541,9 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  vfile-location@5.0.3:
+    resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
+
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
 
@@ -9975,6 +10552,34 @@ packages:
 
   victory-vendor@37.3.6:
     resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
+
+  vue-component-type-helpers@3.3.2:
+    resolution: {integrity: sha512-l4Z2Y34m7nFMlx8vrslJaVtXxUpzgDMSESC7TakG/c5kwjYT/do+E0NcT2/vWDzaoIhsShg/2OKwX7Q4nbzC0g==}
+
+  vue-demi@0.14.10:
+    resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
+    engines: {node: '>=12'}
+    hasBin: true
+    peerDependencies:
+      '@vue/composition-api': ^1.0.0-rc.1
+      vue: ^3.0.0-0 || ^2.6.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
+
+  vue-sonner@1.3.2:
+    resolution: {integrity: sha512-UbZ48E9VIya3ToiRHAZUbodKute/z/M1iT8/3fU8zEbwBRE11AKuHikssv18LMk2gTTr6eMQT4qf6JoLHWuj/A==}
+
+  vue@3.5.35:
+    resolution: {integrity: sha512-cx89fnr+0kVGHiNFG6y6s0bdjypJRFNZn6x3WPstNdQR1bi1mbB7h4v5IBGTsPJU3nK1+0Iqj3Zf+hZWMieR4Q==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
@@ -9989,6 +10594,9 @@ packages:
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+
+  web-namespaces@2.0.1:
+    resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
@@ -10256,6 +10864,13 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
+  '@ai-sdk/gateway@3.0.13(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.2
+      '@ai-sdk/provider-utils': 4.0.5(zod@4.3.6)
+      '@vercel/oidc': 3.1.0
+      zod: 4.3.6
+
   '@ai-sdk/gateway@3.0.22(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.5
@@ -10269,6 +10884,13 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.9(zod@4.3.6)
       zod: 4.3.6
 
+  '@ai-sdk/provider-utils@4.0.5(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.2
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 4.3.6
+
   '@ai-sdk/provider-utils@4.0.9(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.5
@@ -10276,9 +10898,22 @@ snapshots:
       eventsource-parser: 3.0.6
       zod: 4.3.6
 
+  '@ai-sdk/provider@3.0.2':
+    dependencies:
+      json-schema: 0.4.0
+
   '@ai-sdk/provider@3.0.5':
     dependencies:
       json-schema: 0.4.0
+
+  '@ai-sdk/vue@3.0.33(vue@3.5.35(typescript@5.9.3))(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider-utils': 4.0.5(zod@4.3.6)
+      ai: 6.0.33(zod@4.3.6)
+      swrv: 1.2.0(vue@3.5.35(typescript@5.9.3))
+      vue: 3.5.35(typescript@5.9.3)
+    transitivePeerDependencies:
+      - zod
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -10528,7 +11163,7 @@ snapshots:
       '@babel/types': 7.28.6
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -10580,7 +11215,7 @@ snapshots:
       '@babel/core': 7.28.6
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       lodash.debounce: 4.0.8
       resolve: 1.22.11
     transitivePeerDependencies:
@@ -10644,7 +11279,11 @@ snapshots:
 
   '@babel/helper-string-parser@7.27.1': {}
 
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/helper-validator-option@7.27.1': {}
 
@@ -10664,6 +11303,10 @@ snapshots:
   '@babel/parser@7.28.6':
     dependencies:
       '@babel/types': 7.28.6
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
 
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.28.6)':
     dependencies:
@@ -11300,7 +11943,7 @@ snapshots:
       '@babel/parser': 7.28.6
       '@babel/template': 7.28.6
       '@babel/types': 7.28.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -11308,6 +11951,11 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@bcoe/v8-coverage@0.2.3': {}
 
@@ -11333,6 +11981,100 @@ snapshots:
 
   '@cfworker/json-schema@4.1.1':
     optional: true
+
+  '@codemirror/autocomplete@6.20.2':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      '@lezer/common': 1.5.2
+
+  '@codemirror/commands@6.10.3':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      '@lezer/common': 1.5.2
+
+  '@codemirror/lang-css@6.3.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.2
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.3
+
+  '@codemirror/lang-html@6.4.11':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.2
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.3
+      '@lezer/html': 1.3.13
+
+  '@codemirror/lang-javascript@6.2.5':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.2
+      '@codemirror/language': 6.12.3
+      '@codemirror/lint': 6.9.6
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      '@lezer/common': 1.5.2
+      '@lezer/javascript': 1.5.4
+
+  '@codemirror/lang-json@6.0.2':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@lezer/json': 1.0.3
+
+  '@codemirror/lang-xml@6.1.0':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.2
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      '@lezer/common': 1.5.2
+      '@lezer/xml': 1.0.6
+
+  '@codemirror/lang-yaml@6.1.3':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.2
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+      '@lezer/yaml': 1.0.4
+
+  '@codemirror/language@6.12.3':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+      style-mod: 4.1.3
+
+  '@codemirror/lint@6.9.6':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      crelt: 1.0.6
+
+  '@codemirror/state@6.6.0':
+    dependencies:
+      '@marijn/find-cluster-break': 1.0.2
+
+  '@codemirror/view@6.43.0':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      crelt: 1.0.6
+      style-mod: 4.1.3
+      w3c-keyname: 2.2.8
 
   '@colors/colors@1.6.0': {}
 
@@ -11546,7 +12288,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.14.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -11560,7 +12302,7 @@ snapshots:
   '@eslint/eslintrc@3.3.3':
     dependencies:
       ajv: 6.14.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -11912,6 +12654,28 @@ snapshots:
 
   '@firebase/webchannel-wrapper@1.0.5': {}
 
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/utils@0.2.10': {}
+
+  '@floating-ui/utils@0.2.11': {}
+
+  '@floating-ui/vue@1.1.9(vue@3.5.35(typescript@5.9.3))':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      '@floating-ui/utils': 0.2.10
+      vue-demi: 0.14.10(vue@3.5.35(typescript@5.9.3))
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+
   '@fullcalendar/core@6.1.20':
     dependencies:
       preact: 10.12.1
@@ -12254,6 +13018,15 @@ snapshots:
       protobufjs: 7.6.1
       yargs: 17.7.2
 
+  '@headlessui/tailwindcss@0.2.2(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))':
+    dependencies:
+      tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.8.4)
+
+  '@headlessui/vue@1.7.23(vue@3.5.35(typescript@5.9.3))':
+    dependencies:
+      '@tanstack/vue-virtual': 3.13.26(vue@3.5.35(typescript@5.9.3))
+      vue: 3.5.35(typescript@5.9.3)
+
   '@hono/node-server@1.19.14(hono@4.12.18)':
     dependencies:
       hono: 4.12.18
@@ -12261,7 +13034,7 @@ snapshots:
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
@@ -12366,6 +13139,14 @@ snapshots:
 
   '@img/sharp-win32-x64@0.34.5':
     optional: true
+
+  '@internationalized/date@3.12.1':
+    dependencies:
+      '@swc/helpers': 0.5.18
+
+  '@internationalized/number@3.6.6':
+    dependencies:
+      '@swc/helpers': 0.5.18
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -12603,6 +13384,52 @@ snapshots:
 
   '@keyv/serialize@1.1.1': {}
 
+  '@lezer/common@1.5.2': {}
+
+  '@lezer/css@1.3.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/highlight@1.2.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/html@1.3.13':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/javascript@1.5.4':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/json@1.0.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/lr@1.4.10':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/xml@1.0.6':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/yaml@1.0.4':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
   '@lukeed/csprng@1.1.0': {}
 
   '@mapbox/node-pre-gyp@1.0.11':
@@ -12619,6 +13446,8 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  '@marijn/find-cluster-break@1.0.2': {}
 
   '@mjackson/node-fetch-server@0.2.0': {}
 
@@ -12749,7 +13578,7 @@ snapshots:
       tslib: 2.8.1
       uid: 2.0.2
 
-  '@next-auth/prisma-adapter@1.0.7(@prisma/client@5.22.0(prisma@5.22.0))(next-auth@4.24.13(next@15.5.18(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
+  '@next-auth/prisma-adapter@1.0.7(@prisma/client@5.22.0(prisma@5.22.0))(next-auth@4.24.13(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
     dependencies:
       '@prisma/client': 5.22.0(prisma@5.22.0)
       next-auth: 4.24.13(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -13499,6 +14328,8 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.8.0
 
+  '@phosphor-icons/core@2.1.1': {}
+
   '@pinojs/redact@0.4.0': {}
 
   '@pkgjs/parseargs@0.11.0':
@@ -13604,7 +14435,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@18.3.27)(react@18.2.0)(redux@5.0.1))(react@18.2.0)':
+  '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@18.3.27)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@standard-schema/utils': 0.3.0
@@ -13616,9 +14447,343 @@ snapshots:
       react: 18.2.0
       react-redux: 9.2.0(@types/react@18.3.27)(react@18.2.0)(redux@5.0.1)
 
+  '@replit/codemirror-css-color-picker@6.3.0(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0)':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.15.0': {}
+
+  '@scalar/agent-chat@0.12.5(axios@1.16.0)(qrcode@1.5.4)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))(typescript@5.9.3)(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/vue': 3.0.33(vue@3.5.35(typescript@5.9.3))(zod@4.3.6)
+      '@scalar/api-client': 3.8.5(axios@1.16.0)(qrcode@1.5.4)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))(typescript@5.9.3)
+      '@scalar/components': 0.26.0(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))(typescript@5.9.3)
+      '@scalar/helpers': 0.8.0
+      '@scalar/icons': 0.7.2(typescript@5.9.3)
+      '@scalar/json-magic': 0.12.14
+      '@scalar/openapi-types': 0.9.0
+      '@scalar/schemas': 0.3.2
+      '@scalar/themes': 0.15.5
+      '@scalar/types': 0.12.2
+      '@scalar/use-toasts': 0.10.2(typescript@5.9.3)
+      '@scalar/validation': 0.6.0
+      '@scalar/workspace-store': 0.52.0(typescript@5.9.3)
+      '@vueuse/core': 13.9.0(vue@3.5.35(typescript@5.9.3))
+      ai: 6.0.33(zod@4.3.6)
+      js-base64: 3.7.8
+      neverpanic: 0.0.7(typescript@5.9.3)
+      truncate-json: 3.0.1
+      vue: 3.5.35(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - async-validator
+      - axios
+      - change-case
+      - drauu
+      - idb-keyval
+      - jwt-decode
+      - nprogress
+      - qrcode
+      - sortablejs
+      - supports-color
+      - tailwindcss
+      - typescript
+      - universal-cookie
+      - zod
+
+  '@scalar/api-client@3.8.5(axios@1.16.0)(qrcode@1.5.4)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))(typescript@5.9.3)':
+    dependencies:
+      '@headlessui/tailwindcss': 0.2.2(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
+      '@headlessui/vue': 1.7.23(vue@3.5.35(typescript@5.9.3))
+      '@scalar/components': 0.26.0(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))(typescript@5.9.3)
+      '@scalar/helpers': 0.8.0
+      '@scalar/icons': 0.7.2(typescript@5.9.3)
+      '@scalar/json-magic': 0.12.14
+      '@scalar/oas-utils': 0.17.3(typescript@5.9.3)
+      '@scalar/openapi-types': 0.9.0
+      '@scalar/sidebar': 0.9.17(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))(typescript@5.9.3)
+      '@scalar/snippetz': 0.9.11
+      '@scalar/themes': 0.15.5
+      '@scalar/typebox': 0.1.3
+      '@scalar/types': 0.12.2
+      '@scalar/use-codemirror': 0.14.11(typescript@5.9.3)
+      '@scalar/use-hooks': 0.4.6(typescript@5.9.3)
+      '@scalar/use-toasts': 0.10.2(typescript@5.9.3)
+      '@scalar/workspace-store': 0.52.0(typescript@5.9.3)
+      '@types/har-format': 1.2.16
+      '@vueuse/core': 13.9.0(vue@3.5.35(typescript@5.9.3))
+      '@vueuse/integrations': 13.9.0(axios@1.16.0)(focus-trap@7.8.0)(fuse.js@7.3.0)(qrcode@1.5.4)(vue@3.5.35(typescript@5.9.3))
+      cookie: 0.7.0
+      focus-trap: 7.8.0
+      fuse.js: 7.3.0
+      js-base64: 3.7.8
+      jsonc-parser: 3.3.1
+      nanoid: 5.1.6
+      pretty-ms: 9.3.0
+      radix-vue: 1.9.17(vue@3.5.35(typescript@5.9.3))
+      set-cookie-parser: 3.1.0
+      vue: 3.5.35(typescript@5.9.3)
+      yaml: 2.8.4
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - async-validator
+      - axios
+      - change-case
+      - drauu
+      - idb-keyval
+      - jwt-decode
+      - nprogress
+      - qrcode
+      - sortablejs
+      - supports-color
+      - tailwindcss
+      - typescript
+      - universal-cookie
+
+  '@scalar/api-reference-react@0.9.41(axios@1.16.0)(qrcode@1.5.4)(react@18.2.0)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))(typescript@5.9.3)(zod@4.3.6)':
+    dependencies:
+      '@scalar/api-reference': 1.57.5(axios@1.16.0)(qrcode@1.5.4)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))(typescript@5.9.3)(zod@4.3.6)
+      '@scalar/types': 0.12.2
+      react: 18.2.0
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - async-validator
+      - axios
+      - change-case
+      - drauu
+      - idb-keyval
+      - jwt-decode
+      - nprogress
+      - qrcode
+      - sortablejs
+      - supports-color
+      - tailwindcss
+      - typescript
+      - universal-cookie
+      - zod
+
+  '@scalar/api-reference@1.57.5(axios@1.16.0)(qrcode@1.5.4)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))(typescript@5.9.3)(zod@4.3.6)':
+    dependencies:
+      '@headlessui/vue': 1.7.23(vue@3.5.35(typescript@5.9.3))
+      '@scalar/agent-chat': 0.12.5(axios@1.16.0)(qrcode@1.5.4)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))(typescript@5.9.3)(zod@4.3.6)
+      '@scalar/api-client': 3.8.5(axios@1.16.0)(qrcode@1.5.4)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))(typescript@5.9.3)
+      '@scalar/code-highlight': 0.3.4
+      '@scalar/components': 0.26.0(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))(typescript@5.9.3)
+      '@scalar/helpers': 0.8.0
+      '@scalar/icons': 0.7.2(typescript@5.9.3)
+      '@scalar/oas-utils': 0.17.3(typescript@5.9.3)
+      '@scalar/schemas': 0.3.2
+      '@scalar/sidebar': 0.9.17(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))(typescript@5.9.3)
+      '@scalar/snippetz': 0.9.11
+      '@scalar/themes': 0.15.5
+      '@scalar/types': 0.12.2
+      '@scalar/use-hooks': 0.4.6(typescript@5.9.3)
+      '@scalar/use-toasts': 0.10.2(typescript@5.9.3)
+      '@scalar/validation': 0.6.0
+      '@scalar/workspace-store': 0.52.0(typescript@5.9.3)
+      '@unhead/vue': 2.1.15(vue@3.5.35(typescript@5.9.3))
+      '@vueuse/core': 13.9.0(vue@3.5.35(typescript@5.9.3))
+      fuse.js: 7.3.0
+      microdiff: 1.5.0
+      nanoid: 5.1.6
+      vue: 3.5.35(typescript@5.9.3)
+      yaml: 2.8.4
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - async-validator
+      - axios
+      - change-case
+      - drauu
+      - idb-keyval
+      - jwt-decode
+      - nprogress
+      - qrcode
+      - sortablejs
+      - supports-color
+      - tailwindcss
+      - typescript
+      - universal-cookie
+      - zod
+
+  '@scalar/code-highlight@0.3.4':
+    dependencies:
+      hast-util-to-text: 4.0.2
+      highlight.js: 11.11.1
+      lowlight: 3.3.0
+      rehype-external-links: 3.0.0
+      rehype-format: 5.0.1
+      rehype-parse: 9.0.1
+      rehype-raw: 7.0.0
+      rehype-sanitize: 6.0.0
+      rehype-stringify: 10.0.1
+      remark-gfm: 4.0.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@scalar/components@0.26.0(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))(typescript@5.9.3)':
+    dependencies:
+      '@floating-ui/utils': 0.2.10
+      '@floating-ui/vue': 1.1.9(vue@3.5.35(typescript@5.9.3))
+      '@headlessui/tailwindcss': 0.2.2(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
+      '@headlessui/vue': 1.7.23(vue@3.5.35(typescript@5.9.3))
+      '@scalar/code-highlight': 0.3.4
+      '@scalar/helpers': 0.8.0
+      '@scalar/icons': 0.7.2(typescript@5.9.3)
+      '@scalar/themes': 0.15.5
+      '@scalar/use-hooks': 0.4.6(typescript@5.9.3)
+      '@vueuse/core': 13.9.0(vue@3.5.35(typescript@5.9.3))
+      cva: 1.0.0-beta.4(typescript@5.9.3)
+      nanoid: 5.1.6
+      radix-vue: 1.9.17(vue@3.5.35(typescript@5.9.3))
+      vue: 3.5.35(typescript@5.9.3)
+      vue-component-type-helpers: 3.3.2
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - supports-color
+      - tailwindcss
+      - typescript
+
+  '@scalar/helpers@0.8.0': {}
+
+  '@scalar/icons@0.7.2(typescript@5.9.3)':
+    dependencies:
+      '@phosphor-icons/core': 2.1.1
+      '@types/node': 24.8.1
+      chalk: 5.6.2
+      vue: 3.5.35(typescript@5.9.3)
+    transitivePeerDependencies:
+      - typescript
+
+  '@scalar/json-magic@0.12.14':
+    dependencies:
+      '@scalar/helpers': 0.8.0
+      pathe: 2.0.3
+      yaml: 2.8.4
+
+  '@scalar/oas-utils@0.17.3(typescript@5.9.3)':
+    dependencies:
+      '@scalar/helpers': 0.8.0
+      '@scalar/themes': 0.15.5
+      '@scalar/types': 0.12.2
+      '@scalar/workspace-store': 0.52.0(typescript@5.9.3)
+      flatted: 3.4.2
+      vue: 3.5.35(typescript@5.9.3)
+      yaml: 2.8.4
+    transitivePeerDependencies:
+      - typescript
+
+  '@scalar/openapi-types@0.9.0': {}
+
+  '@scalar/openapi-upgrader@0.2.8':
+    dependencies:
+      '@scalar/openapi-types': 0.9.0
+
+  '@scalar/schemas@0.3.2':
+    dependencies:
+      '@scalar/helpers': 0.8.0
+      '@scalar/validation': 0.6.0
+
+  '@scalar/sidebar@0.9.17(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))(typescript@5.9.3)':
+    dependencies:
+      '@scalar/components': 0.26.0(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))(typescript@5.9.3)
+      '@scalar/helpers': 0.8.0
+      '@scalar/icons': 0.7.2(typescript@5.9.3)
+      '@scalar/themes': 0.15.5
+      '@scalar/use-hooks': 0.4.6(typescript@5.9.3)
+      '@scalar/workspace-store': 0.52.0(typescript@5.9.3)
+      vue: 3.5.35(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - supports-color
+      - tailwindcss
+      - typescript
+
+  '@scalar/snippetz@0.9.11':
+    dependencies:
+      '@scalar/helpers': 0.8.0
+      '@scalar/types': 0.12.2
+      js-base64: 3.7.8
+      stringify-object: 6.0.0
+
+  '@scalar/themes@0.15.5':
+    dependencies:
+      nanoid: 5.1.6
+
+  '@scalar/typebox@0.1.3': {}
+
+  '@scalar/types@0.12.2':
+    dependencies:
+      '@scalar/helpers': 0.8.0
+      nanoid: 5.1.6
+      type-fest: 5.6.0
+      zod: 4.3.6
+
+  '@scalar/use-codemirror@0.14.11(typescript@5.9.3)':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.2
+      '@codemirror/commands': 6.10.3
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/lang-json': 6.0.2
+      '@codemirror/lang-xml': 6.1.0
+      '@codemirror/lang-yaml': 6.1.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/lint': 6.9.6
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@replit/codemirror-css-color-picker': 6.3.0(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0)
+      vue: 3.5.35(typescript@5.9.3)
+    transitivePeerDependencies:
+      - typescript
+
+  '@scalar/use-hooks@0.4.6(typescript@5.9.3)':
+    dependencies:
+      '@scalar/use-toasts': 0.10.2(typescript@5.9.3)
+      '@scalar/validation': 0.6.0
+      '@vueuse/core': 13.9.0(vue@3.5.35(typescript@5.9.3))
+      cva: 1.0.0-beta.4(typescript@5.9.3)
+      tailwind-merge: 3.5.0
+      vue: 3.5.35(typescript@5.9.3)
+    transitivePeerDependencies:
+      - typescript
+
+  '@scalar/use-toasts@0.10.2(typescript@5.9.3)':
+    dependencies:
+      vue: 3.5.35(typescript@5.9.3)
+      vue-sonner: 1.3.2
+    transitivePeerDependencies:
+      - typescript
+
+  '@scalar/validation@0.6.0': {}
+
+  '@scalar/workspace-store@0.52.0(typescript@5.9.3)':
+    dependencies:
+      '@scalar/helpers': 0.8.0
+      '@scalar/json-magic': 0.12.14
+      '@scalar/openapi-upgrader': 0.2.8
+      '@scalar/schemas': 0.3.2
+      '@scalar/snippetz': 0.9.11
+      '@scalar/typebox': 0.1.3
+      '@scalar/types': 0.12.2
+      '@scalar/validation': 0.6.0
+      js-base64: 3.7.8
+      type-fest: 5.6.0
+      vue: 3.5.35(typescript@5.9.3)
+      yaml: 2.8.4
+    transitivePeerDependencies:
+      - typescript
 
   '@sec-ant/readable-stream@0.4.1': {}
 
@@ -14123,6 +15288,13 @@ snapshots:
       mini-svg-data-uri: 1.4.4
       tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.8.4)
 
+  '@tanstack/virtual-core@3.16.0': {}
+
+  '@tanstack/vue-virtual@3.13.26(vue@3.5.35(typescript@5.9.3))':
+    dependencies:
+      '@tanstack/virtual-core': 3.16.0
+      vue: 3.5.35(typescript@5.9.3)
+
   '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.28.6
@@ -14155,7 +15327,7 @@ snapshots:
 
   '@tokenizer/inflate@0.4.1':
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       token-types: 6.1.2
     transitivePeerDependencies:
       - supports-color
@@ -14278,6 +15450,8 @@ snapshots:
       '@types/express-serve-static-core': 4.19.8
       '@types/qs': 6.15.0
       '@types/serve-static': 1.15.10
+
+  '@types/har-format@1.2.16': {}
 
   '@types/hast@3.0.4':
     dependencies:
@@ -14432,6 +15606,10 @@ snapshots:
 
   '@types/use-sync-external-store@0.0.6': {}
 
+  '@types/web-bluetooth@0.0.20': {}
+
+  '@types/web-bluetooth@0.0.21': {}
+
   '@types/yargs-parser@21.0.3': {}
 
   '@types/yargs@17.0.35':
@@ -14460,7 +15638,7 @@ snapshots:
       '@typescript-eslint/types': 8.53.1
       '@typescript-eslint/typescript-estree': 8.53.1(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.53.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       eslint: 8.57.1
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -14470,7 +15648,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.53.1(typescript@5.9.3)
       '@typescript-eslint/types': 8.53.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -14489,7 +15667,7 @@ snapshots:
       '@typescript-eslint/types': 8.53.1
       '@typescript-eslint/typescript-estree': 8.53.1(typescript@5.9.3)
       '@typescript-eslint/utils': 8.53.1(eslint@8.57.1)(typescript@5.9.3)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       eslint: 8.57.1
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -14504,7 +15682,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.53.1(typescript@5.9.3)
       '@typescript-eslint/types': 8.53.1
       '@typescript-eslint/visitor-keys': 8.53.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       minimatch: 9.0.9
       semver: 7.7.3
       tinyglobby: 0.2.15
@@ -14530,6 +15708,12 @@ snapshots:
       eslint-visitor-keys: 4.2.1
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@unhead/vue@2.1.15(vue@3.5.35(typescript@5.9.3))':
+    dependencies:
+      hookable: 6.1.1
+      unhead: 2.1.15
+      vue: 3.5.35(typescript@5.9.3)
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     optional: true
@@ -14590,10 +15774,11 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vercel/analytics@1.6.1(next@15.5.18(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)':
+  '@vercel/analytics@1.6.1(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(vue@3.5.35(typescript@5.9.3))':
     optionalDependencies:
       next: 15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
+      vue: 3.5.35(typescript@5.9.3)
 
   '@vercel/cli-auth@0.0.1':
     dependencies:
@@ -14631,7 +15816,7 @@ snapshots:
       - '@types/node'
       - prisma
 
-  '@verifactu/ui@file:packages/ui(@types/react@18.3.27)(next@15.5.18(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react-is@18.3.1)(react@18.2.0)':
+  '@verifactu/ui@file:packages/ui(@types/react@18.3.27)(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react-is@18.3.1)(react@18.2.0)':
     dependencies:
       '@verifactu/utils': file:packages/utils
       clsx: 2.1.1
@@ -14655,6 +15840,103 @@ snapshots:
     dependencies:
       jose: 6.1.3
       zod: 4.3.6
+
+  '@vue/compiler-core@3.5.35':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@vue/shared': 3.5.35
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
+  '@vue/compiler-dom@3.5.35':
+    dependencies:
+      '@vue/compiler-core': 3.5.35
+      '@vue/shared': 3.5.35
+
+  '@vue/compiler-sfc@3.5.35':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@vue/compiler-core': 3.5.35
+      '@vue/compiler-dom': 3.5.35
+      '@vue/compiler-ssr': 3.5.35
+      '@vue/shared': 3.5.35
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.14
+      source-map-js: 1.2.1
+
+  '@vue/compiler-ssr@3.5.35':
+    dependencies:
+      '@vue/compiler-dom': 3.5.35
+      '@vue/shared': 3.5.35
+
+  '@vue/reactivity@3.5.35':
+    dependencies:
+      '@vue/shared': 3.5.35
+
+  '@vue/runtime-core@3.5.35':
+    dependencies:
+      '@vue/reactivity': 3.5.35
+      '@vue/shared': 3.5.35
+
+  '@vue/runtime-dom@3.5.35':
+    dependencies:
+      '@vue/reactivity': 3.5.35
+      '@vue/runtime-core': 3.5.35
+      '@vue/shared': 3.5.35
+      csstype: 3.2.3
+
+  '@vue/server-renderer@3.5.35(vue@3.5.35(typescript@5.9.3))':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.35
+      '@vue/shared': 3.5.35
+      vue: 3.5.35(typescript@5.9.3)
+
+  '@vue/shared@3.5.35': {}
+
+  '@vueuse/core@10.11.1(vue@3.5.35(typescript@5.9.3))':
+    dependencies:
+      '@types/web-bluetooth': 0.0.20
+      '@vueuse/metadata': 10.11.1
+      '@vueuse/shared': 10.11.1(vue@3.5.35(typescript@5.9.3))
+      vue-demi: 0.14.10(vue@3.5.35(typescript@5.9.3))
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+
+  '@vueuse/core@13.9.0(vue@3.5.35(typescript@5.9.3))':
+    dependencies:
+      '@types/web-bluetooth': 0.0.21
+      '@vueuse/metadata': 13.9.0
+      '@vueuse/shared': 13.9.0(vue@3.5.35(typescript@5.9.3))
+      vue: 3.5.35(typescript@5.9.3)
+
+  '@vueuse/integrations@13.9.0(axios@1.16.0)(focus-trap@7.8.0)(fuse.js@7.3.0)(qrcode@1.5.4)(vue@3.5.35(typescript@5.9.3))':
+    dependencies:
+      '@vueuse/core': 13.9.0(vue@3.5.35(typescript@5.9.3))
+      '@vueuse/shared': 13.9.0(vue@3.5.35(typescript@5.9.3))
+      vue: 3.5.35(typescript@5.9.3)
+    optionalDependencies:
+      axios: 1.16.0(debug@4.4.3)
+      focus-trap: 7.8.0
+      fuse.js: 7.3.0
+      qrcode: 1.5.4
+
+  '@vueuse/metadata@10.11.1': {}
+
+  '@vueuse/metadata@13.9.0': {}
+
+  '@vueuse/shared@10.11.1(vue@3.5.35(typescript@5.9.3))':
+    dependencies:
+      vue-demi: 0.14.10(vue@3.5.35(typescript@5.9.3))
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+
+  '@vueuse/shared@13.9.0(vue@3.5.35(typescript@5.9.3))':
+    dependencies:
+      vue: 3.5.35(typescript@5.9.3)
 
   '@workflow/astro@4.0.0-beta.38(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.18)':
     dependencies:
@@ -14744,7 +16026,7 @@ snapshots:
       '@workflow/world': 4.1.0-beta.9(zod@4.3.6)
       '@workflow/world-local': 4.1.0-beta.37(@opentelemetry/api@1.9.0)
       '@workflow/world-vercel': 4.1.0-beta.38(@opentelemetry/api@1.9.0)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       devalue: 5.8.1
       ms: 2.1.3
       nanoid: 5.1.6
@@ -14777,7 +16059,7 @@ snapshots:
       - aws-crt
       - supports-color
 
-  '@workflow/next@4.0.1-beta.60(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.18)(next@15.5.18(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
+  '@workflow/next@4.0.1-beta.60(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.18)(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.18)
       '@workflow/builders': 4.0.1-beta.55(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.18)
@@ -15040,11 +16322,19 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   agent-base@7.1.4: {}
+
+  ai@6.0.33(zod@4.3.6):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.13(zod@4.3.6)
+      '@ai-sdk/provider': 3.0.2
+      '@ai-sdk/provider-utils': 4.0.5(zod@4.3.6)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.3.6
 
   ai@6.0.49(zod@4.3.6):
     dependencies:
@@ -15168,6 +16458,10 @@ snapshots:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
+
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
 
   aria-query@5.3.0:
     dependencies:
@@ -15456,7 +16750,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
@@ -15837,6 +17131,8 @@ snapshots:
       crc-32: 1.2.2
       readable-stream: 3.6.2
 
+  crelt@1.0.6: {}
+
   cross-env@10.1.0:
     dependencies:
       '@epic-web/invariant': 1.0.0
@@ -15882,6 +17178,12 @@ snapshots:
       rrweb-cssom: 0.8.0
 
   csstype@3.2.3: {}
+
+  cva@1.0.0-beta.4(typescript@5.9.3):
+    dependencies:
+      clsx: 2.1.1
+    optionalDependencies:
+      typescript: 5.9.3
 
   d3-array@3.2.4:
     dependencies:
@@ -16200,6 +17502,8 @@ snapshots:
 
   entities@6.0.1: {}
 
+  entities@7.0.1: {}
+
   environment@1.1.0: {}
 
   error-ex@1.3.4:
@@ -16425,7 +17729,7 @@ snapshots:
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       eslint: 8.57.1
       get-tsconfig: 4.13.0
       is-bun-module: 2.0.0
@@ -16554,7 +17858,7 @@ snapshots:
       ajv: 6.14.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -16609,6 +17913,8 @@ snapshots:
   estraverse@5.3.0: {}
 
   estree-util-is-identifier-name@3.0.0: {}
+
+  estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
     dependencies:
@@ -16756,7 +18062,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.0
       cookie-signature: 1.2.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -16921,7 +18227,7 @@ snapshots:
 
   finalhandler@2.1.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -17019,9 +18325,13 @@ snapshots:
 
   fn.name@1.1.0: {}
 
+  focus-trap@7.8.0:
+    dependencies:
+      tabbable: 6.4.0
+
   follow-redirects@1.16.0(debug@4.4.3):
     optionalDependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
 
   fontkit@2.0.4:
     dependencies:
@@ -17141,6 +18451,8 @@ snapshots:
 
   functions-have-names@1.2.3: {}
 
+  fuse.js@7.3.0: {}
+
   gauge@3.0.2:
     dependencies:
       aproba: 2.1.0
@@ -17232,6 +18544,8 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.2
       math-intrinsics: 1.1.0
+
+  get-own-enumerable-keys@1.0.0: {}
 
   get-package-type@0.1.0: {}
 
@@ -17446,6 +18760,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  guess-json-indent@3.0.1: {}
+
   handlebars@4.7.9:
     dependencies:
       minimist: 1.2.8
@@ -17483,6 +18799,109 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-embedded@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-is-element: 3.0.0
+
+  hast-util-format@1.1.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-embedded: 3.0.0
+      hast-util-minify-whitespace: 1.0.1
+      hast-util-phrasing: 3.0.1
+      hast-util-whitespace: 3.0.0
+      html-whitespace-sensitive-tag-names: 3.0.1
+      unist-util-visit-parents: 6.0.2
+
+  hast-util-from-html@2.0.3:
+    dependencies:
+      '@types/hast': 3.0.4
+      devlop: 1.1.0
+      hast-util-from-parse5: 8.0.3
+      parse5: 7.3.0
+      vfile: 6.0.3
+      vfile-message: 4.0.3
+
+  hast-util-from-parse5@8.0.3:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      hastscript: 9.0.1
+      property-information: 7.1.0
+      vfile: 6.0.3
+      vfile-location: 5.0.3
+      web-namespaces: 2.0.1
+
+  hast-util-has-property@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-is-body-ok-link@3.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-is-element@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-minify-whitespace@1.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-embedded: 3.0.0
+      hast-util-is-element: 3.0.0
+      hast-util-whitespace: 3.0.0
+      unist-util-is: 6.0.1
+
+  hast-util-parse-selector@4.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-phrasing@3.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-embedded: 3.0.0
+      hast-util-has-property: 3.0.0
+      hast-util-is-body-ok-link: 3.0.1
+      hast-util-is-element: 3.0.0
+
+  hast-util-raw@9.1.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      '@ungap/structured-clone': 1.3.0
+      hast-util-from-parse5: 8.0.3
+      hast-util-to-parse5: 8.0.1
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      parse5: 7.3.0
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+
+  hast-util-sanitize@5.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@ungap/structured-clone': 1.3.0
+      unist-util-position: 5.0.0
+
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.8
@@ -17503,9 +18922,34 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  hast-util-to-parse5@8.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+
+  hast-util-to-text@4.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      hast-util-is-element: 3.0.0
+      unist-util-find-after: 5.0.0
+
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
+
+  hastscript@9.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      hast-util-parse-selector: 4.0.0
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
 
   he@1.2.0: {}
 
@@ -17520,11 +18964,15 @@ snapshots:
       process: 0.10.1
       xtend: 4.0.2
 
+  highlight.js@11.11.1: {}
+
   hoist-non-react-statics@3.3.2:
     dependencies:
       react-is: 16.13.1
 
   hono@4.12.18: {}
+
+  hookable@6.1.1: {}
 
   html-encoding-sniffer@4.0.0:
     dependencies:
@@ -17543,6 +18991,10 @@ snapshots:
       selderee: 0.11.0
 
   html-url-attributes@3.0.1: {}
+
+  html-void-elements@3.0.0: {}
+
+  html-whitespace-sensitive-tag-names@3.0.1: {}
 
   htmlparser2@8.0.2:
     dependencies:
@@ -17567,14 +19019,14 @@ snapshots:
     dependencies:
       '@tootallnate/once': 3.0.1
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -17586,14 +19038,14 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -17618,6 +19070,10 @@ snapshots:
       safer-buffer: 2.1.2
 
   idb@7.1.1: {}
+
+  identifier-regex@1.0.1:
+    dependencies:
+      reserved-identifiers: 1.2.0
 
   ieee754@1.2.1: {}
 
@@ -17675,6 +19131,8 @@ snapshots:
   ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
+
+  is-absolute-url@4.0.1: {}
 
   is-alphabetical@2.0.1: {}
 
@@ -17767,6 +19225,11 @@ snapshots:
 
   is-hexadecimal@2.0.1: {}
 
+  is-identifier@1.0.1:
+    dependencies:
+      identifier-regex: 1.0.1
+      super-regex: 1.1.0
+
   is-inside-container@1.0.0:
     dependencies:
       is-docker: 3.0.0
@@ -17786,6 +19249,8 @@ snapshots:
 
   is-obj@2.0.0: {}
 
+  is-obj@3.0.0: {}
+
   is-path-inside@3.0.3: {}
 
   is-plain-obj@1.1.0: {}
@@ -17804,6 +19269,8 @@ snapshots:
       gopd: 1.2.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
+
+  is-regexp@3.1.0: {}
 
   is-set@2.0.3: {}
 
@@ -17888,7 +19355,7 @@ snapshots:
   istanbul-lib-source-maps@5.0.6:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
@@ -18330,6 +19797,8 @@ snapshots:
 
   jquery@3.7.1: {}
 
+  js-base64@3.7.8: {}
+
   js-beautify@1.15.4:
     dependencies:
       config-chain: 1.1.13
@@ -18413,6 +19882,8 @@ snapshots:
 
   json5@2.2.3: {}
 
+  jsonc-parser@3.3.1: {}
+
   jsonfile@6.2.0:
     dependencies:
       universalify: 2.0.1
@@ -18455,7 +19926,7 @@ snapshots:
   jwks-rsa@3.2.2:
     dependencies:
       '@types/jsonwebtoken': 9.0.10
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       jose: 4.15.9
       limiter: 1.1.5
       lru-memoizer: 2.3.0
@@ -18640,6 +20111,12 @@ snapshots:
       tslib: 2.8.1
 
   lowercase-keys@3.0.0: {}
+
+  lowlight@3.3.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      devlop: 1.1.0
+      highlight.js: 11.11.1
 
   lru-cache@10.4.3: {}
 
@@ -18863,6 +20340,8 @@ snapshots:
 
   methods@1.1.2: {}
 
+  microdiff@1.5.0: {}
+
   micromark-core-commonmark@2.0.3:
     dependencies:
       decode-named-character-reference: 1.3.0
@@ -19035,7 +20514,7 @@ snapshots:
   micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.13
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -19196,6 +20675,10 @@ snapshots:
   negotiator@1.0.0: {}
 
   neo-async@2.6.2: {}
+
+  neverpanic@0.0.7(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
 
   next-auth@4.24.13(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
@@ -19871,6 +21354,23 @@ snapshots:
 
   quick-lru@5.1.1: {}
 
+  radix-vue@1.9.17(vue@3.5.35(typescript@5.9.3)):
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      '@floating-ui/vue': 1.1.9(vue@3.5.35(typescript@5.9.3))
+      '@internationalized/date': 3.12.1
+      '@internationalized/number': 3.6.6
+      '@tanstack/vue-virtual': 3.13.26(vue@3.5.35(typescript@5.9.3))
+      '@vueuse/core': 10.11.1(vue@3.5.35(typescript@5.9.3))
+      '@vueuse/shared': 10.11.1(vue@3.5.35(typescript@5.9.3))
+      aria-hidden: 1.2.6
+      defu: 6.1.7
+      fast-deep-equal: 3.1.3
+      nanoid: 5.1.6
+      vue: 3.5.35(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+
   range-parser@1.2.1: {}
 
   raw-body@2.5.3:
@@ -20049,7 +21549,7 @@ snapshots:
 
   recharts@3.8.1(@types/react@18.3.27)(react-dom@18.2.0(react@18.2.0))(react-is@18.3.1)(react@18.2.0)(redux@5.0.1):
     dependencies:
-      '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@18.3.27)(react@18.2.0)(redux@5.0.1))(react@18.2.0)
+      '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@18.3.27)(react@18.2.0))(react@18.2.0)
       clsx: 2.1.1
       decimal.js-light: 2.5.1
       es-toolkit: 1.46.1
@@ -20125,6 +21625,43 @@ snapshots:
     dependencies:
       jsesc: 3.1.0
 
+  rehype-external-links@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@ungap/structured-clone': 1.3.0
+      hast-util-is-element: 3.0.0
+      is-absolute-url: 4.0.1
+      space-separated-tokens: 2.0.2
+      unist-util-visit: 5.1.0
+
+  rehype-format@5.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-format: 1.1.0
+
+  rehype-parse@9.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-from-html: 2.0.3
+      unified: 11.0.5
+
+  rehype-raw@7.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-raw: 9.1.0
+      vfile: 6.0.3
+
+  rehype-sanitize@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-sanitize: 5.0.2
+
+  rehype-stringify@10.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+      unified: 11.0.5
+
   remark-gfm@4.0.1:
     dependencies:
       '@types/mdast': 4.0.4
@@ -20165,7 +21702,7 @@ snapshots:
 
   require-in-the-middle@7.5.2:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       module-details-from-path: 1.0.4
       resolve: 1.22.11
     transitivePeerDependencies:
@@ -20194,6 +21731,8 @@ snapshots:
       svix: 1.84.1
     optionalDependencies:
       '@react-email/render': 1.1.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+
+  reserved-identifiers@1.2.0: {}
 
   resolve-alpn@1.2.1: {}
 
@@ -20267,7 +21806,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -20376,7 +21915,7 @@ snapshots:
 
   send@1.2.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -20413,6 +21952,8 @@ snapshots:
   set-blocking@2.0.0: {}
 
   set-cookie-parser@2.7.2: {}
+
+  set-cookie-parser@3.1.0: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -20532,7 +22073,7 @@ snapshots:
     dependencies:
       axios: 1.16.0(debug@4.4.3)
       axios-ntlm: 1.4.6(debug@4.4.3)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       follow-redirects: 1.16.0(debug@4.4.3)
       formidable: 3.5.4
       sax: 1.6.0
@@ -20608,6 +22149,10 @@ snapshots:
       - react-native-b4a
 
   string-argv@0.3.2: {}
+
+  string-byte-length@3.0.1: {}
+
+  string-byte-slice@3.0.1: {}
 
   string-length@4.0.2:
     dependencies:
@@ -20702,6 +22247,13 @@ snapshots:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
 
+  stringify-object@6.0.0:
+    dependencies:
+      get-own-enumerable-keys: 1.0.0
+      is-identifier: 1.0.1
+      is-obj: 3.0.0
+      is-regexp: 3.1.0
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -20761,6 +22313,8 @@ snapshots:
 
   stubs@3.0.0: {}
 
+  style-mod@4.1.3: {}
+
   style-to-js@1.1.21:
     dependencies:
       style-to-object: 1.0.14
@@ -20796,7 +22350,7 @@ snapshots:
     dependencies:
       component-emitter: 1.3.1
       cookiejar: 2.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       fast-safe-stringify: 2.1.1
       form-data: 4.0.5
       formidable: 3.5.4
@@ -20854,13 +22408,23 @@ snapshots:
 
   swiper@12.1.2: {}
 
+  swrv@1.2.0(vue@3.5.35(typescript@5.9.3)):
+    dependencies:
+      vue: 3.5.35(typescript@5.9.3)
+
   symbol-tree@3.2.4: {}
 
   synckit@0.11.12:
     dependencies:
       '@pkgr/core': 0.2.9
 
+  tabbable@6.4.0: {}
+
+  tagged-tag@1.0.0: {}
+
   tailwind-merge@2.6.0: {}
+
+  tailwind-merge@3.5.0: {}
 
   tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4):
     dependencies:
@@ -21040,6 +22604,12 @@ snapshots:
 
   trough@2.2.0: {}
 
+  truncate-json@3.0.1:
+    dependencies:
+      guess-json-indent: 3.0.1
+      string-byte-length: 3.0.1
+      string-byte-slice: 3.0.1
+
   ts-algebra@2.0.0: {}
 
   ts-api-utils@2.4.0(typescript@5.9.3):
@@ -21084,6 +22654,10 @@ snapshots:
   type-fest@0.21.3: {}
 
   type-fest@4.41.0: {}
+
+  type-fest@5.6.0:
+    dependencies:
+      tagged-tag: 1.0.0
 
   type-is@1.6.18:
     dependencies:
@@ -21171,6 +22745,10 @@ snapshots:
 
   undici@6.24.1: {}
 
+  unhead@2.1.15:
+    dependencies:
+      hookable: 6.1.1
+
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
   unicode-match-property-ecmascript@2.0.0:
@@ -21205,6 +22783,11 @@ snapshots:
       is-plain-obj: 4.1.0
       trough: 2.2.0
       vfile: 6.0.3
+
+  unist-util-find-after@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
 
   unist-util-is@6.0.1:
     dependencies:
@@ -21317,6 +22900,11 @@ snapshots:
 
   vary@1.1.2: {}
 
+  vfile-location@5.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile: 6.0.3
+
   vfile-message@4.0.3:
     dependencies:
       '@types/unist': 3.0.3
@@ -21344,6 +22932,26 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
+  vue-component-type-helpers@3.3.2: {}
+
+  vue-demi@0.14.10(vue@3.5.35(typescript@5.9.3)):
+    dependencies:
+      vue: 3.5.35(typescript@5.9.3)
+
+  vue-sonner@1.3.2: {}
+
+  vue@3.5.35(typescript@5.9.3):
+    dependencies:
+      '@vue/compiler-dom': 3.5.35
+      '@vue/compiler-sfc': 3.5.35
+      '@vue/runtime-dom': 3.5.35
+      '@vue/server-renderer': 3.5.35(vue@3.5.35(typescript@5.9.3))
+      '@vue/shared': 3.5.35
+    optionalDependencies:
+      typescript: 5.9.3
+
+  w3c-keyname@2.2.8: {}
+
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
@@ -21361,6 +22969,8 @@ snapshots:
     dependencies:
       defaults: 1.0.4
     optional: true
+
+  web-namespaces@2.0.1: {}
 
   web-streams-polyfill@3.3.3: {}
 
@@ -21485,14 +23095,14 @@ snapshots:
 
   workerpool@9.3.4: {}
 
-  workflow@4.2.0-beta.64(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.18))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.18))(@swc/helpers@0.5.18)(next@15.5.18(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router@7.13.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.9.3):
+  workflow@4.2.0-beta.64(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.18))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.18))(@swc/helpers@0.5.18)(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router@7.13.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.9.3):
     dependencies:
       '@workflow/astro': 4.0.0-beta.38(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.18)
       '@workflow/cli': 4.2.0-beta.64(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.18)(react-router@7.13.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.9.3)
       '@workflow/core': 4.2.0-beta.64(@opentelemetry/api@1.9.0)
       '@workflow/errors': 4.1.0-beta.18
       '@workflow/nest': 0.0.0-beta.13(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.18))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.18))(@swc/helpers@0.5.18)
-      '@workflow/next': 4.0.1-beta.60(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.18)(next@15.5.18(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@workflow/next': 4.0.1-beta.60(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.18)(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       '@workflow/nitro': 4.0.1-beta.59(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.18)
       '@workflow/nuxt': 4.0.1-beta.48(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.18)
       '@workflow/rollup': 4.0.0-beta.21(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.18)


### PR DESCRIPTION
## Contexto

Tanda 2 del plan de Knowledge Base (tras PR #138 de coherency).

La auditoría de docs reveló cimientos fuertes (OpenAPI 3.1 spec, 6 specs platform, MCP server spec, páginas `/developers`) pero fragmentados — el spec no estaba renderizado, no había referencia de error codes, rate limits ni webhooks.

Esta PR publica la referencia interactiva y las páginas dedicadas para que un developer externo pueda integrar Isaak Platform en **menos de 1 hora**.

## Nuevas rutas

| Ruta | Contenido | Tamaño build |
|---|---|---|
| `/developers/api` | **Scalar** render de OpenAPI 3.1 ejecutable | 1.02 MB |
| `/developers/errors` | HTTP codes + `error.code` + retry guide | 144 B |
| `/developers/rate-limits` | Límites por plan + headers + backoff | 145 B |
| `/developers/webhooks` | 9 eventos + HMAC + reintentos (beta cerrada) | 145 B |

## Cambios en `/developers/page.tsx`

- Tarjeta REST API ahora apunta a `/developers/api` (Scalar) en lugar de anchor interno
- Nueva sección "Documentación detallada" con 4 tarjetas a las subpáginas

## Stack

- `@scalar/api-reference-react` ^0.9.41 (client-side, OpenAPI 3.1 renderer, theme `default`)
- OpenAPI spec copiado de `docs/isaak/ISAAK_API_V1_OPENAPI.yaml` a `apps/landing/public/openapi/isaak-v1.yaml` (source of truth sigue en docs/)

## Master plans

- **`docs/engineering/ISAAK_MASTER_PLAN.md`**: nuevo Track D "Developer Portal y API pública" con estado actual + roadmap D1–D8 (emisor real de webhooks, SDK TS/Python, Postman collection, guías, changelog, idempotency, status page)
- **`docs/product/ISAAK_MASTER_PLAN.md`**: sección "Developer Portal — propuesta de valor para devs externos" con audiencias, stack documental, modelo comercial y métricas

## Notas de diseño

- **Webhooks** documenta el modelo PROPUESTO. El emisor real (cola, reintentos, dead-letter) está en roadmap D1. La página sirve de contrato público y reserva nombres de eventos.
- **Rate limits**: números (60/120/300/600 RPM por plan) son intencionales, sujetos a iteración tras observar uso real.
- **Error codes**: set actual + ampliaciones esperables (idempotency, certificate_missing). Implementación servidor parcial.

## Verificación

- `pnpm --filter verifactu-landing build`: ✅ **Compiled successfully** (22.6s)
- Rutas `/developers/{api,errors,rate-limits,webhooks}` server-rendered en output
- typecheck landing: 1 error preexistente (NextRequest test) idéntico a main, **sin regresión**

## Test plan

- [ ] Vercel deploy verde para landing
- [ ] Visitar `/developers` → tarjetas a las 4 subsecciones funcionan
- [ ] Visitar `/developers/api` → Scalar renderiza el OpenAPI, sidebar con grupos `company`/`invoices`/`verifactu`/`audit`/`keys`, botón "Try It" funcional
- [ ] Visitar `/developers/errors`, `/rate-limits`, `/webhooks` → páginas estáticas con copy correcto y links de vuelta
- [ ] Buscar regresiones en `/developers` original (sigue funcionando hero, quickstart, MCP section, Inspector)

## Próximas tandas

- **Tanda 3**: 11 tests rotos preexistentes (`accept.test.ts`, `holded-session.test.ts`) — branch dedicada
- **Roadmap D1**: implementar emisor real de webhooks (cola, dead-letter)
- **Roadmap D2**: SDK TypeScript auto-gen desde OpenAPI