### PR TITLE
feat(developers): guías paso a paso en /developers/guides

### DIFF
--- a/apps/landing/app/developers/guides/[slug]/page.tsx
+++ b/apps/landing/app/developers/guides/[slug]/page.tsx
@@ -1,0 +1,221 @@
+import { AlertTriangle, ArrowLeft, ArrowRight, CheckCircle2, Clock, Info } from 'lucide-react';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import Header from '../../../components/Header';
+import { Container, Footer } from '../../../lib/home/ui';
+import { GUIDES, getGuide, type GuideStep } from '../guides-data';
+
+const navLinks = [
+  { label: 'VeriFactu', href: '/verifactu/que-es' },
+  { label: 'Que es Isaak', href: '/que-es-isaak' },
+  { label: 'Conectores', href: '/conectores' },
+  { label: 'Precios', href: '/precios' },
+  { label: 'Developers', href: '/developers' },
+];
+
+export function generateStaticParams() {
+  return GUIDES.map((g) => ({ slug: g.slug }));
+}
+
+type Params = { params: Promise<{ slug: string }> };
+
+export async function generateMetadata({ params }: Params): Promise<Metadata> {
+  const { slug } = await params;
+  const guide = getGuide(slug);
+  if (!guide) {
+    return { title: 'Guía no encontrada | Isaak Developers' };
+  }
+  return {
+    title: `${guide.title} | Isaak Developers — Verifactu Business`,
+    description: guide.summary,
+    alternates: { canonical: `/developers/guides/${guide.slug}` },
+    openGraph: {
+      title: guide.title,
+      description: guide.summary,
+      type: 'article',
+      locale: 'es_ES',
+      url: `https://verifactu.business/developers/guides/${guide.slug}`,
+      siteName: 'Verifactu Business',
+    },
+  };
+}
+
+// Colores por kind para los callouts inline en los pasos.
+const CALLOUT_STYLES = {
+  info: {
+    wrap: 'border-sky-200 bg-sky-50 text-sky-900',
+    Icon: Info,
+    iconClass: 'text-sky-600',
+  },
+  warn: {
+    wrap: 'border-amber-200 bg-amber-50 text-amber-900',
+    Icon: AlertTriangle,
+    iconClass: 'text-amber-600',
+  },
+  success: {
+    wrap: 'border-emerald-200 bg-emerald-50 text-emerald-900',
+    Icon: CheckCircle2,
+    iconClass: 'text-emerald-600',
+  },
+} as const;
+
+function StepBlock({ step, index }: { step: GuideStep; index: number }) {
+  return (
+    <article
+      id={`paso-${index + 1}`}
+      className="scroll-mt-24 border-t border-slate-100 py-10 first:border-t-0 first:pt-0"
+    >
+      <h2 className="text-xl font-bold text-[#011c67] sm:text-2xl">{step.title}</h2>
+      <p className="mt-3 text-slate-600 leading-7">{step.body}</p>
+
+      {step.callout && (
+        <div
+          className={`mt-5 flex gap-3 rounded-xl border px-4 py-3 text-sm leading-6 ${CALLOUT_STYLES[step.callout.kind].wrap}`}
+        >
+          {(() => {
+            const Icon = CALLOUT_STYLES[step.callout.kind].Icon;
+            return (
+              <Icon
+                className={`mt-0.5 h-4 w-4 flex-shrink-0 ${CALLOUT_STYLES[step.callout.kind].iconClass}`}
+              />
+            );
+          })()}
+          <span>{step.callout.text}</span>
+        </div>
+      )}
+
+      {step.code?.map((block, i) => (
+        <div key={i} className="mt-5 overflow-hidden rounded-2xl border border-slate-200">
+          <div className="flex items-center gap-2 border-b border-slate-200 bg-slate-800 px-4 py-2.5">
+            <div className="h-2.5 w-2.5 rounded-full bg-red-500" />
+            <div className="h-2.5 w-2.5 rounded-full bg-amber-400" />
+            <div className="h-2.5 w-2.5 rounded-full bg-emerald-500" />
+            <span className="ml-2 text-xs font-medium text-slate-400">
+              {block.label ?? block.language}
+            </span>
+          </div>
+          <pre className="overflow-x-auto bg-slate-900 p-5 text-sm leading-7 text-slate-200">
+            <code>{block.content}</code>
+          </pre>
+        </div>
+      ))}
+    </article>
+  );
+}
+
+export default async function GuideDetailPage({ params }: Params) {
+  const { slug } = await params;
+  const guide = getGuide(slug);
+  if (!guide) notFound();
+
+  const Icon = guide.icon;
+
+  return (
+    <div className="min-h-screen bg-white text-slate-900">
+      <Header navLinks={navLinks} />
+
+      <section className="border-b border-slate-200 bg-[linear-gradient(180deg,#f4f8ff_0%,#ffffff_70%)] py-12 sm:py-14">
+        <Container>
+          <Link
+            href="/developers/guides"
+            className="inline-flex items-center gap-1.5 text-sm text-slate-600 hover:text-[#2361d8]"
+          >
+            <ArrowLeft className="h-3.5 w-3.5" />
+            Guías
+          </Link>
+
+          <div className="mt-5 flex items-start gap-4">
+            <div className="inline-flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-2xl bg-[#2361d8]/8">
+              <Icon className="h-6 w-6 text-[#2361d8]" />
+            </div>
+            <div className="min-w-0">
+              <div className="text-xs font-semibold uppercase tracking-[0.16em] text-[#2361d8]">
+                {guide.eyebrow}
+              </div>
+              <h1 className="mt-2 text-3xl font-bold tracking-tight text-[#011c67] sm:text-4xl">
+                {guide.title}
+              </h1>
+              <p className="mt-3 max-w-3xl text-base leading-7 text-slate-600">{guide.summary}</p>
+              <div className="mt-4 inline-flex items-center gap-1.5 rounded-full bg-white px-3 py-1 text-xs font-medium text-slate-600 ring-1 ring-slate-200">
+                <Clock className="h-3 w-3" />
+                {guide.readingMinutes} min de lectura
+              </div>
+            </div>
+          </div>
+        </Container>
+      </section>
+
+      <section className="py-12">
+        <Container>
+          <div className="grid gap-10 lg:grid-cols-[1fr_220px]">
+            <div className="min-w-0">
+              {/* Prerrequisitos */}
+              <div className="rounded-2xl border border-slate-200 bg-slate-50 p-5">
+                <h2 className="text-xs font-semibold uppercase tracking-widest text-slate-500">
+                  Antes de empezar
+                </h2>
+                <ul className="mt-3 space-y-2 text-sm text-slate-700">
+                  {guide.prerequisites.map((p) => (
+                    <li key={p} className="flex gap-2">
+                      <CheckCircle2 className="mt-0.5 h-4 w-4 flex-shrink-0 text-emerald-500" />
+                      <span>{p}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              {/* Pasos */}
+              <div className="mt-10">
+                {guide.steps.map((step, i) => (
+                  <StepBlock key={i} step={step} index={i} />
+                ))}
+              </div>
+
+              {/* Next steps */}
+              <div className="mt-10 rounded-2xl border border-[#2361d8]/15 bg-[linear-gradient(135deg,#f0f5ff_0%,#ffffff_100%)] p-6">
+                <h2 className="text-lg font-semibold text-[#011c67]">¿Y ahora qué?</h2>
+                <ul className="mt-4 space-y-2.5">
+                  {guide.nextSteps.map((s) => (
+                    <li key={s.href}>
+                      <Link
+                        href={s.href}
+                        className="inline-flex items-center gap-1 text-sm font-medium text-[#2361d8] hover:underline"
+                      >
+                        {s.label}
+                        <ArrowRight className="h-3.5 w-3.5" />
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+
+            {/* ToC sticky */}
+            <aside className="hidden lg:block">
+              <div className="sticky top-24 rounded-2xl border border-slate-200 bg-white p-5">
+                <h2 className="text-xs font-semibold uppercase tracking-widest text-slate-500">
+                  En esta guía
+                </h2>
+                <ol className="mt-3 space-y-2 text-sm">
+                  {guide.steps.map((step, i) => (
+                    <li key={i}>
+                      <a
+                        href={`#paso-${i + 1}`}
+                        className="block text-slate-600 hover:text-[#2361d8]"
+                      >
+                        {step.title}
+                      </a>
+                    </li>
+                  ))}
+                </ol>
+              </div>
+            </aside>
+          </div>
+        </Container>
+      </section>
+
+      <Footer />
+    </div>
+  );
+}

--- a/apps/landing/app/developers/guides/guides-data.ts
+++ b/apps/landing/app/developers/guides/guides-data.ts
@@ -1,0 +1,520 @@
+// Catálogo de guías paso a paso del Developers portal.
+// Cada guía es contenido estático servido por /developers/guides/[slug].
+//
+// IMPORTANTE: las guías solo documentan funcionalidad YA disponible en
+// producción. Nada de "tools nuevas" ni cambios de URL en MCP connectors
+// hasta que termine la revisión OpenAI/Anthropic.
+
+import type { LucideIcon } from 'lucide-react';
+import { Bot, FileText, Plug, Webhook } from 'lucide-react';
+
+export type GuideStep = {
+  /** Título corto del paso (aparece en el sidebar de ToC). */
+  title: string;
+  /** Descripción del paso. Acepta JSX inline vía dangerouslySetInnerHTML NO — solo strings. */
+  body: string;
+  /** Bloques de código opcionales. */
+  code?: Array<{
+    language: 'bash' | 'js' | 'ts' | 'python' | 'json' | 'http';
+    label?: string;
+    content: string;
+  }>;
+  /** Callout opcional para advertencias o tips. */
+  callout?: {
+    kind: 'info' | 'warn' | 'success';
+    text: string;
+  };
+};
+
+export type Guide = {
+  slug: string;
+  title: string;
+  eyebrow: string;
+  icon: LucideIcon;
+  /** Resumen de 1-2 frases para el índice y meta description. */
+  summary: string;
+  /** Estimación de lectura (minutos). */
+  readingMinutes: number;
+  /** Prerrequisitos en lenguaje plano. */
+  prerequisites: string[];
+  /** Pasos en orden. */
+  steps: GuideStep[];
+  /** Enlaces "qué hago ahora" — referencias dentro del portal. */
+  nextSteps: Array<{ label: string; href: string }>;
+};
+
+// ─── Guías ─────────────────────────────────────────────────────────────────────
+
+const PRIMERA_FACTURA: Guide = {
+  slug: 'primera-factura',
+  title: 'Tu primera factura vía API en 5 minutos',
+  eyebrow: 'Quickstart',
+  icon: FileText,
+  summary:
+    'Crea, valida y emite una factura a VeriFactu desde cURL. Sin instalar nada, solo tu API key.',
+  readingMinutes: 5,
+  prerequisites: [
+    'Cuenta gratuita en isaak.verifactu.business',
+    'Certificado VeriFactu subido (necesario para emitir a AEAT)',
+    'Una API key de prueba (isk_test_…) o de producción (isk_live_…)',
+  ],
+  steps: [
+    {
+      title: '1. Obtén tu API key',
+      body: 'Ve a Ajustes → API keys y genera una key. La key de test (isk_test_…) usa el sandbox de AEAT (Pre-Producción) y no genera asientos contables reales.',
+      callout: {
+        kind: 'info',
+        text: 'Guarda la key en una variable de entorno. NUNCA la commitees al repo ni la pegues en un cliente JavaScript del navegador.',
+      },
+      code: [
+        {
+          language: 'bash',
+          label: 'Variable de entorno',
+          content: 'export ISAAK_API_KEY="isk_test_xxxxxxxxxxxxxxxx"',
+        },
+      ],
+    },
+    {
+      title: '2. Verifica la autenticación',
+      body: 'La primera llamada debería devolver los datos fiscales de tu empresa. Si recibes 401, revisa que el header Authorization tenga el formato exacto "Bearer <key>".',
+      code: [
+        {
+          language: 'bash',
+          label: 'GET /api/v1/companies/current',
+          content: `curl https://isaak.verifactu.business/api/v1/companies/current \\
+  -H "Authorization: Bearer $ISAAK_API_KEY"`,
+        },
+        {
+          language: 'json',
+          label: 'Respuesta',
+          content: `{
+  "ok": true,
+  "data": {
+    "id": "tnt_xxx",
+    "name": "Acme SL",
+    "nif": "B12345678",
+    "verifactuEnabled": true
+  },
+  "meta": { "requestId": "req_...", "timestamp": "2026-05-28T10:00:00.000Z" }
+}`,
+        },
+      ],
+    },
+    {
+      title: '3. Crea un borrador',
+      body: 'El POST devuelve la factura en estado draft. Todavía NO está en AEAT — solo está guardada en Isaak. Aprovecha para revisar líneas, NIF del cliente y totales antes de emitir.',
+      code: [
+        {
+          language: 'bash',
+          label: 'POST /api/v1/invoices',
+          content: `curl -X POST https://isaak.verifactu.business/api/v1/invoices \\
+  -H "Authorization: Bearer $ISAAK_API_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "clientName": "Cliente Demo SL",
+    "clientNif": "B87654321",
+    "lines": [
+      { "description": "Consultoría mayo 2026", "quantity": 1, "unitPrice": 1000.00, "vatRate": 21 }
+    ]
+  }'`,
+        },
+      ],
+      callout: {
+        kind: 'success',
+        text: 'La respuesta incluye el id de la factura (inv_…) y el confirmationToken que necesitarás en el paso 4.',
+      },
+    },
+    {
+      title: '4. Emite a AEAT (irreversible)',
+      body: 'Las emisiones a VeriFactu son inmutables. Por eso el endpoint /issue exige un confirmationToken: lo devuelve el preview anterior y caduca a los 5 minutos. Sin él recibes 400 missing_confirmation.',
+      code: [
+        {
+          language: 'bash',
+          label: 'POST /api/v1/invoices/:id/issue',
+          content: `curl -X POST https://isaak.verifactu.business/api/v1/invoices/inv_xxx/issue \\
+  -H "Authorization: Bearer $ISAAK_API_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '{ "confirmationToken": "tkn_xxx_del_paso_previo" }'`,
+        },
+      ],
+      callout: {
+        kind: 'warn',
+        text: 'En isk_test_…, la respuesta es idéntica a producción pero NO se registra en AEAT real. Usa isk_test antes de mover código a prod.',
+      },
+    },
+    {
+      title: '5. Descarga el PDF firmado',
+      body: 'Una vez emitida, el PDF incluye el QR con el hash VeriFactu y el código seguro. Se sirve como application/pdf desde el endpoint /pdf.',
+      code: [
+        {
+          language: 'bash',
+          label: 'GET /api/v1/invoices/:id/pdf',
+          content: `curl https://isaak.verifactu.business/api/v1/invoices/inv_xxx/pdf \\
+  -H "Authorization: Bearer $ISAAK_API_KEY" \\
+  -o factura.pdf`,
+        },
+      ],
+    },
+  ],
+  nextSteps: [
+    { label: 'Manejar errores y reintentos', href: '/developers/errors' },
+    { label: 'Recibir el evento invoice.issued vía webhook', href: '/developers/guides/webhooks-hmac' },
+    { label: 'Referencia interactiva completa', href: '/developers/api' },
+  ],
+};
+
+const WEBHOOKS_HMAC: Guide = {
+  slug: 'webhooks-hmac',
+  title: 'Recibir webhooks con firma HMAC verificada',
+  eyebrow: 'Webhooks',
+  icon: Webhook,
+  summary:
+    'Recibe eventos en tiempo real (invoice.issued, certificate.expiring…) y verifica la firma HMAC-SHA256 con código de ejemplo en Node, Python y Go.',
+  readingMinutes: 7,
+  prerequisites: [
+    'Endpoint HTTPS público que pueda recibir POSTs (ngrok sirve para pruebas locales)',
+    'Plan Pro o Business con webhooks activos',
+    'Acceso a Ajustes → Webhooks en isaak.verifactu.business para registrar la URL',
+  ],
+  steps: [
+    {
+      title: '1. Registra tu endpoint',
+      body: 'En el panel de Isaak, sección Webhooks, pulsa "Añadir endpoint". Introduce tu URL HTTPS y selecciona los eventos que quieras recibir. Isaak te dará un signing secret (whsec_…) que necesitarás en el paso 3.',
+      callout: {
+        kind: 'info',
+        text: 'El signing secret se muestra UNA SOLA VEZ tras crearlo. Guárdalo en tu gestor de secretos antes de cerrar la ventana.',
+      },
+    },
+    {
+      title: '2. Acepta el POST',
+      body: 'Tu endpoint recibe un POST application/json con el evento. Devuelve 2xx en menos de 5 segundos. Si tardas más o devuelves >= 400, Isaak reintenta con backoff exponencial (1m, 5m, 30m, 2h, 12h, 24h) hasta 6 veces.',
+      code: [
+        {
+          language: 'json',
+          label: 'Body del POST',
+          content: `{
+  "id": "evt_2026_05_28_abc123",
+  "type": "invoice.issued",
+  "createdAt": "2026-05-28T10:23:45.000Z",
+  "tenantId": "tnt_xxx",
+  "data": {
+    "invoiceId": "inv_2026_0042",
+    "number": "2026/0042",
+    "amount": 1210.00,
+    "verifactuHash": "a1b2c3d4..."
+  }
+}`,
+        },
+      ],
+    },
+    {
+      title: '3. Verifica la firma',
+      body: 'Cada POST trae las cabeceras x-isaak-signature y x-isaak-timestamp. Calcula HMAC-SHA256 sobre "<timestamp>.<raw_body>" con tu signing secret y compara con timingSafeEqual. Si el timestamp tiene más de 5 minutos, rechaza el evento (anti-replay).',
+      code: [
+        {
+          language: 'js',
+          label: 'Node.js (Express)',
+          content: `import crypto from 'node:crypto';
+import express from 'express';
+
+const app = express();
+const SECRET = process.env.ISAAK_WEBHOOK_SECRET;
+
+// IMPORTANTE: necesitas el cuerpo crudo (Buffer), NO el JSON parseado
+app.post('/webhooks/isaak',
+  express.raw({ type: 'application/json' }),
+  (req, res) => {
+    const sig = req.header('x-isaak-signature');
+    const ts = req.header('x-isaak-timestamp');
+
+    if (Math.abs(Date.now() / 1000 - Number(ts)) > 300) {
+      return res.status(400).send('timestamp out of window');
+    }
+
+    const payload = \`\${ts}.\${req.body.toString('utf8')}\`;
+    const expected = crypto.createHmac('sha256', SECRET).update(payload).digest('hex');
+
+    if (!crypto.timingSafeEqual(Buffer.from(sig), Buffer.from(expected))) {
+      return res.status(401).send('invalid signature');
+    }
+
+    const event = JSON.parse(req.body.toString('utf8'));
+    console.log('event', event.type, event.id);
+    res.status(200).send('ok');
+  }
+);`,
+        },
+        {
+          language: 'python',
+          label: 'Python (Flask)',
+          content: `import hmac, hashlib, os, time, json
+from flask import Flask, request, abort
+
+app = Flask(__name__)
+SECRET = os.environ['ISAAK_WEBHOOK_SECRET'].encode()
+
+@app.post('/webhooks/isaak')
+def isaak_webhook():
+    sig = request.headers.get('X-Isaak-Signature', '')
+    ts = request.headers.get('X-Isaak-Timestamp', '0')
+
+    if abs(time.time() - float(ts)) > 300:
+        abort(400, 'timestamp out of window')
+
+    payload = f"{ts}.{request.get_data(as_text=True)}".encode()
+    expected = hmac.new(SECRET, payload, hashlib.sha256).hexdigest()
+
+    if not hmac.compare_digest(sig, expected):
+        abort(401, 'invalid signature')
+
+    event = request.get_json()
+    print('event', event['type'], event['id'])
+    return ('', 200)`,
+        },
+      ],
+      callout: {
+        kind: 'warn',
+        text: 'NO uses comparación de strings (==): es vulnerable a timing attacks. Usa crypto.timingSafeEqual (Node) o hmac.compare_digest (Python).',
+      },
+    },
+    {
+      title: '4. Hazlo idempotente',
+      body: 'Isaak puede reintentar un evento ya entregado (ej. si tu servidor no respondió a tiempo). Usa el campo id del evento como clave de idempotencia: guárdalo en BBDD con UNIQUE constraint y descarta duplicados con 200 OK.',
+      code: [
+        {
+          language: 'js',
+          label: 'Tabla de idempotencia (Postgres + Prisma)',
+          content: `model ProcessedWebhook {
+  id        String   @id  // evt_… del payload
+  type      String
+  createdAt DateTime @default(now())
+}
+
+// En el handler:
+try {
+  await prisma.processedWebhook.create({ data: { id: event.id, type: event.type } });
+} catch (e) {
+  if (e.code === 'P2002') {
+    // Duplicate — ya procesado. Responde 200 igualmente.
+    return res.status(200).send('ok');
+  }
+  throw e;
+}`,
+        },
+      ],
+    },
+    {
+      title: '5. Prueba con curl',
+      body: 'Genera tú mismo una firma válida y simula un evento contra tu propio endpoint local. Te ahorra esperar a que Isaak emita uno real.',
+      code: [
+        {
+          language: 'bash',
+          label: 'Generar firma + enviar',
+          content: `SECRET="whsec_xxx"
+TS=$(date +%s)
+BODY='{"id":"evt_test","type":"invoice.issued","data":{}}'
+SIG=$(printf '%s.%s' "$TS" "$BODY" | openssl dgst -sha256 -hmac "$SECRET" -hex | awk '{print $2}')
+
+curl -X POST http://localhost:3000/webhooks/isaak \\
+  -H "Content-Type: application/json" \\
+  -H "x-isaak-timestamp: $TS" \\
+  -H "x-isaak-signature: $SIG" \\
+  -d "$BODY"`,
+        },
+      ],
+    },
+  ],
+  nextSteps: [
+    { label: 'Catálogo completo de eventos', href: '/developers/webhooks' },
+    { label: 'Códigos de error y reintentos', href: '/developers/errors' },
+    { label: 'Rate limits de la API', href: '/developers/rate-limits' },
+  ],
+};
+
+const CONECTAR_HOLDED: Guide = {
+  slug: 'conectar-holded-api',
+  title: 'Conectar Holded (ERP) en 5 minutos',
+  eyebrow: 'Integración',
+  icon: Plug,
+  summary:
+    'Conecta tu cuenta de Holded a Isaak con la API key del ERP. Las keys se cifran AES-256-GCM antes de guardarse — nunca viajan en claro entre apps.',
+  readingMinutes: 4,
+  prerequisites: [
+    'Cuenta Holded con permisos para generar API keys',
+    'API key de Isaak (isk_live_… o isk_test_…)',
+  ],
+  steps: [
+    {
+      title: '1. Genera la API key en Holded',
+      body: 'En Holded entra a Configuración → Desarrolladores → API → Nueva API key. Copia el valor — Holded solo lo muestra una vez. Necesitas permisos de lectura sobre Contactos, Documentos y Catálogo.',
+    },
+    {
+      title: '2. Envía la key a Isaak',
+      body: 'POST /api/v1/integrations/holded/api-key con la key en el body. Isaak la cifra con AES-256-GCM usando HOLDED_KEY_SECRET y la guarda en tu fila de tenant. Nunca queda en logs ni en respuestas.',
+      code: [
+        {
+          language: 'bash',
+          label: 'POST /api/v1/integrations/holded/api-key',
+          content: `curl -X POST https://isaak.verifactu.business/api/v1/integrations/holded/api-key \\
+  -H "Authorization: Bearer $ISAAK_API_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '{ "holdedApiKey": "TU_HOLDED_API_KEY" }'`,
+        },
+        {
+          language: 'json',
+          label: 'Respuesta',
+          content: `{
+  "ok": true,
+  "data": {
+    "connected": true,
+    "holdedAccountName": "Acme SL",
+    "lastSyncAt": null
+  }
+}`,
+        },
+      ],
+      callout: {
+        kind: 'success',
+        text: 'Si la key es válida, Isaak hace una llamada de verificación a /me en la API de Holded y guarda el nombre de la cuenta. Si no, devuelve 400 invalid_holded_key sin tocar tu BBDD.',
+      },
+    },
+    {
+      title: '3. Lanza la primera sincronización',
+      body: 'El sync extrae contactos, facturas emitidas y recibidas. Lo lanzas a demanda — Isaak no lo programa automáticamente para no consumir tu quota Holded.',
+      code: [
+        {
+          language: 'bash',
+          label: 'POST /api/v1/integrations/holded/sync',
+          content: `curl -X POST https://isaak.verifactu.business/api/v1/integrations/holded/sync \\
+  -H "Authorization: Bearer $ISAAK_API_KEY"`,
+        },
+      ],
+    },
+    {
+      title: '4. Verifica el estado',
+      body: 'GET /api/v1/integrations/accounting/status devuelve el estado de todas tus integraciones contables (Holded, Chift cuando esté activo, etc.). Útil para mostrar un "conectado" en tu propio UI.',
+      code: [
+        {
+          language: 'bash',
+          label: 'GET /api/v1/integrations/accounting/status',
+          content: `curl https://isaak.verifactu.business/api/v1/integrations/accounting/status \\
+  -H "Authorization: Bearer $ISAAK_API_KEY"`,
+        },
+      ],
+    },
+    {
+      title: '5. Desconecta cuando quieras',
+      body: 'DELETE elimina la API key cifrada. Tras esto Isaak no puede leer ni escribir en Holded. Los datos ya sincronizados quedan en Isaak, pero no se actualizan más.',
+      code: [
+        {
+          language: 'bash',
+          label: 'DELETE /api/v1/integrations/holded/api-key',
+          content: `curl -X DELETE https://isaak.verifactu.business/api/v1/integrations/holded/api-key \\
+  -H "Authorization: Bearer $ISAAK_API_KEY"`,
+        },
+      ],
+    },
+  ],
+  nextSteps: [
+    { label: 'Listado de integraciones soportadas', href: '/conectores' },
+    { label: 'Webhooks: reaccionar a sincronizaciones', href: '/developers/guides/webhooks-hmac' },
+    { label: 'Estado de conectores en vivo', href: 'https://holded.verifactu.business' },
+  ],
+};
+
+const MCP_CLAUDE_DESKTOP: Guide = {
+  slug: 'mcp-claude-desktop',
+  title: 'Conectar Isaak a Claude Desktop (MCP)',
+  eyebrow: 'MCP',
+  icon: Bot,
+  summary:
+    'Añade el servidor MCP de Isaak a Claude Desktop para que el modelo pueda consultar tus facturas y emitir a VeriFactu desde la conversación.',
+  readingMinutes: 4,
+  prerequisites: [
+    'Claude Desktop instalado (Mac, Windows o Linux)',
+    'API key de Isaak con scope mcp.invoke',
+    'Plan Starter o superior (MCP requiere autenticación API key)',
+  ],
+  steps: [
+    {
+      title: '1. Localiza el archivo de configuración',
+      body: 'Claude Desktop lee la configuración MCP de un archivo JSON. Si no existe, créalo con contenido vacío {} antes de editar.',
+      code: [
+        {
+          language: 'bash',
+          label: 'Rutas por plataforma',
+          content: `# macOS
+~/Library/Application Support/Claude/claude_desktop_config.json
+
+# Windows
+%APPDATA%\\Claude\\claude_desktop_config.json
+
+# Linux
+~/.config/Claude/claude_desktop_config.json`,
+        },
+      ],
+    },
+    {
+      title: '2. Añade el servidor Isaak',
+      body: 'Pega el bloque mcpServers.isaak con tu API key. Si ya tienes otros servidores configurados, añade isaak dentro del objeto mcpServers existente.',
+      code: [
+        {
+          language: 'json',
+          label: 'claude_desktop_config.json',
+          content: `{
+  "mcpServers": {
+    "isaak": {
+      "url": "https://isaak.verifactu.business/api/mcp/isaak",
+      "headers": {
+        "Authorization": "Bearer isk_live_TU_API_KEY"
+      }
+    }
+  }
+}`,
+        },
+      ],
+      callout: {
+        kind: 'warn',
+        text: 'No commitees este archivo a git con tu API key real. En equipos compartidos usa una key de scope reducido (solo lectura) si tu uso es exploratorio.',
+      },
+    },
+    {
+      title: '3. Reinicia Claude Desktop',
+      body: 'Cierra Claude Desktop por completo (Cmd+Q en Mac) y vuelve a abrir. La primera vez tarda unos segundos en establecer la conexión con el servidor MCP.',
+    },
+    {
+      title: '4. Confirma las herramientas disponibles',
+      body: 'En el icono de "plug" abajo a la izquierda del chat verás isaak con un punto verde si la conexión funciona. Click para ver las 9 herramientas: listar facturas, crear borrador, validar antes de emitir, etc.',
+      callout: {
+        kind: 'info',
+        text: 'Si ves un punto rojo, abre Configuración → Developer → Logs en Claude Desktop. Errores típicos: API key inválida (401) o URL mal escrita.',
+      },
+    },
+    {
+      title: '5. Prueba con una conversación',
+      body: 'Pregunta a Claude algo como "¿Cuáles fueron mis facturas más altas en abril?" o "Crea un borrador para Acme SL por 500€ de consultoría". Claude usará automáticamente las tools MCP — verás un panel con la herramienta y los argumentos antes de ejecutarse.',
+    },
+  ],
+  nextSteps: [
+    { label: 'Listado completo de tools MCP', href: '/developers#mcp' },
+    { label: 'Debuggear con MCP Inspector', href: '/developers#inspector' },
+    { label: 'Conector Holded para Claude', href: 'https://claude.verifactu.business' },
+  ],
+};
+
+// ─── Catálogo exportado ────────────────────────────────────────────────────────
+
+export const GUIDES: Guide[] = [
+  PRIMERA_FACTURA,
+  WEBHOOKS_HMAC,
+  CONECTAR_HOLDED,
+  MCP_CLAUDE_DESKTOP,
+];
+
+export const GUIDES_BY_SLUG: Record<string, Guide> = Object.fromEntries(
+  GUIDES.map((g) => [g.slug, g])
+);
+
+export function getGuide(slug: string): Guide | undefined {
+  return GUIDES_BY_SLUG[slug];
+}

--- a/apps/landing/app/developers/guides/page.tsx
+++ b/apps/landing/app/developers/guides/page.tsx
@@ -1,0 +1,118 @@
+import { ArrowLeft, ArrowRight, BookOpen, Clock } from 'lucide-react';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import Header from '../../components/Header';
+import { Container, Footer } from '../../lib/home/ui';
+import { GUIDES } from './guides-data';
+
+export const metadata: Metadata = {
+  title: 'Guías paso a paso | Isaak Platform API — Verifactu Business',
+  description:
+    'Tutoriales prácticos con código real: primera factura via API, webhooks con HMAC, conectar Holded y configurar el conector MCP en Claude Desktop.',
+  alternates: { canonical: '/developers/guides' },
+  openGraph: {
+    title: 'Guías paso a paso — Isaak Developers',
+    description:
+      'Tutoriales prácticos con código real para integrar Isaak en tu software.',
+    type: 'website',
+    locale: 'es_ES',
+    url: 'https://verifactu.business/developers/guides',
+    siteName: 'Verifactu Business',
+  },
+};
+
+const navLinks = [
+  { label: 'VeriFactu', href: '/verifactu/que-es' },
+  { label: 'Que es Isaak', href: '/que-es-isaak' },
+  { label: 'Conectores', href: '/conectores' },
+  { label: 'Precios', href: '/precios' },
+  { label: 'Developers', href: '/developers' },
+];
+
+export default function GuidesIndexPage() {
+  return (
+    <div className="min-h-screen bg-white text-slate-900">
+      <Header navLinks={navLinks} />
+
+      <section className="border-b border-slate-200 bg-[linear-gradient(180deg,#f4f8ff_0%,#ffffff_70%)] py-14 sm:py-16">
+        <Container>
+          <Link
+            href="/developers"
+            className="inline-flex items-center gap-1.5 text-sm text-slate-600 hover:text-[#2361d8]"
+          >
+            <ArrowLeft className="h-3.5 w-3.5" />
+            Developers
+          </Link>
+          <div className="mt-4 inline-flex items-center gap-2 rounded-full border border-[#2361d8]/15 bg-[#2361d8]/5 px-4 py-1.5 text-xs font-semibold uppercase tracking-[0.16em] text-[#2361d8]">
+            <BookOpen className="h-3.5 w-3.5" />
+            Guías paso a paso
+          </div>
+          <h1 className="mt-5 max-w-3xl text-4xl font-bold tracking-tight text-[#011c67] sm:text-5xl">
+            Aprende integrando, no leyendo.
+          </h1>
+          <p className="mt-4 max-w-3xl text-lg leading-8 text-slate-600">
+            Cada guía es un tutorial completo con código que copias y pegas. Desde la primera
+            factura via cURL hasta firmar webhooks en producción.
+          </p>
+        </Container>
+      </section>
+
+      <section className="py-14">
+        <Container>
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-2">
+            {GUIDES.map((guide) => {
+              const Icon = guide.icon;
+              return (
+                <Link
+                  key={guide.slug}
+                  href={`/developers/guides/${guide.slug}`}
+                  className="group flex flex-col rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition hover:border-[#2361d8]/30 hover:shadow-md"
+                >
+                  <div className="flex items-center justify-between">
+                    <div className="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-[#2361d8]/8">
+                      <Icon className="h-5 w-5 text-[#2361d8]" />
+                    </div>
+                    <span className="inline-flex items-center gap-1 rounded-full bg-slate-100 px-2.5 py-1 text-xs font-medium text-slate-600">
+                      <Clock className="h-3 w-3" />
+                      {guide.readingMinutes} min
+                    </span>
+                  </div>
+                  <div className="mt-4 text-xs font-semibold uppercase tracking-[0.16em] text-[#2361d8]">
+                    {guide.eyebrow}
+                  </div>
+                  <h2 className="mt-2 text-xl font-semibold text-[#011c67]">{guide.title}</h2>
+                  <p className="mt-2 text-sm leading-6 text-slate-600">{guide.summary}</p>
+                  <span className="mt-5 inline-flex items-center gap-1 text-sm font-medium text-[#2361d8] group-hover:underline">
+                    Abrir guía <ArrowRight className="h-3.5 w-3.5" />
+                  </span>
+                </Link>
+              );
+            })}
+          </div>
+        </Container>
+      </section>
+
+      <section className="border-t border-slate-100 py-14">
+        <Container>
+          <div className="rounded-[2rem] border border-[#2361d8]/15 bg-[linear-gradient(135deg,#f0f5ff_0%,#ffffff_100%)] p-10 text-center sm:p-12">
+            <h2 className="text-2xl font-bold tracking-tight text-[#011c67] sm:text-3xl">
+              ¿Te falta una guía?
+            </h2>
+            <p className="mt-3 text-slate-600">
+              Si estás integrando algo que no encuentras aquí, dínoslo y lo escribimos.
+            </p>
+            <Link
+              href="/recursos/contacto"
+              className="mt-6 inline-flex items-center justify-center gap-2 rounded-full bg-[#2361d8] px-7 py-3 text-sm font-semibold text-white shadow-md transition hover:bg-[#1f55c0]"
+            >
+              Proponer una guía
+              <ArrowRight className="h-4 w-4" />
+            </Link>
+          </div>
+        </Container>
+      </section>
+
+      <Footer />
+    </div>
+  );
+}

--- a/apps/landing/app/developers/page.tsx
+++ b/apps/landing/app/developers/page.tsx
@@ -426,6 +426,23 @@ export default function DevelopersPage() {
 
             <div className="mt-8 grid gap-4 sm:grid-cols-2">
               <Link
+                href="/developers/guides"
+                className="group rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition hover:border-[#2361d8]/30 hover:shadow-md"
+              >
+                <div className="text-xs font-semibold uppercase tracking-widest text-emerald-700">
+                  Tutoriales
+                </div>
+                <h3 className="mt-2 text-lg font-semibold text-[#011c67]">Guías paso a paso</h3>
+                <p className="mt-2 text-sm leading-6 text-slate-600">
+                  Primera factura via cURL, webhooks con HMAC, conectar Holded, MCP en Claude
+                  Desktop. Código real, copy-paste.
+                </p>
+                <span className="mt-4 inline-flex items-center gap-1 text-sm font-medium text-[#2361d8] group-hover:underline">
+                  Abrir guías <ArrowRight className="h-3.5 w-3.5" />
+                </span>
+              </Link>
+
+              <Link
                 href="/developers/api"
                 className="group rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition hover:border-[#2361d8]/30 hover:shadow-md"
               >


### PR DESCRIPTION
## Contexto

Tanda **D4** del Master Plan Developers Portal. Tras la doc-hub estática (Scalar API ref, errors, rate-limits, webhooks doc) faltaban **tutoriales** — código real que un dev copia y pega.

## Estructura

```
/developers/guides              ← índice (cards con icono + tiempo lectura)
/developers/guides/[slug]       ← detalle SSG, ToC sticky, callouts, code blocks
```

Data-driven (`guides-data.ts`) con `generateStaticParams` + `generateMetadata` por slug. Añadir una guía nueva = añadir un objeto al array.

## Catálogo inicial (4 guías)

| Slug | Eyebrow | Duración | Contenido |
|---|---|---|---|
| `primera-factura` | Quickstart | 5 min | `GET /companies/current` → `POST /invoices` → `POST /invoices/:id/issue` con confirmationToken → `GET /pdf`. Explica `isk_test` vs `isk_live`. |
| `webhooks-hmac` | Webhooks | 7 min | Recibir webhooks firmados. Node (Express raw body) + Python (Flask). Timing-safe compare, anti-replay 5min, idempotencia con tabla `ProcessedWebhook`, simular firma con `openssl`. |
| `conectar-holded-api` | Integración | 4 min | Generar key Holded → `POST /integrations/holded/api-key` (cifrado AES-256-GCM) → sync → status → disconnect. |
| `mcp-claude-desktop` | MCP | 4 min | Configurar el server MCP Isaak en Claude Desktop. Rutas por plataforma, bloque JSON, debug con logs. |

## Decisiones clave

- **Data-driven** (`guides-data.ts` exporta `GUIDES`, `getGuide(slug)`): añadir guías nuevas sin tocar JSX. SEO intacto vía SSG.
- **`GuideStep` flexible**: `code` y `callout` opcionales — algunas guías son solo texto + pasos numerados.
- **Callouts tipados** (`info` / `warn` / `success`) con sus iconos lucide. Reusables.
- **ToC sticky solo en `lg:`**: móvil tiene flujo lineal claro.
- **MCP guide segura**: documenta solo el server **Isaak** (ya activo en prod). NO añade tools ni cambia URLs del conector Holded, que sigue en revisión Anthropic.

## Cambio adicional al hub

`/developers/page.tsx`: nuevo card **"Guías paso a paso"** como primera entrada en la sección "Documentación detallada" (antes de API ref / errors / rate-limits / webhooks).

## Verificación

- ✅ `npx tsc --noEmit` — 0 errores en archivos nuevos (solo persiste 1 error preexistente en `magic-link.test.ts`, no relacionado).
- ✅ `npx next build` — las 4 guías se prerrenderizan como SSG:
  ```
  ● /developers/guides/[slug]
    ├ /developers/guides/primera-factura
    ├ /developers/guides/webhooks-hmac
    ├ /developers/guides/conectar-holded-api
    └ /developers/guides/mcp-claude-desktop
  ```
- ✅ Sin cambios en handlers de API ni en MCP connectors.

## Test plan

- [ ] Vercel deploy verde para `landing`
- [ ] `/developers` renderiza el card "Guías paso a paso" como primera entrada
- [ ] `/developers/guides` lista las 4 cards
- [ ] Las 4 URLs `/developers/guides/<slug>` cargan con su contenido completo
- [ ] Móvil: pasos legibles sin ToC; desktop: ToC sticky a la derecha
- [ ] Code blocks con scroll horizontal en líneas largas (cURL multi-línea)

## Siguiente tanda candidata

- **D1** webhooks delivery real con HMAC (la guía está, falta el sender)
- **D2** SDK TypeScript en npm (`@verifactu/sdk`)