### PR TITLE
test(isaak): arreglar 11 tests rotos en accept y holded-session

### DIFF
--- a/apps/isaak/app/api/team/__tests__/accept.test.ts
+++ b/apps/isaak/app/api/team/__tests__/accept.test.ts
@@ -68,6 +68,10 @@ function makeRequest(token = TOKEN) {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  // clearAllMocks NO resetea la queue de mockResolvedValueOnce, así que los
+  // describes hijos que añaden mockResolvedValueOnce dejan residuos entre
+  // tests. Reseteamos findFirst explícitamente.
+  (prisma.membership.findFirst as jest.Mock).mockReset();
   buildIsaakAuthUrlMock.mockReturnValue(`${ISAAK}/auth?source=team_invite_accept`);
   (prisma.membership.update as jest.Mock).mockResolvedValue({});
   (prisma.membership.delete as jest.Mock).mockResolvedValue({});
@@ -124,9 +128,16 @@ describe('token lookup', () => {
     getSessionMock.mockResolvedValue(SESSION);
     (prisma.membership.findFirst as jest.Mock).mockResolvedValue(null);
     await GET(makeRequest());
-    const call = (prisma.membership.findFirst as jest.Mock).mock.calls[0][0];
-    // Must use JSON path query, not scan all memberships
-    expect(call.where).toEqual(
+    const calls = (prisma.membership.findFirst as jest.Mock).mock.calls;
+    // SEC C4: lookup primario por hash SHA-256 del token (no full scan)
+    expect(calls[0][0].where).toEqual(
+      expect.objectContaining({
+        status: 'invited',
+        metadataJson: { path: ['inviteTokenHash'], equals: expect.any(String) },
+      })
+    );
+    // Fallback legacy: invitaciones pre-C4 con inviteToken raw
+    expect(calls[1][0].where).toEqual(
       expect.objectContaining({
         status: 'invited',
         metadataJson: { path: ['inviteToken'], equals: TOKEN },

--- a/apps/isaak/app/lib/__tests__/holded-session.test.ts
+++ b/apps/isaak/app/lib/__tests__/holded-session.test.ts
@@ -26,7 +26,7 @@ jest.mock('@verifactu/auth', () => ({
 jest.mock('@/app/lib/prisma', () => ({
   prisma: {
     user: { findFirst: jest.fn(), update: jest.fn(), create: jest.fn() },
-    membership: { updateMany: jest.fn(), findUnique: jest.fn() },
+    membership: { update: jest.fn(), findUnique: jest.fn() },
     userPreference: { findUnique: jest.fn(), upsert: jest.fn() },
   },
 }));
@@ -36,7 +36,8 @@ import { prisma } from '@/app/lib/prisma';
 import { getHoldedSession } from '../holded-session';
 
 type UserMock = jest.MockedFunction<typeof prisma.user.findFirst>;
-type UpdateManyMock = jest.MockedFunction<typeof prisma.membership.updateMany>;
+type MembershipUpdateMock = jest.MockedFunction<typeof prisma.membership.update>;
+type MembershipFindMock = jest.MockedFunction<typeof prisma.membership.findUnique>;
 type PrefMock = jest.MockedFunction<typeof prisma.userPreference.findUnique>;
 
 const mockUserFind = prisma.user.findFirst as unknown as UserMock;
@@ -46,7 +47,8 @@ const mockUserUpdate = prisma.user.update as unknown as jest.MockedFunction<
 const mockUserCreate = prisma.user.create as unknown as jest.MockedFunction<
   typeof prisma.user.create
 >;
-const mockUpdateMany = prisma.membership.updateMany as unknown as UpdateManyMock;
+const mockMembershipUpdate = prisma.membership.update as unknown as MembershipUpdateMock;
+const mockMembershipFind = prisma.membership.findUnique as unknown as MembershipFindMock;
 const mockPrefFind = prisma.userPreference.findUnique as unknown as PrefMock;
 const mockPrefUpsert = prisma.userPreference.upsert as unknown as jest.MockedFunction<
   typeof prisma.userPreference.upsert
@@ -69,7 +71,7 @@ const EXISTING_USER = {
 beforeEach(() => {
   jest.clearAllMocks();
   (cookies as jest.Mock).mockResolvedValue(cookieStoreMock);
-  mockUpdateMany.mockResolvedValue({ count: 0 });
+  mockMembershipUpdate.mockResolvedValue({} as never);
   mockPrefUpsert.mockResolvedValue({} as never);
 });
 
@@ -99,7 +101,7 @@ describe('path 1 — resolveSharedTenantSession finds user directly', () => {
       email: 'user@example.com',
       name: 'Ana',
     });
-    mockPrefFind.mockResolvedValue({ preferredTenantId: 'tenant-preferred' });
+    mockPrefFind.mockResolvedValue({ preferredTenantId: 'tenant-preferred' } as never);
     (prisma.membership.findUnique as jest.Mock).mockResolvedValue({ status: 'active' });
 
     const session = await getHoldedSession();
@@ -114,7 +116,7 @@ describe('path 1 — resolveSharedTenantSession finds user directly', () => {
       email: 'user@example.com',
       name: 'Ana',
     });
-    mockPrefFind.mockResolvedValue({ preferredTenantId: 'tenant-preferred' });
+    mockPrefFind.mockResolvedValue({ preferredTenantId: 'tenant-preferred' } as never);
     (prisma.membership.findUnique as jest.Mock).mockResolvedValue({ status: 'invited' });
 
     const session = await getHoldedSession();
@@ -129,7 +131,7 @@ describe('path 1 — resolveSharedTenantSession finds user directly', () => {
       email: 'user@example.com',
       name: 'Ana',
     });
-    mockPrefFind.mockResolvedValue({ preferredTenantId: 'tenant-preferred' });
+    mockPrefFind.mockResolvedValue({ preferredTenantId: 'tenant-preferred' } as never);
     (prisma.membership.findUnique as jest.Mock).mockResolvedValue(null);
 
     const session = await getHoldedSession();
@@ -151,7 +153,7 @@ describe('blocked user', () => {
   it('returns null when user.isBlocked is true (path 2)', async () => {
     resolveSharedTenantSessionMock.mockResolvedValue(null);
     getSharedSessionPayloadMock.mockResolvedValue(VALID_PAYLOAD);
-    mockUserFind.mockResolvedValue({ ...EXISTING_USER, isBlocked: true });
+    mockUserFind.mockResolvedValue({ ...EXISTING_USER, isBlocked: true } as never);
 
     const session = await getHoldedSession();
     expect(session).toBeNull();
@@ -164,6 +166,9 @@ describe('path 2 — cross-domain handoff via raw payload', () => {
   beforeEach(() => {
     resolveSharedTenantSessionMock.mockResolvedValue(null);
     getSharedSessionPayloadMock.mockResolvedValue(VALID_PAYLOAD);
+    // Default: la membership existe y está activa (no requiere transición).
+    // El código devuelve null si findUnique devuelve null (C1: no auto-create).
+    mockMembershipFind.mockResolvedValue({ id: 'membership-1', status: 'active' } as never);
   });
 
   it('returns null when payload is missing', async () => {
@@ -185,8 +190,8 @@ describe('path 2 — cross-domain handoff via raw payload', () => {
   });
 
   it('updates existing user and returns session', async () => {
-    mockUserFind.mockResolvedValue(EXISTING_USER);
-    mockUserUpdate.mockResolvedValue(EXISTING_USER);
+    mockUserFind.mockResolvedValue(EXISTING_USER as never);
+    mockUserUpdate.mockResolvedValue(EXISTING_USER as never);
 
     const session = await getHoldedSession();
     expect(mockUserUpdate).toHaveBeenCalledWith(
@@ -201,7 +206,7 @@ describe('path 2 — cross-domain handoff via raw payload', () => {
 
   it('creates new user when no existing user found', async () => {
     mockUserFind.mockResolvedValue(null);
-    mockUserCreate.mockResolvedValue(EXISTING_USER);
+    mockUserCreate.mockResolvedValue(EXISTING_USER as never);
 
     const session = await getHoldedSession();
     expect(mockUserCreate).toHaveBeenCalledWith(
@@ -219,43 +224,43 @@ describe('C1 invariant — no auto-membership creation', () => {
   beforeEach(() => {
     resolveSharedTenantSessionMock.mockResolvedValue(null);
     getSharedSessionPayloadMock.mockResolvedValue(VALID_PAYLOAD);
-    mockUserFind.mockResolvedValue(EXISTING_USER);
-    mockUserUpdate.mockResolvedValue(EXISTING_USER);
+    mockUserFind.mockResolvedValue(EXISTING_USER as never);
+    mockUserUpdate.mockResolvedValue(EXISTING_USER as never);
+    // Default para C1: membership existe pero INACTIVA → debe activarse via update
+    mockMembershipFind.mockResolvedValue({ id: 'membership-1', status: 'invited' } as never);
   });
 
-  it('calls updateMany (not upsert/create) to reactivate membership', async () => {
+  it('calls update (not upsert/create) to reactivate inactive membership', async () => {
     await getHoldedSession();
-    expect(mockUpdateMany).toHaveBeenCalledWith(
+    expect(mockMembershipUpdate).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: expect.objectContaining({
-          tenantId: 'tenant-abc',
-          userId: 'user-id-1',
-        }),
+        where: { id: 'membership-1' },
         data: { status: 'active' },
       })
     );
   });
 
-  it('never calls membership.create or membership.upsert', async () => {
+  it('never exposes membership.create or membership.upsert in the prisma mock', async () => {
     await getHoldedSession();
-    expect(prisma.membership.upsert).toBeUndefined();
-    expect((prisma.membership as Record<string, unknown>).create).toBeUndefined();
+    expect((prisma.membership as unknown as Record<string, unknown>).upsert).toBeUndefined();
+    expect((prisma.membership as unknown as Record<string, unknown>).create).toBeUndefined();
   });
 
-  it('updateMany targets only inactive memberships (status: {not: active})', async () => {
+  it('skips update when membership is already active', async () => {
+    mockMembershipFind.mockResolvedValue({ id: 'membership-1', status: 'active' } as never);
     await getHoldedSession();
-    const call = mockUpdateMany.mock.calls[0][0];
-    expect(call.where).toEqual(expect.objectContaining({ status: { not: 'active' } }));
+    expect(mockMembershipUpdate).not.toHaveBeenCalled();
   });
 
-  it('still returns a session even if updateMany finds no rows to update', async () => {
-    mockUpdateMany.mockResolvedValue({ count: 0 });
+  it('returns null when no membership exists (C1: no auto-create)', async () => {
+    mockMembershipFind.mockResolvedValue(null);
     const session = await getHoldedSession();
-    expect(session?.userId).toBe('user-id-1');
+    expect(session).toBeNull();
+    expect(mockMembershipUpdate).not.toHaveBeenCalled();
   });
 
-  it('still returns a session even if updateMany throws', async () => {
-    mockUpdateMany.mockRejectedValue(new Error('DB error'));
+  it('still returns a session even if update throws', async () => {
+    mockMembershipUpdate.mockRejectedValue(new Error('DB error'));
     const session = await getHoldedSession();
     expect(session?.userId).toBe('user-id-1');
   });
@@ -271,7 +276,7 @@ describe('user name normalization', () => {
   });
 
   it('uses payload.name when present', async () => {
-    mockUserCreate.mockResolvedValue({ ...EXISTING_USER, name: 'Ana García' });
+    mockUserCreate.mockResolvedValue({ ...EXISTING_USER, name: 'Ana García' } as never);
     await getHoldedSession();
     const createCall = mockUserCreate.mock.calls[0][0];
     expect(createCall.data.name).toBe('Ana García');
@@ -279,7 +284,7 @@ describe('user name normalization', () => {
 
   it('falls back to email prefix when payload has no name', async () => {
     getSharedSessionPayloadMock.mockResolvedValue({ ...VALID_PAYLOAD, name: undefined });
-    mockUserCreate.mockResolvedValue({ ...EXISTING_USER, name: 'user' });
+    mockUserCreate.mockResolvedValue({ ...EXISTING_USER, name: 'user' } as never);
     await getHoldedSession();
     const createCall = mockUserCreate.mock.calls[0][0];
     expect(createCall.data.name).toBe('user');
@@ -288,8 +293,8 @@ describe('user name normalization', () => {
   it('falls back to existing user name when payload.name is empty', async () => {
     resolveSharedTenantSessionMock.mockResolvedValue(null);
     getSharedSessionPayloadMock.mockResolvedValue({ ...VALID_PAYLOAD, name: '  ' });
-    mockUserFind.mockResolvedValue({ ...EXISTING_USER, name: 'Existing Name' });
-    mockUserUpdate.mockResolvedValue({ ...EXISTING_USER, name: 'Existing Name' });
+    mockUserFind.mockResolvedValue({ ...EXISTING_USER, name: 'Existing Name' } as never);
+    mockUserUpdate.mockResolvedValue({ ...EXISTING_USER, name: 'Existing Name' } as never);
     await getHoldedSession();
     const updateCall = mockUserUpdate.mock.calls[0][0];
     expect(updateCall.data.name).toBe('Existing Name');


### PR DESCRIPTION
## Contexto

Tanda 3 del plan. Los 11 tests preexistentes rotos en main estaban desincronizados con la implementación actual del código tras refactorings de seguridad (SEC C1, SEC C4).

## Tests arreglados

### `apps/isaak/app/api/team/__tests__/accept.test.ts` (5 fixes)

**Root cause — side-effect entre tests**: `jest.clearAllMocks()` **NO** resetea el queue de `mockResolvedValueOnce` — solo limpia `.mock.calls`. Los describes hijos hacían `findFirst.mockResolvedValueOnce(A).mockResolvedValueOnce(B)` en su beforeEach, y los residuos contaminaban el siguiente test.

- Fix: añadido `(prisma.membership.findFirst).mockReset()` en el beforeEach global. `mockReset()` sí limpia el queue.

**Root cause — test "uses findFirst with JSON path filter"**: el test esperaba `metadataJson.path = ['inviteToken']` pero el código (SEC C4 hardening) ahora hace 2 lookups:
1. `path: ['inviteTokenHash']` (SHA-256 del token, primario)
2. `path: ['inviteToken']` (fallback legacy para invitaciones pre-C4)

- Fix: actualizado el test para validar ambos calls (índice 0 = hash, índice 1 = legacy).

### `apps/isaak/app/lib/__tests__/holded-session.test.ts` (6 fixes)

**Root cause**: el código `holded-session.ts` fue refactorizado para usar `prisma.membership.findUnique` + `prisma.membership.update` (singular) en lugar de `prisma.membership.updateMany`. Los tests seguían mockeando la API antigua.

- Fix 1: reemplazado `updateMany: jest.fn()` por `update: jest.fn()` en el `jest.mock` de prisma.
- Fix 2: `beforeEach` global ajustado para mockear `update` en lugar de `updateMany`.
- Fix 3: añadido mock por defecto de `membership.findUnique` devolviendo `{ id, status: 'active' }` en describe `'path 2'`. Sin esto, `findUnique` devolvía `undefined`, el código activaba el branch C1 "no auto-create" y retornaba `null` (session?.userId undefined).
- Fix 4: reescritura del describe `'C1 invariant'`:
  - `calls updateMany` → `calls update (not upsert/create)`
  - `updateMany targets only inactive` → eliminado (la lógica vive en if/else del código, no en query)
  - Nuevo: `skips update when membership is already active`
  - Nuevo: `returns null when no membership exists (C1: no auto-create)` — preserva el invariante de seguridad
  - `still returns a session even if updateMany throws` → `still returns a session even if update throws`
- Fix 5: bonus — limpieza de errores TS preexistentes en los mocks. Casts `as never` en `mockResolvedValue()` donde los User/Membership mocks no incluyen todos los campos del schema Prisma.

## Verificación

| Métrica | Antes (main) | Después |
|---|---|---|
| Tests fallando | 11 (5 accept + 6 holded-session) | **0** |
| Tests verde | 963 | **974** |
| Errores TS isaak | 18 | **2** (solo ShieldCheck, arreglado en PR #138) |
| `pnpm test` (todos los apps) | rojo | ✅ **7/7 verde** |

## Notas

- **Sin cambios al código de producción.** Solo tests.
- **Sin migraciones.**
- **Sin cambios en `/api/mcp`.**
- Los tests ahora reflejan el contrato de seguridad real (SEC C1 — no auto-create membership; SEC C4 — hash SHA-256 del invite token).

## Test plan

- [ ] Vercel CI verde para los 7 apps
- [ ] Confirmar que `pnpm --filter verifactu-isaak test` devuelve 974/974
- [ ] Confirmar que `pnpm --filter verifactu-isaak exec tsc --noEmit` devuelve solo los 2 errores de ShieldCheck (resueltos por PR #138 al mergearse)