### PR TITLE
chore(hygiene): añadir NEXT_PUBLIC_HOLDED_SITE_URL a .env.example de admin/app/isaak

### DIFF
--- a/apps/admin/.env.example
+++ b/apps/admin/.env.example
@@ -80,3 +80,9 @@ ANTHROPIC_API_KEY=your-anthropic-api-key
 
 # Isaak Fase K — Descifrado de API keys Holded (mismo valor que OAUTH_DATA_ENCRYPTION_SECRET en apps/holded-mcp)
 OAUTH_DATA_ENCRYPTION_SECRET=your-oauth-data-encryption-secret
+
+# ==============================================================================
+# CROSS-APP URLS (links a apps hermanas en el monorepo)
+# ==============================================================================
+NEXT_PUBLIC_HOLDED_SITE_URL=https://holded.verifactu.business
+NEXT_PUBLIC_ISAAK_URL=https://isaak.verifactu.business

--- a/apps/app/.env.example
+++ b/apps/app/.env.example
@@ -69,3 +69,8 @@ RESEND_FROM=your-resend-from
 RESEND_API_KEY_HOLDED=your-holded-resend-api-key
 RESEND_FROM_HOLDED=your-holded-resend-from
 OPENAI_APPS_CHALLENGE=
+
+# ==============================================================================
+# CROSS-APP URLS (links al hub de conectores Holded y al landing)
+# ==============================================================================
+NEXT_PUBLIC_HOLDED_SITE_URL=https://holded.verifactu.business

--- a/apps/isaak/.env.example
+++ b/apps/isaak/.env.example
@@ -176,3 +176,8 @@ FIREBASE_ADMIN_PRIVATE_KEY=-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KE
 
 # Cuántas submissions procesa el worker por corrida.
 # AEAT_WORKER_BATCH_SIZE=5
+
+# ==============================================================================
+# CROSS-APP URLS (links al landing público y al hub de conectores Holded)
+# ==============================================================================
+NEXT_PUBLIC_HOLDED_SITE_URL=https://holded.verifactu.business


### PR DESCRIPTION
## Contexto

Tanda 4 del plan: hygiene P2 del audit residual. Triage completo — la mayoría de hallazgos del auditor eran **falsos positivos**.

## Cambio aplicado

3 archivos `.env.example` actualizados para documentar `NEXT_PUBLIC_HOLDED_SITE_URL` (usada activamente pero no declarada):

- **apps/admin/.env.example**: + `NEXT_PUBLIC_HOLDED_SITE_URL` + `NEXT_PUBLIC_ISAAK_URL`
- **apps/isaak/.env.example**: + `NEXT_PUBLIC_HOLDED_SITE_URL`
- **apps/app/.env.example**: + `NEXT_PUBLIC_HOLDED_SITE_URL`

Los handlers usan fallback hardcoded a `https://holded.verifactu.business`, así que sin la env no se rompía nada — pero el .env.example es la única fuente de verdad para nuevos contributors / staging envs.

## Hallazgos descartados como falsos positivos

| # | Hallazgo del auditor | Verdadero motivo |
|---|---|---|
| 1 | `aeat-submission-worker` cron sin entry en `vercel.json` | **Intencional**. Vercel serverless no puede correr Playwright (~300MB). El endpoint existe como interfaz HTTP para workers externos (Cloud Run, GitHub Actions). Documentado en `lib/aeat-browser/README.md`. |
| 2 | `apps/app/api/cron/route.ts` sin entry en `vercel.json` | **No tocar durante revisión OpenAI** (CLAUDE.md regla crítica). Es un endpoint POST de bank reconciliation; cualquier scheduler externo puede invocarlo con `CRON_SECRET`. |
| 3 | `HOLDED_FIREBASE_*` env vars "duplicadas" | **Intencional**. `apps/landing/app/lib/firebase.ts` hace `readEnv` con fallback `HOLDED_FIREBASE_*` → `FIREBASE_*`. Patrón de override sub-tenant Holded sobre el proyecto Firebase central. |
| 4 | TODOs antiguos en `aeat-formats/303/spec/fields-2024-10.ts` | **No son TODOs**. Son anotaciones del formato oficial AEAT en sus campos (la palabra "TODO" forma parte de la spec). |
| 5 | TODOs en `aeat-browser/adapters/playwright-stub.ts` | Documentados como **pilot v1** en el README del módulo. Selectores no validados, requieren acceso a pre-pro AEAT. |
| 6 | README aeat-browser "desfasado" | **Está al día**. Solo línea 74 menciona que `cli.ts` no está implementado, lo cual es correcto. |

## Verificación

- Sin cambios funcionales
- Sin migraciones
- Sin cambios en `/api/mcp` ni en handlers
- Apps siguen funcionando con los fallbacks hardcoded actuales

## Test plan

- [ ] Vercel deploy verde para admin, app, isaak
- [ ] Confirmar que `.env.example` de los 3 apps lista `NEXT_PUBLIC_HOLDED_SITE_URL` para nuevos devs