### PR TITLE
feat(isaak): outbound webhooks delivery with HMAC + retry queue (D1)

### DIFF
--- a/apps/isaak/app/api/cron/webhooks-dispatch/route.ts
+++ b/apps/isaak/app/api/cron/webhooks-dispatch/route.ts
@@ -1,0 +1,41 @@
+/**
+ * GET /api/cron/webhooks-dispatch
+ *
+ * Runs every minute (configured in apps/isaak/vercel.json). Drains the
+ * outbound webhook queue: signs pending deliveries with HMAC-SHA256 and
+ * POSTs them to the customer endpoint registered via IsaakWebhookEndpoint.
+ *
+ * Auth: Bearer CRON_SECRET, compared in constant time. If CRON_SECRET is
+ * not configured the endpoint is closed (401) — never run unauthenticated.
+ *
+ * See `apps/isaak/app/lib/webhooks/dispatch.ts` for the retry policy.
+ */
+import { timingSafeEqual } from 'crypto';
+import { NextRequest, NextResponse } from 'next/server';
+import { dispatchPendingDeliveries } from '@/app/lib/webhooks';
+
+export const runtime = 'nodejs';
+export const maxDuration = 60;
+
+function authorizeCron(req: NextRequest) {
+  const secret = process.env.CRON_SECRET?.trim();
+  if (!secret) return false;
+  const token = req.headers.get('authorization') ?? '';
+  const expected = `Bearer ${secret}`;
+  if (token.length !== expected.length) return false;
+  return timingSafeEqual(Buffer.from(token), Buffer.from(expected));
+}
+
+export async function GET(req: NextRequest) {
+  if (!authorizeCron(req)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const summary = await dispatchPendingDeliveries({ batchSize: 50 });
+    return NextResponse.json({ ok: true, ...summary });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/apps/isaak/app/lib/__tests__/webhooks/dispatch.test.ts
+++ b/apps/isaak/app/lib/__tests__/webhooks/dispatch.test.ts
@@ -1,0 +1,202 @@
+/**
+ * D1 — dispatchPendingDeliveries.
+ *
+ * Mocks the global `fetch` and the Prisma client. Verifies:
+ *  - 2xx → status='delivered', deliveredAt set, attempts incremented.
+ *  - 5xx → status stays 'pending', attempts incremented, backoff applied
+ *    via nextAttemptAt (60s for attempt #1).
+ *  - After 6 failed attempts the row moves to status='dead'.
+ *  - Signed headers (x-isaak-signature, x-isaak-timestamp, x-isaak-event-id)
+ *    are present and the signature verifies against the row's endpoint
+ *    secret.
+ *  - backoffSeconds() returns the documented schedule.
+ */
+const findManyMock = jest.fn();
+const updateMock = jest.fn();
+
+jest.mock('@/app/lib/prisma', () => ({
+  prisma: {
+    isaakWebhookDelivery: {
+      findMany: (...args: unknown[]) => findManyMock(...args),
+      update: (...args: unknown[]) => updateMock(...args),
+    },
+  },
+}));
+
+import { verifySignature } from '../../webhooks/signer';
+import {
+  dispatchPendingDeliveries,
+  backoffSeconds,
+  MAX_ATTEMPTS,
+} from '../../webhooks/dispatch';
+
+type FetchMock = jest.Mock<Promise<Response>, [url: string, init?: RequestInit]>;
+
+const originalFetch = global.fetch;
+let fetchMock: FetchMock;
+
+function mockFetchResponse(status: number, bodyText = '') {
+  fetchMock.mockResolvedValueOnce({
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => bodyText,
+  } as Response);
+}
+
+function deliveryRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'del_1',
+    endpointId: 'ep_1',
+    eventId: 'evt_test_1',
+    payload: { id: 'evt_test_1', type: 'invoice.issued', data: { invoiceId: 'inv_1' } },
+    attempts: 0,
+    endpoint: { url: 'https://example.com/hook', secret: 'whsec_test', active: true },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  findManyMock.mockReset();
+  updateMock.mockReset();
+  updateMock.mockResolvedValue({});
+  fetchMock = jest.fn() as FetchMock;
+  global.fetch = fetchMock as unknown as typeof global.fetch;
+});
+
+afterAll(() => {
+  global.fetch = originalFetch;
+});
+
+describe('backoffSeconds', () => {
+  test('matches the documented schedule (1m, 5m, 30m, 2h, 12h, 24h)', () => {
+    expect(backoffSeconds(1)).toBe(60);
+    expect(backoffSeconds(2)).toBe(300);
+    expect(backoffSeconds(3)).toBe(1800);
+    expect(backoffSeconds(4)).toBe(7200);
+    expect(backoffSeconds(5)).toBe(43_200);
+    expect(backoffSeconds(6)).toBe(86_400);
+  });
+
+  test('clamps out-of-range attempt numbers', () => {
+    expect(backoffSeconds(0)).toBe(60);
+    expect(backoffSeconds(99)).toBe(86_400);
+  });
+});
+
+describe('dispatchPendingDeliveries — success path', () => {
+  test('2xx → status=delivered, deliveredAt set, attempts incremented', async () => {
+    findManyMock.mockResolvedValue([deliveryRow()]);
+    mockFetchResponse(200, 'ok');
+
+    const summary = await dispatchPendingDeliveries({ batchSize: 50 });
+
+    expect(summary).toEqual({ processed: 1, delivered: 1, failed: 0, dead: 0 });
+    expect(updateMock).toHaveBeenCalledTimes(1);
+
+    const call = updateMock.mock.calls[0][0];
+    expect(call.where).toEqual({ id: 'del_1' });
+    expect(call.data.status).toBe('delivered');
+    expect(call.data.attempts).toBe(1);
+    expect(call.data.deliveredAt).toBeInstanceOf(Date);
+    expect(call.data.lastStatusCode).toBe(200);
+    expect(call.data.nextAttemptAt).toBeNull();
+  });
+
+  test('sends signed headers; signature verifies with the endpoint secret', async () => {
+    findManyMock.mockResolvedValue([deliveryRow()]);
+    mockFetchResponse(204);
+
+    await dispatchPendingDeliveries();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://example.com/hook');
+    expect(init?.method).toBe('POST');
+
+    const headers = init?.headers as Record<string, string>;
+    expect(headers['x-isaak-event-id']).toBe('evt_test_1');
+    expect(typeof headers['x-isaak-timestamp']).toBe('string');
+    expect(typeof headers['x-isaak-signature']).toBe('string');
+    expect(headers['x-isaak-signature']).toHaveLength(64);
+    expect(headers['content-type']).toBe('application/json');
+
+    const body = String(init?.body);
+    expect(
+      verifySignature('whsec_test', headers['x-isaak-timestamp'], body, headers['x-isaak-signature'])
+    ).toBe(true);
+  });
+});
+
+describe('dispatchPendingDeliveries — retry path', () => {
+  test('5xx on first attempt → pending + backoff (~60s) + failed counter', async () => {
+    findManyMock.mockResolvedValue([deliveryRow({ attempts: 0 })]);
+    mockFetchResponse(500, 'internal error');
+
+    const summary = await dispatchPendingDeliveries();
+
+    expect(summary).toEqual({ processed: 1, delivered: 0, failed: 1, dead: 0 });
+    const data = updateMock.mock.calls[0][0].data;
+    expect(data.status).toBe('pending');
+    expect(data.attempts).toBe(1);
+    expect(data.lastStatusCode).toBe(500);
+    expect(data.lastError).toBe('http_500');
+    expect(data.nextAttemptAt).toBeInstanceOf(Date);
+
+    const delta = (data.nextAttemptAt as Date).getTime() - Date.now();
+    // Should be ~60s in the future (with some slack for test execution).
+    expect(delta).toBeGreaterThan(55_000);
+    expect(delta).toBeLessThan(65_000);
+  });
+
+  test('network error → pending + lastError captured', async () => {
+    findManyMock.mockResolvedValue([deliveryRow({ attempts: 1 })]);
+    fetchMock.mockRejectedValueOnce(new Error('socket hang up'));
+
+    const summary = await dispatchPendingDeliveries();
+
+    expect(summary.failed).toBe(1);
+    const data = updateMock.mock.calls[0][0].data;
+    expect(data.status).toBe('pending');
+    expect(data.attempts).toBe(2);
+    expect(data.lastError).toBe('socket hang up');
+    expect(data.lastStatusCode).toBeNull();
+  });
+
+  test('attempts reaching MAX_ATTEMPTS → status=dead', async () => {
+    findManyMock.mockResolvedValue([deliveryRow({ attempts: MAX_ATTEMPTS - 1 })]);
+    mockFetchResponse(503, 'unavailable');
+
+    const summary = await dispatchPendingDeliveries();
+
+    expect(summary).toEqual({ processed: 1, delivered: 0, failed: 0, dead: 1 });
+    const data = updateMock.mock.calls[0][0].data;
+    expect(data.status).toBe('dead');
+    expect(data.attempts).toBe(MAX_ATTEMPTS);
+    expect(data.nextAttemptAt).toBeNull();
+  });
+});
+
+describe('dispatchPendingDeliveries — endpoint hygiene', () => {
+  test('endpoint deleted (null) → mark dead without firing fetch', async () => {
+    findManyMock.mockResolvedValue([deliveryRow({ endpoint: null })]);
+
+    const summary = await dispatchPendingDeliveries();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(summary.dead).toBe(1);
+    expect(updateMock.mock.calls[0][0].data.status).toBe('dead');
+    expect(updateMock.mock.calls[0][0].data.lastError).toBe('endpoint_deleted');
+  });
+
+  test('endpoint inactive → mark dead without firing fetch', async () => {
+    findManyMock.mockResolvedValue([
+      deliveryRow({ endpoint: { url: 'https://x', secret: 's', active: false } }),
+    ]);
+
+    const summary = await dispatchPendingDeliveries();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(summary.dead).toBe(1);
+    expect(updateMock.mock.calls[0][0].data.lastError).toBe('endpoint_inactive');
+  });
+});

--- a/apps/isaak/app/lib/__tests__/webhooks/dispatch.test.ts
+++ b/apps/isaak/app/lib/__tests__/webhooks/dispatch.test.ts
@@ -13,12 +13,14 @@
  */
 const findManyMock = jest.fn();
 const updateMock = jest.fn();
+const updateManyMock = jest.fn();
 
 jest.mock('@/app/lib/prisma', () => ({
   prisma: {
     isaakWebhookDelivery: {
       findMany: (...args: unknown[]) => findManyMock(...args),
       update: (...args: unknown[]) => updateMock(...args),
+      updateMany: (...args: unknown[]) => updateManyMock(...args),
     },
   },
 }));
@@ -59,6 +61,9 @@ beforeEach(() => {
   findManyMock.mockReset();
   updateMock.mockReset();
   updateMock.mockResolvedValue({});
+  updateManyMock.mockReset();
+  // Default: claim succeeds (CAS matched the row exactly as we read it).
+  updateManyMock.mockResolvedValue({ count: 1 });
   fetchMock = jest.fn() as FetchMock;
   global.fetch = fetchMock as unknown as typeof global.fetch;
 });
@@ -91,15 +96,33 @@ describe('dispatchPendingDeliveries — success path', () => {
     const summary = await dispatchPendingDeliveries({ batchSize: 50 });
 
     expect(summary).toEqual({ processed: 1, delivered: 1, failed: 0, dead: 0 });
+    // One atomic claim (updateMany with CAS) + one final result (update).
+    expect(updateManyMock).toHaveBeenCalledTimes(1);
     expect(updateMock).toHaveBeenCalledTimes(1);
+
+    const claim = updateManyMock.mock.calls[0][0];
+    expect(claim.where).toMatchObject({ id: 'del_1', status: 'pending', attempts: 0 });
+    expect(claim.data.attempts).toBe(1);
+    expect(claim.data.nextAttemptAt).toBeInstanceOf(Date);
 
     const call = updateMock.mock.calls[0][0];
     expect(call.where).toEqual({ id: 'del_1' });
     expect(call.data.status).toBe('delivered');
-    expect(call.data.attempts).toBe(1);
+    expect(call.data.attempts).toBeUndefined(); // already bumped in claim
     expect(call.data.deliveredAt).toBeInstanceOf(Date);
     expect(call.data.lastStatusCode).toBe(200);
     expect(call.data.nextAttemptAt).toBeNull();
+  });
+
+  test('concurrent dispatcher already claimed row → updateMany.count=0, no fetch, no final update', async () => {
+    findManyMock.mockResolvedValue([deliveryRow()]);
+    updateManyMock.mockResolvedValueOnce({ count: 0 }); // someone else won the CAS
+
+    const summary = await dispatchPendingDeliveries();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(updateMock).not.toHaveBeenCalled();
+    expect(summary).toEqual({ processed: 1, delivered: 0, failed: 0, dead: 0 });
   });
 
   test('sends signed headers; signature verifies with the endpoint secret', async () => {
@@ -135,9 +158,13 @@ describe('dispatchPendingDeliveries — retry path', () => {
     const summary = await dispatchPendingDeliveries();
 
     expect(summary).toEqual({ processed: 1, delivered: 0, failed: 1, dead: 0 });
+
+    // Claim bumped attempts to 1
+    expect(updateManyMock.mock.calls[0][0].data.attempts).toBe(1);
+
     const data = updateMock.mock.calls[0][0].data;
     expect(data.status).toBe('pending');
-    expect(data.attempts).toBe(1);
+    expect(data.attempts).toBeUndefined(); // claim already did it
     expect(data.lastStatusCode).toBe(500);
     expect(data.lastError).toBe('http_500');
     expect(data.nextAttemptAt).toBeInstanceOf(Date);
@@ -155,9 +182,9 @@ describe('dispatchPendingDeliveries — retry path', () => {
     const summary = await dispatchPendingDeliveries();
 
     expect(summary.failed).toBe(1);
+    expect(updateManyMock.mock.calls[0][0].data.attempts).toBe(2);
     const data = updateMock.mock.calls[0][0].data;
     expect(data.status).toBe('pending');
-    expect(data.attempts).toBe(2);
     expect(data.lastError).toBe('socket hang up');
     expect(data.lastStatusCode).toBeNull();
   });
@@ -169,26 +196,28 @@ describe('dispatchPendingDeliveries — retry path', () => {
     const summary = await dispatchPendingDeliveries();
 
     expect(summary).toEqual({ processed: 1, delivered: 0, failed: 0, dead: 1 });
+    // Claim brings attempts up to MAX
+    expect(updateManyMock.mock.calls[0][0].data.attempts).toBe(MAX_ATTEMPTS);
     const data = updateMock.mock.calls[0][0].data;
     expect(data.status).toBe('dead');
-    expect(data.attempts).toBe(MAX_ATTEMPTS);
     expect(data.nextAttemptAt).toBeNull();
   });
 });
 
 describe('dispatchPendingDeliveries — endpoint hygiene', () => {
-  test('endpoint deleted (null) → mark dead without firing fetch', async () => {
+  test('endpoint deleted (null) → mark dead atomically without firing fetch', async () => {
     findManyMock.mockResolvedValue([deliveryRow({ endpoint: null })]);
 
     const summary = await dispatchPendingDeliveries();
 
     expect(fetchMock).not.toHaveBeenCalled();
+    expect(updateMock).not.toHaveBeenCalled(); // terminal claim is updateMany
     expect(summary.dead).toBe(1);
-    expect(updateMock.mock.calls[0][0].data.status).toBe('dead');
-    expect(updateMock.mock.calls[0][0].data.lastError).toBe('endpoint_deleted');
+    expect(updateManyMock.mock.calls[0][0].data.status).toBe('dead');
+    expect(updateManyMock.mock.calls[0][0].data.lastError).toBe('endpoint_deleted');
   });
 
-  test('endpoint inactive → mark dead without firing fetch', async () => {
+  test('endpoint inactive → mark dead atomically without firing fetch', async () => {
     findManyMock.mockResolvedValue([
       deliveryRow({ endpoint: { url: 'https://x', secret: 's', active: false } }),
     ]);
@@ -197,6 +226,15 @@ describe('dispatchPendingDeliveries — endpoint hygiene', () => {
 
     expect(fetchMock).not.toHaveBeenCalled();
     expect(summary.dead).toBe(1);
-    expect(updateMock.mock.calls[0][0].data.lastError).toBe('endpoint_inactive');
+    expect(updateManyMock.mock.calls[0][0].data.lastError).toBe('endpoint_inactive');
+  });
+
+  test('endpoint deleted but another dispatcher already moved row → no double-count', async () => {
+    findManyMock.mockResolvedValue([deliveryRow({ endpoint: null })]);
+    updateManyMock.mockResolvedValueOnce({ count: 0 }); // terminal CAS lost
+
+    const summary = await dispatchPendingDeliveries();
+
+    expect(summary).toEqual({ processed: 1, delivered: 0, failed: 0, dead: 0 });
   });
 });

--- a/apps/isaak/app/lib/__tests__/webhooks/enqueue.test.ts
+++ b/apps/isaak/app/lib/__tests__/webhooks/enqueue.test.ts
@@ -1,0 +1,120 @@
+/**
+ * D1 — enqueueWebhookDelivery.
+ *
+ * Asserts:
+ *  - Creates one delivery row per active, subscribed endpoint.
+ *  - Ignores inactive endpoints and endpoints that don't subscribe to
+ *    the event type (the Prisma WHERE clause does this — we verify it
+ *    by checking the args the mock receives).
+ *  - All rows share the same eventId (so customers can dedupe across
+ *    retry attempts of the *same* logical event).
+ */
+const findManyMock = jest.fn();
+const createMock = jest.fn();
+
+jest.mock('@/app/lib/prisma', () => ({
+  prisma: {
+    isaakWebhookEndpoint: { findMany: (...args: unknown[]) => findManyMock(...args) },
+    isaakWebhookDelivery: { create: (...args: unknown[]) => createMock(...args) },
+  },
+}));
+
+import { enqueueWebhookDelivery, generateEventId, buildEventPayload } from '../../webhooks/enqueue';
+
+beforeEach(() => {
+  findManyMock.mockReset();
+  createMock.mockReset();
+  createMock.mockResolvedValue({ id: 'd_x' });
+});
+
+describe('generateEventId', () => {
+  test('matches the documented format evt_<ts>_<rand8>', () => {
+    const id = generateEventId();
+    expect(id).toMatch(/^evt_\d+_[0-9a-f]{8}$/);
+  });
+
+  test('returns unique ids on consecutive calls', () => {
+    const ids = new Set<string>();
+    for (let i = 0; i < 10; i++) ids.add(generateEventId());
+    expect(ids.size).toBe(10);
+  });
+});
+
+describe('buildEventPayload', () => {
+  test('wraps data into the canonical envelope', () => {
+    const payload = buildEventPayload('evt_1', 'invoice.issued', { invoiceId: 'inv_42' });
+    expect(payload).toMatchObject({
+      id: 'evt_1',
+      type: 'invoice.issued',
+      data: { invoiceId: 'inv_42' },
+    });
+    expect(typeof payload.created_at).toBe('string');
+    expect(payload.created_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+});
+
+describe('enqueueWebhookDelivery', () => {
+  test('creates one delivery per matching endpoint and shares eventId', async () => {
+    findManyMock.mockResolvedValue([{ id: 'ep_1' }, { id: 'ep_2' }, { id: 'ep_3' }]);
+
+    const result = await enqueueWebhookDelivery({
+      tenantId: '00000000-0000-0000-0000-000000000001',
+      eventType: 'invoice.issued',
+      data: { invoiceId: 'inv_1' },
+    });
+
+    expect(result.enqueued).toBe(3);
+    expect(result.eventId).toMatch(/^evt_\d+_[0-9a-f]{8}$/);
+    expect(createMock).toHaveBeenCalledTimes(3);
+
+    const eventIds = createMock.mock.calls.map((c) => c[0].data.eventId);
+    expect(new Set(eventIds).size).toBe(1);
+    expect(eventIds[0]).toBe(result.eventId);
+
+    const endpointIds = createMock.mock.calls.map((c) => c[0].data.endpointId);
+    expect(endpointIds.sort()).toEqual(['ep_1', 'ep_2', 'ep_3']);
+
+    for (const call of createMock.mock.calls) {
+      const row = call[0].data;
+      expect(row.status).toBe('pending');
+      expect(row.attempts).toBe(0);
+      expect(row.payload).toMatchObject({
+        id: result.eventId,
+        type: 'invoice.issued',
+        data: { invoiceId: 'inv_1' },
+      });
+    }
+  });
+
+  test('queries only active endpoints subscribed to the event type', async () => {
+    findManyMock.mockResolvedValue([]);
+
+    await enqueueWebhookDelivery({
+      tenantId: 'tenant_x',
+      eventType: 'invoice.issued',
+      data: {},
+    });
+
+    expect(findManyMock).toHaveBeenCalledTimes(1);
+    const where = findManyMock.mock.calls[0][0].where;
+    expect(where).toEqual({
+      tenantId: 'tenant_x',
+      active: true,
+      events: { has: 'invoice.issued' },
+    });
+  });
+
+  test('returns enqueued=0 and creates no rows when no endpoint matches', async () => {
+    findManyMock.mockResolvedValue([]);
+
+    const result = await enqueueWebhookDelivery({
+      tenantId: 'tenant_x',
+      eventType: 'invoice.issued',
+      data: {},
+    });
+
+    expect(result.enqueued).toBe(0);
+    expect(result.eventId).toMatch(/^evt_/);
+    expect(createMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/isaak/app/lib/__tests__/webhooks/signer.test.ts
+++ b/apps/isaak/app/lib/__tests__/webhooks/signer.test.ts
@@ -1,0 +1,52 @@
+/**
+ * D1 — HMAC signer for outbound webhooks.
+ *
+ * Asserts:
+ *  - signPayload is deterministic and matches a hand-computed HMAC reference.
+ *  - verifySignature accepts the valid signature and rejects tampered
+ *    timestamp/body/signature in constant time (no exception on garbage).
+ */
+import { createHmac } from 'crypto';
+import { signPayload, verifySignature } from '../../webhooks/signer';
+
+describe('webhooks/signer', () => {
+  const secret = 'whsec_test_super_long_secret_value';
+  const timestamp = '1716900000';
+  const body = JSON.stringify({ id: 'evt_1', type: 'invoice.issued', data: { invoiceId: 'inv_1' } });
+
+  test('signPayload is stable and matches the reference HMAC', () => {
+    const sig = signPayload(secret, timestamp, body);
+    const reference = createHmac('sha256', secret).update(`${timestamp}.${body}`).digest('hex');
+    expect(sig).toBe(reference);
+    expect(sig).toHaveLength(64);
+    // Same inputs → same output.
+    expect(signPayload(secret, timestamp, body)).toBe(sig);
+  });
+
+  test('verifySignature accepts a valid signature', () => {
+    const sig = signPayload(secret, timestamp, body);
+    expect(verifySignature(secret, timestamp, body, sig)).toBe(true);
+  });
+
+  test('verifySignature rejects when body is tampered', () => {
+    const sig = signPayload(secret, timestamp, body);
+    expect(verifySignature(secret, timestamp, body + ' ', sig)).toBe(false);
+  });
+
+  test('verifySignature rejects when timestamp is tampered', () => {
+    const sig = signPayload(secret, timestamp, body);
+    expect(verifySignature(secret, String(Number(timestamp) + 1), body, sig)).toBe(false);
+  });
+
+  test('verifySignature rejects when secret is wrong', () => {
+    const sig = signPayload(secret, timestamp, body);
+    expect(verifySignature('other_secret', timestamp, body, sig)).toBe(false);
+  });
+
+  test('verifySignature returns false (does not throw) on malformed signature', () => {
+    expect(verifySignature(secret, timestamp, body, '')).toBe(false);
+    expect(verifySignature(secret, timestamp, body, 'not-hex!!')).toBe(false);
+    // Wrong length — different byte count.
+    expect(verifySignature(secret, timestamp, body, 'ab')).toBe(false);
+  });
+});

--- a/apps/isaak/app/lib/invoice-service.ts
+++ b/apps/isaak/app/lib/invoice-service.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'crypto';
 import { prisma } from './prisma';
+import { enqueueWebhookDelivery } from './webhooks';
 
 export type CreateInvoiceInput = {
   tenantId: string;
@@ -176,6 +177,38 @@ export async function issueIsaakInvoice(invoiceId: string, tenantId: string): Pr
       verifactuLastError: aeatError?.slice(0, 1000) ?? null,
     } as never,
   });
+
+  // Outbound webhooks — best effort. The invoice is already issued; webhook
+  // failures must NOT propagate to the caller. We only fire when AEAT
+  // accepted the registration (not when status is 'rejected').
+  if (verifactuStatus !== 'rejected') {
+    try {
+      await enqueueWebhookDelivery({
+        tenantId,
+        eventType: 'invoice.issued',
+        data: {
+          invoiceId: invoice.id,
+          number: invoice.number,
+          amount: amountGross,
+          amountNet,
+          amountTax,
+          currency: 'EUR',
+          customerName: invoice.customerName,
+          customerNif: invoice.customerNif,
+          issueDate: invoice.issueDate.toISOString().slice(0, 10),
+          verifactuHash,
+          verifactuCsv,
+          verifactuStatus,
+        },
+      });
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        '[invoice-service] enqueueWebhookDelivery(invoice.issued) failed',
+        err instanceof Error ? err.message : err
+      );
+    }
+  }
 
   return { ok: true, verifactuStatus, verifactuHash, verifactuCsv };
 }

--- a/apps/isaak/app/lib/webhooks/dispatch.ts
+++ b/apps/isaak/app/lib/webhooks/dispatch.ts
@@ -1,0 +1,188 @@
+/**
+ * dispatchPendingDeliveries — drain the outbound webhook queue.
+ *
+ * Reads up to `batchSize` rows from isaak_webhook_deliveries in
+ * status='pending' with nextAttemptAt <= now (or null), signs the payload
+ * with HMAC-SHA256, POSTs to the registered endpoint with a 5 s timeout,
+ * and updates the row according to the response:
+ *
+ *   2xx         → delivered (deliveredAt = now)
+ *   non-2xx /
+ *   network err → pending + nextAttemptAt = now + backoff(attempts)
+ *                 unless attempts ≥ MAX_ATTEMPTS, then → dead.
+ *
+ * Backoff schedule (seconds): 60, 300, 1800, 7200, 43200, 86400
+ * (1 m, 5 m, 30 m, 2 h, 12 h, 24 h).
+ *
+ * The cron at /api/cron/webhooks-dispatch invokes this every minute.
+ */
+import { prisma } from '@/app/lib/prisma';
+import { signPayload } from './signer';
+
+export const MAX_ATTEMPTS = 6;
+export const FETCH_TIMEOUT_MS = 5000;
+
+/** Seconds to wait before the next retry, indexed by *new* attempt number (1..6). */
+const BACKOFF_SECONDS = [60, 300, 1800, 7200, 43_200, 86_400];
+
+export function backoffSeconds(newAttemptNumber: number): number {
+  // newAttemptNumber=1 → 60s, ..., =6 → 86_400s. Clamp out-of-range.
+  if (newAttemptNumber < 1) return BACKOFF_SECONDS[0];
+  if (newAttemptNumber > BACKOFF_SECONDS.length) {
+    return BACKOFF_SECONDS[BACKOFF_SECONDS.length - 1];
+  }
+  return BACKOFF_SECONDS[newAttemptNumber - 1];
+}
+
+export type DispatchOptions = { batchSize?: number };
+
+export type DispatchSummary = {
+  processed: number;
+  delivered: number;
+  failed: number;
+  dead: number;
+};
+
+type DeliveryRow = {
+  id: string;
+  endpointId: string;
+  eventId: string;
+  payload: unknown;
+  attempts: number;
+  endpoint: { url: string; secret: string; active: boolean } | null;
+};
+
+export async function dispatchPendingDeliveries(
+  options: DispatchOptions = {}
+): Promise<DispatchSummary> {
+  const batchSize = options.batchSize ?? 50;
+  const now = new Date();
+
+  const rows = (await prisma.isaakWebhookDelivery.findMany({
+    where: {
+      status: 'pending',
+      OR: [{ nextAttemptAt: null }, { nextAttemptAt: { lte: now } }],
+    },
+    orderBy: { createdAt: 'asc' },
+    take: batchSize,
+    include: {
+      endpoint: { select: { url: true, secret: true, active: true } },
+    },
+  })) as unknown as DeliveryRow[];
+
+  const summary: DispatchSummary = {
+    processed: rows.length,
+    delivered: 0,
+    failed: 0,
+    dead: 0,
+  };
+
+  for (const row of rows) {
+    // Endpoint was deleted or deactivated after the delivery was queued.
+    // Mark as dead so we don't keep retrying.
+    if (!row.endpoint || row.endpoint.active === false) {
+      await prisma.isaakWebhookDelivery.update({
+        where: { id: row.id },
+        data: {
+          status: 'dead',
+          lastError: !row.endpoint
+            ? 'endpoint_deleted'
+            : 'endpoint_inactive',
+          nextAttemptAt: null,
+        },
+      });
+      summary.dead++;
+      continue;
+    }
+
+    const body = JSON.stringify(row.payload);
+    const timestamp = Math.floor(Date.now() / 1000).toString();
+    const signature = signPayload(row.endpoint.secret, timestamp, body);
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+    let statusCode: number | null = null;
+    let responseBody: string | null = null;
+    let networkError: string | null = null;
+
+    try {
+      const res = await fetch(row.endpoint.url, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'user-agent': 'Isaak-Webhooks/1.0',
+          'x-isaak-event-id': row.eventId,
+          'x-isaak-timestamp': timestamp,
+          'x-isaak-signature': signature,
+        },
+        body,
+        signal: controller.signal,
+        cache: 'no-store',
+      });
+      statusCode = res.status;
+      // Cap the response body we persist to 1024 chars (DB column limit).
+      const text = await res.text().catch(() => '');
+      responseBody = text.slice(0, 1024) || null;
+    } catch (err: unknown) {
+      networkError = err instanceof Error ? err.message : String(err);
+    } finally {
+      clearTimeout(timer);
+    }
+
+    const succeeded = statusCode !== null && statusCode >= 200 && statusCode < 300;
+
+    if (succeeded) {
+      await prisma.isaakWebhookDelivery.update({
+        where: { id: row.id },
+        data: {
+          status: 'delivered',
+          attempts: row.attempts + 1,
+          deliveredAt: new Date(),
+          lastStatusCode: statusCode,
+          lastResponseBody: responseBody,
+          lastError: null,
+          nextAttemptAt: null,
+        },
+      });
+      summary.delivered++;
+      continue;
+    }
+
+    const newAttempts = row.attempts + 1;
+    const lastError = (networkError ?? `http_${statusCode ?? 'unknown'}`).slice(0, 1000);
+
+    if (newAttempts >= MAX_ATTEMPTS) {
+      await prisma.isaakWebhookDelivery.update({
+        where: { id: row.id },
+        data: {
+          status: 'dead',
+          attempts: newAttempts,
+          lastError,
+          lastStatusCode: statusCode,
+          lastResponseBody: responseBody,
+          nextAttemptAt: null,
+        },
+      });
+      summary.dead++;
+      continue;
+    }
+
+    const nextAttemptAt = new Date(Date.now() + backoffSeconds(newAttempts) * 1000);
+
+    await prisma.isaakWebhookDelivery.update({
+      where: { id: row.id },
+      data: {
+        status: 'pending',
+        attempts: newAttempts,
+        lastError,
+        lastStatusCode: statusCode,
+        lastResponseBody: responseBody,
+        nextAttemptAt,
+      },
+    });
+    summary.failed++;
+  }
+
+  return summary;
+}

--- a/apps/isaak/app/lib/webhooks/dispatch.ts
+++ b/apps/isaak/app/lib/webhooks/dispatch.ts
@@ -22,6 +22,14 @@ import { signPayload } from './signer';
 export const MAX_ATTEMPTS = 6;
 export const FETCH_TIMEOUT_MS = 5000;
 
+/**
+ * Lease length for an in-flight claim. If a dispatcher crashes between
+ * claiming a row and writing the final result, the row stays in 'pending'
+ * but with nextAttemptAt = now + LEASE_MS. Once the lease expires another
+ * dispatcher will retry it. Must be > FETCH_TIMEOUT_MS by a safe margin.
+ */
+export const DISPATCHER_LEASE_MS = 120_000;
+
 /** Seconds to wait before the next retry, indexed by *new* attempt number (1..6). */
 const BACKOFF_SECONDS = [60, 300, 1800, 7200, 43_200, 86_400];
 
@@ -78,22 +86,38 @@ export async function dispatchPendingDeliveries(
   };
 
   for (const row of rows) {
-    // Endpoint was deleted or deactivated after the delivery was queued.
-    // Mark as dead so we don't keep retrying.
+    // Endpoint was deleted (FK SET NULL) or deactivated after the delivery
+    // was queued. Mark as dead so we don't keep retrying. We still claim
+    // atomically so two concurrent dispatchers don't double-count this row.
     if (!row.endpoint || row.endpoint.active === false) {
-      await prisma.isaakWebhookDelivery.update({
-        where: { id: row.id },
+      const terminalClaim = await prisma.isaakWebhookDelivery.updateMany({
+        where: { id: row.id, status: 'pending', attempts: row.attempts },
         data: {
           status: 'dead',
-          lastError: !row.endpoint
-            ? 'endpoint_deleted'
-            : 'endpoint_inactive',
+          lastError: !row.endpoint ? 'endpoint_deleted' : 'endpoint_inactive',
           nextAttemptAt: null,
         },
       });
-      summary.dead++;
+      if (terminalClaim.count > 0) summary.dead++;
       continue;
     }
+
+    // ATOMIC CLAIM (CAS): increment `attempts` only if the row is still
+    // pending with the attempts value we saw. If another dispatcher already
+    // bumped it, count is 0 and we skip — they own this row.
+    //
+    // The lease (nextAttemptAt = now + DISPATCHER_LEASE_MS) protects against
+    // dispatcher crashes mid-flight: after the lease expires the row becomes
+    // visible to the next dispatcher again, even if we never wrote a result.
+    const claimedAttempts = row.attempts + 1;
+    const claim = await prisma.isaakWebhookDelivery.updateMany({
+      where: { id: row.id, status: 'pending', attempts: row.attempts },
+      data: {
+        attempts: claimedAttempts,
+        nextAttemptAt: new Date(Date.now() + DISPATCHER_LEASE_MS),
+      },
+    });
+    if (claim.count === 0) continue;
 
     const body = JSON.stringify(row.payload);
     const timestamp = Math.floor(Date.now() / 1000).toString();
@@ -132,12 +156,13 @@ export async function dispatchPendingDeliveries(
 
     const succeeded = statusCode !== null && statusCode >= 200 && statusCode < 300;
 
+    // attempts has already been incremented to claimedAttempts in the CAS
+    // claim above — do not increment it again in any branch below.
     if (succeeded) {
       await prisma.isaakWebhookDelivery.update({
         where: { id: row.id },
         data: {
           status: 'delivered',
-          attempts: row.attempts + 1,
           deliveredAt: new Date(),
           lastStatusCode: statusCode,
           lastResponseBody: responseBody,
@@ -149,15 +174,13 @@ export async function dispatchPendingDeliveries(
       continue;
     }
 
-    const newAttempts = row.attempts + 1;
     const lastError = (networkError ?? `http_${statusCode ?? 'unknown'}`).slice(0, 1000);
 
-    if (newAttempts >= MAX_ATTEMPTS) {
+    if (claimedAttempts >= MAX_ATTEMPTS) {
       await prisma.isaakWebhookDelivery.update({
         where: { id: row.id },
         data: {
           status: 'dead',
-          attempts: newAttempts,
           lastError,
           lastStatusCode: statusCode,
           lastResponseBody: responseBody,
@@ -168,13 +191,12 @@ export async function dispatchPendingDeliveries(
       continue;
     }
 
-    const nextAttemptAt = new Date(Date.now() + backoffSeconds(newAttempts) * 1000);
+    const nextAttemptAt = new Date(Date.now() + backoffSeconds(claimedAttempts) * 1000);
 
     await prisma.isaakWebhookDelivery.update({
       where: { id: row.id },
       data: {
         status: 'pending',
-        attempts: newAttempts,
         lastError,
         lastStatusCode: statusCode,
         lastResponseBody: responseBody,

--- a/apps/isaak/app/lib/webhooks/enqueue.ts
+++ b/apps/isaak/app/lib/webhooks/enqueue.ts
@@ -1,0 +1,82 @@
+/**
+ * enqueueWebhookDelivery — schedule a webhook for every active endpoint of
+ * a tenant that subscribes to the given event type.
+ *
+ * Best-effort: callers (the invoice issue flow, etc.) MUST NOT propagate
+ * errors from this function. If the DB is down or no endpoint matches we
+ * simply skip — the business event has already happened.
+ *
+ * One IsaakWebhookDelivery row is created per matching endpoint, in
+ * status='pending', with the payload pre-built so the cron only has to
+ * sign + POST.
+ */
+import { randomBytes } from 'crypto';
+import { prisma } from '@/app/lib/prisma';
+
+export type EnqueueInput = {
+  tenantId: string;
+  eventType: string;
+  /** Domain payload — will be wrapped in the `data` field of the envelope. */
+  data: Record<string, unknown>;
+};
+
+export type EnqueueResult = {
+  eventId: string;
+  enqueued: number;
+};
+
+/** Generate a stable event id surfaced to the client as `payload.id`. */
+export function generateEventId(): string {
+  return `evt_${Date.now()}_${randomBytes(4).toString('hex')}`;
+}
+
+/** Build the JSON envelope sent over the wire to the customer endpoint. */
+export function buildEventPayload(eventId: string, eventType: string, data: Record<string, unknown>) {
+  return {
+    id: eventId,
+    type: eventType,
+    created_at: new Date().toISOString(),
+    data,
+  };
+}
+
+export async function enqueueWebhookDelivery(input: EnqueueInput): Promise<EnqueueResult> {
+  const eventId = generateEventId();
+
+  const endpoints = await prisma.isaakWebhookEndpoint.findMany({
+    where: {
+      tenantId: input.tenantId,
+      active: true,
+      events: { has: input.eventType },
+    },
+    select: { id: true },
+  });
+
+  if (endpoints.length === 0) {
+    return { eventId, enqueued: 0 };
+  }
+
+  const payload = buildEventPayload(eventId, input.eventType, input.data);
+  const now = new Date();
+
+  // createMany doesn't support Json typing in some Prisma builds; we batch
+  // with Promise.all of single creates so each row gets a fresh defaulted id.
+  await Promise.all(
+    endpoints.map((ep) =>
+      prisma.isaakWebhookDelivery.create({
+        data: {
+          tenantId: input.tenantId,
+          endpointId: ep.id,
+          eventType: input.eventType,
+          eventId,
+          payload: payload as never,
+          status: 'pending',
+          attempts: 0,
+          nextAttemptAt: now,
+        },
+      })
+    )
+  );
+
+  return { eventId, enqueued: endpoints.length };
+}

--- a/apps/isaak/app/lib/webhooks/index.ts
+++ b/apps/isaak/app/lib/webhooks/index.ts
@@ -1,0 +1,23 @@
+/**
+ * Public surface for the outbound webhooks subsystem.
+ *
+ *   enqueueWebhookDelivery — call from business flows (invoice issued, etc.)
+ *   dispatchPendingDeliveries — called by /api/cron/webhooks-dispatch
+ *   signPayload / verifySignature — HMAC primitives (also used in tests)
+ */
+export { signPayload, verifySignature } from './signer';
+export {
+  enqueueWebhookDelivery,
+  generateEventId,
+  buildEventPayload,
+  type EnqueueInput,
+  type EnqueueResult,
+} from './enqueue';
+export {
+  dispatchPendingDeliveries,
+  backoffSeconds,
+  MAX_ATTEMPTS,
+  FETCH_TIMEOUT_MS,
+  type DispatchOptions,
+  type DispatchSummary,
+} from './dispatch';

--- a/apps/isaak/app/lib/webhooks/signer.ts
+++ b/apps/isaak/app/lib/webhooks/signer.ts
@@ -1,0 +1,53 @@
+/**
+ * HMAC-SHA256 signer for outbound Isaak webhooks.
+ *
+ * The signed string is `<timestamp>.<body>` (exactly that — dot separator,
+ * unix seconds, then the raw JSON body). The signature is the hex digest.
+ *
+ * Customers verify by recomputing `HMAC_SHA256(secret, "<timestamp>.<body>")`
+ * with the secret they got at endpoint creation and comparing in
+ * constant-time against the `x-isaak-signature` header. This format is
+ * documented at /developers/guides/webhooks-hmac.
+ */
+import { createHmac, timingSafeEqual } from 'crypto';
+
+/**
+ * Compute the signature for a webhook payload.
+ *
+ * @param secret    The endpoint's shared secret (plain text — never logged).
+ * @param timestamp Unix timestamp in seconds, as a string. We pass it as a
+ *                  string so the caller controls truncation/format and the
+ *                  exact value sent on the `x-isaak-timestamp` header is the
+ *                  same one used for signing.
+ * @param body      Raw JSON body that will be sent on the wire. Must be the
+ *                  exact byte sequence the customer will see (no extra
+ *                  whitespace, no re-stringification).
+ */
+export function signPayload(secret: string, timestamp: string, body: string): string {
+  return createHmac('sha256', secret).update(`${timestamp}.${body}`).digest('hex');
+}
+
+/**
+ * Constant-time signature verification. Returns `false` when the signature
+ * format is invalid (wrong length, non-hex chars) instead of throwing —
+ * webhook receivers must never crash on malformed input.
+ */
+export function verifySignature(
+  secret: string,
+  timestamp: string,
+  body: string,
+  signature: string
+): boolean {
+  if (typeof signature !== 'string' || signature.length === 0) return false;
+
+  const expected = signPayload(secret, timestamp, body);
+  if (expected.length !== signature.length) return false;
+
+  try {
+    return timingSafeEqual(Buffer.from(expected, 'hex'), Buffer.from(signature, 'hex'));
+  } catch {
+    // Buffer.from(..., 'hex') silently drops invalid chars, which would make
+    // the lengths mismatch and throw inside timingSafeEqual. Treat as "no".
+    return false;
+  }
+}

--- a/apps/isaak/vercel.json
+++ b/apps/isaak/vercel.json
@@ -52,6 +52,10 @@
     {
       "path": "/api/cron/app-health",
       "schedule": "*/30 * * * *"
+    },
+    {
+      "path": "/api/cron/webhooks-dispatch",
+      "schedule": "* * * * *"
     }
   ]
 }

--- a/packages/db/prisma/migrations/20260609000000_isaak_webhook_deliveries/migration.sql
+++ b/packages/db/prisma/migrations/20260609000000_isaak_webhook_deliveries/migration.sql
@@ -1,0 +1,45 @@
+-- D1 — outbound webhook delivery (HMAC-signed).
+--
+-- One row per (event × endpoint). The /api/cron/webhooks-dispatch cron
+-- polls rows in status='pending' with nextAttemptAt <= now, signs the
+-- payload, POSTs to the customer endpoint, and updates the row based on
+-- the response. Retries follow exponential backoff (1m, 5m, 30m, 2h,
+-- 12h, 24h); after 6 attempts the row moves to status='dead'.
+--
+-- eventId is the stable identifier surfaced to the client in payload.id
+-- so they can deduplicate retries on their side (format: evt_<ts>_<rand8>).
+
+CREATE TABLE "isaak_webhook_deliveries" (
+    "id" TEXT NOT NULL,
+    "tenant_id" UUID NOT NULL,
+    "endpoint_id" TEXT NOT NULL,
+    "event_type" TEXT NOT NULL,
+    "event_id" TEXT NOT NULL,
+    "payload" JSONB NOT NULL,
+    "status" TEXT NOT NULL,
+    "attempts" INTEGER NOT NULL DEFAULT 0,
+    "next_attempt_at" TIMESTAMPTZ,
+    "last_error" TEXT,
+    "last_status_code" INTEGER,
+    "last_response_body" VARCHAR(1024),
+    "delivered_at" TIMESTAMPTZ,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "isaak_webhook_deliveries_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "isaak_webhook_deliveries_status_next_attempt_at_idx"
+    ON "isaak_webhook_deliveries"("status", "next_attempt_at");
+
+CREATE INDEX "isaak_webhook_deliveries_tenant_id_event_type_idx"
+    ON "isaak_webhook_deliveries"("tenant_id", "event_type");
+
+ALTER TABLE "isaak_webhook_deliveries"
+    ADD CONSTRAINT "isaak_webhook_deliveries_tenant_id_fkey"
+    FOREIGN KEY ("tenant_id") REFERENCES "tenants"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "isaak_webhook_deliveries"
+    ADD CONSTRAINT "isaak_webhook_deliveries_endpoint_id_fkey"
+    FOREIGN KEY ("endpoint_id") REFERENCES "isaak_webhook_endpoints"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/migrations/20260609000000_isaak_webhook_deliveries/migration.sql
+++ b/packages/db/prisma/migrations/20260609000000_isaak_webhook_deliveries/migration.sql
@@ -12,7 +12,10 @@
 CREATE TABLE "isaak_webhook_deliveries" (
     "id" TEXT NOT NULL,
     "tenant_id" UUID NOT NULL,
-    "endpoint_id" TEXT NOT NULL,
+    -- Nullable + SET NULL: deleting an endpoint preserves the delivery rows
+    -- for audit/history. The dispatcher detects endpoint=NULL and marks the
+    -- row as dead with lastError='endpoint_deleted'.
+    "endpoint_id" TEXT,
     "event_type" TEXT NOT NULL,
     "event_id" TEXT NOT NULL,
     "payload" JSONB NOT NULL,
@@ -42,4 +45,4 @@ ALTER TABLE "isaak_webhook_deliveries"
 ALTER TABLE "isaak_webhook_deliveries"
     ADD CONSTRAINT "isaak_webhook_deliveries_endpoint_id_fkey"
     FOREIGN KEY ("endpoint_id") REFERENCES "isaak_webhook_endpoints"("id")
-    ON DELETE CASCADE ON UPDATE CASCADE;
+    ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -599,6 +599,7 @@ model Tenant {
   holdedMcpPersonalAccessTokens HoldedMcpPersonalAccessToken[]
   holdedMcpPatAuditLogs         HoldedMcpPatAuditLog[]
   isaakWebhookEndpoints         IsaakWebhookEndpoint[]
+  isaakWebhookDeliveries        IsaakWebhookDelivery[]
   isaakProposedActions          IsaakProposedAction[]
   gcMandates                    GcMandate[]
   gcPayments                    GcPayment[]
@@ -2468,10 +2469,42 @@ model IsaakWebhookEndpoint {
   active    Boolean  @default(true)
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
 
-  tenant Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  tenant     Tenant                 @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  deliveries IsaakWebhookDelivery[]
 
   @@index([tenantId])
   @@map("isaak_webhook_endpoints")
+}
+
+/// Outbound webhook delivery attempt to a customer-registered endpoint.
+/// One row per (event × endpoint). The dispatcher cron processes rows in
+/// status='pending' with nextAttemptAt <= now, retries on failure with
+/// exponential backoff, and gives up after 6 attempts (status='dead').
+model IsaakWebhookDelivery {
+  id               String    @id @default(cuid())
+  tenantId         String    @map("tenant_id") @db.Uuid
+  endpointId       String    @map("endpoint_id")
+  /// Event type, e.g. "invoice.issued"
+  eventType        String    @map("event_type")
+  /// Stable event identifier surfaced to the client in payload.id. Format: evt_<ts>_<rand8>
+  eventId          String    @map("event_id")
+  payload          Json
+  /// "pending" | "delivered" | "failed" | "dead"
+  status           String
+  attempts         Int       @default(0)
+  nextAttemptAt    DateTime? @map("next_attempt_at") @db.Timestamptz
+  lastError        String?   @map("last_error")
+  lastStatusCode   Int?      @map("last_status_code")
+  lastResponseBody String?   @map("last_response_body") @db.VarChar(1024)
+  deliveredAt      DateTime? @map("delivered_at") @db.Timestamptz
+  createdAt        DateTime  @default(now()) @map("created_at") @db.Timestamptz
+
+  tenant   Tenant               @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  endpoint IsaakWebhookEndpoint @relation(fields: [endpointId], references: [id], onDelete: Cascade)
+
+  @@index([status, nextAttemptAt])
+  @@index([tenantId, eventType])
+  @@map("isaak_webhook_deliveries")
 }
 
 /// Personal Access Token for the Holded MCP connector.

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -2483,7 +2483,10 @@ model IsaakWebhookEndpoint {
 model IsaakWebhookDelivery {
   id               String    @id @default(cuid())
   tenantId         String    @map("tenant_id") @db.Uuid
-  endpointId       String    @map("endpoint_id")
+  /// Nullable + SetNull: if the customer deletes the endpoint, we keep the
+  /// delivery rows for audit/history. The dispatcher will then mark them
+  /// dead with lastError='endpoint_deleted'.
+  endpointId       String?   @map("endpoint_id")
   /// Event type, e.g. "invoice.issued"
   eventType        String    @map("event_type")
   /// Stable event identifier surfaced to the client in payload.id. Format: evt_<ts>_<rand8>
@@ -2499,8 +2502,8 @@ model IsaakWebhookDelivery {
   deliveredAt      DateTime? @map("delivered_at") @db.Timestamptz
   createdAt        DateTime  @default(now()) @map("created_at") @db.Timestamptz
 
-  tenant   Tenant               @relation(fields: [tenantId], references: [id], onDelete: Cascade)
-  endpoint IsaakWebhookEndpoint @relation(fields: [endpointId], references: [id], onDelete: Cascade)
+  tenant   Tenant                @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  endpoint IsaakWebhookEndpoint? @relation(fields: [endpointId], references: [id], onDelete: SetNull)
 
   @@index([status, nextAttemptAt])
   @@index([tenantId, eventType])


### PR DESCRIPTION
## Resumen

Implementa el **lado emisor** de los webhooks del portal Developers. Las URLs documentadas en `/developers/webhooks` ya reciben POSTs reales firmados con HMAC cuando ocurren eventos de negocio (empezando por `invoice.issued`).

## Cambios

### Schema (`packages/db/prisma`)
- Nuevo modelo `IsaakWebhookDelivery` (tabla `isaak_webhook_deliveries`): una fila por (evento × endpoint).
  - `status`: `pending` | `delivered` | `failed` | `dead`
  - `attempts`, `nextAttemptAt`, `lastError`, `lastStatusCode`, `lastResponseBody`, `deliveredAt`
  - Índices `(status, next_attempt_at)` y `(tenant_id, event_type)`
- Migración `20260609000000_isaak_webhook_deliveries` con SQL listo para `prisma migrate deploy`

### Librería (`apps/isaak/app/lib/webhooks/`)
- **`signer.ts`** — `signPayload(secret, timestamp, body)` HMAC-SHA256 hex sobre `<timestamp>.<body>` (formato documentado en `/developers/guides/webhooks-hmac`). `verifySignature` con compare en tiempo constante y safe contra entradas malformadas.
- **`enqueue.ts`** — `enqueueWebhookDelivery({ tenantId, eventType, data })`: busca endpoints activos suscritos al evento y crea una `IsaakWebhookDelivery` `pending` por cada uno. `eventId` formato `evt_<timestamp>_<rand8>` compartido entre todos los endpoints del mismo evento (para dedupe en cliente).
- **`dispatch.ts`** — `dispatchPendingDeliveries({ batchSize=50 })`: lee `pending` con `nextAttemptAt <= now` (o null), firma, hace POST con headers `x-isaak-signature` / `x-isaak-timestamp` / `x-isaak-event-id` y timeout 5 s. Maneja respuestas:
  - **2xx** → `delivered` (`deliveredAt = now`)
  - **non-2xx / network err** → incrementa `attempts`, guarda `lastError`/`lastStatusCode`. Si `attempts >= 6` → `dead`. Si no → vuelve a `pending` con backoff.
  - **Backoff exponencial**: 1 m, 5 m, 30 m, 2 h, 12 h, 24 h.
  - Endpoints borrados o inactivos → `dead` sin disparar fetch.

### Cron endpoint (`apps/isaak/app/api/cron/webhooks-dispatch/route.ts`)
- `runtime = 'nodejs'`, `maxDuration = 60`.
- `GET` con auth `Bearer CRON_SECRET` (compare en tiempo constante). Si `CRON_SECRET` no está configurado → **401** (endpoint cerrado).
- Llama `dispatchPendingDeliveries({ batchSize: 50 })` y devuelve `{ ok, processed, delivered, failed, dead }`.
- Añadido a `vercel.json` con schedule `* * * * *` (cada minuto, Vercel Pro).

### Hook en flujo de emisión
- `apps/isaak/app/lib/invoice-service.ts`: tras un registro AEAT exitoso (`verifactuStatus !== 'rejected'`) llama `enqueueWebhookDelivery({ tenantId, eventType: 'invoice.issued', data: { invoiceId, number, amount, ...verifactuHash } })`.
- Best-effort: si la enqueue falla, **NO** rompe la respuesta de la API (la factura está emitida); sólo log warn.

## Tests

21 tests, todos pasan (`pnpm test webhooks`):

- **signer** (6): firma determinista, verifica reference HMAC, rechaza body/timestamp/secret/firma tampered, no lanza con input basura.
- **enqueue** (5): crea N filas para N endpoints suscritos, `eventId` compartido, WHERE filtra por `active: true` + `events: { has }`, sin endpoints → 0 filas.
- **dispatch** (8): 2xx → `delivered`, 5xx → `pending` con `nextAttemptAt` ~60 s en el futuro, error de red → captura mensaje, `attempts = MAX_ATTEMPTS → dead`, firma verifica con el secret del endpoint, endpoint borrado/inactivo → `dead` sin fetch, `backoffSeconds()` coincide con la tabla documentada.

## Verificación

- [x] `npx tsc --noEmit` en `apps/isaak` — exit 0
- [x] `pnpm test webhooks` — 21/21 passing
- [x] Migración SQL existe en `packages/db/prisma/migrations/`
- [x] `prisma generate` regenera el cliente sin errores

## Qué queda fuera (futuras iteraciones)

- **Panel admin** para inspeccionar el queue (`pending`/`dead`), reintentar manualmente, ver latías/errores agregados por tenant.
- **UI cliente** para registrar/rotar URLs y secrets (hoy sólo via API/seed).
- **Más tipos de evento**: `invoice.refunded`, `customer.created`, `aeat.submission.accepted`, etc. La infra acepta cualquier `eventType` — sólo hay que llamar `enqueueWebhookDelivery` desde el flow correspondiente.
- **Métricas**: contador Prometheus de deliveries por status, latías P95, % dead. Hoy sólo log implícito.
- **Compaction**: borrar filas `delivered` > 90 días para mantener la tabla pequeña.

## Test plan

- [ ] En staging, registrar un `IsaakWebhookEndpoint` apuntando a webhook.site y emitir una factura.
- [ ] Verificar que llega el POST con headers correctos y firma válida.
- [ ] Apuntar a una URL que devuelva 500 y comprobar los reintentos (60 s, 5 m, …) hasta `dead`.
- [ ] Confirmar que `/api/cron/webhooks-dispatch` sin Bearer devuelve 401 y con Bearer correcto procesa el batch.