### PR TITLE
chore: ignorar .claude/ (worktrees efímeros + settings locales)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ env-audit.txt
 .tmp-video/
 **/__MACOSX/
 scripts/video-pipeline/output/
+
+# Claude Code session artifacts (worktrees efímeros, settings locales)
+.claude/


### PR DESCRIPTION
## Contexto

El stop-hook avisaba de `untracked files` por culpa del directorio `.claude/`, que aparece en sesiones de Claude Code on the web con:

- `.claude/settings.local.json` — settings locales no commiteables
- `.claude/worktrees/` — worktrees efímeros de subagents

Ninguno debe entrar al repo.

## Cambio

Añadido `.claude/` al `.gitignore` con comentario explicando el motivo. 3 líneas.

## Verificación

`git status -s` ya no muestra `.claude/` como untracked.

Desbloquea el stop-hook para que no falle al final de cada turno.