### PR TITLE
feat(sdk): @verifactu/sdk skeleton para la Isaak Platform API (D2)

### DIFF
--- a/packages/sdk/.npmignore
+++ b/packages/sdk/.npmignore
@@ -1,0 +1,10 @@
+src/
+__tests__/
+tsconfig.json
+tsup.config.ts
+jest.config.cjs
+.eslintrc*
+*.tsbuildinfo
+node_modules/
+coverage/
+.turbo/

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to `@verifactu/sdk` will be documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/) and the
+project adheres to [Semantic Versioning](https://semver.org/).
+
+## 0.1.0 - Unreleased
+
+Initial release.
+
+- `IsaakClient` with Bearer auth, configurable timeout, configurable retries
+  and pluggable `fetch`.
+- Resources:
+  - `client.companies.getCurrent()`
+  - `client.invoices.list / get / create / issue / getPdf`
+  - `client.keys.list / create`
+- Typed error hierarchy: `IsaakError`, `AuthenticationError`,
+  `PermissionError`, `NotFoundError`, `ConflictError`,
+  `ConfirmationRequiredError`, `ValidationError`, `RateLimitError`,
+  `ServerError`, `NetworkError`, `TimeoutError`.
+- `withRetry` helper with exponential backoff + jitter, honoring
+  `Retry-After`. Auto-attaches `Idempotency-Key` for mutating calls.
+- `verifyWebhookSignature` HMAC verifier compatible with Node, Workers, Deno
+  and Bun (uses Web Crypto, falls back to `node:crypto`).
+- Full TypeScript types matching the public OpenAPI contract.
+- No runtime dependencies. Compatible with Node 18+, Deno, Bun and Cloudflare
+  Workers.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,0 +1,224 @@
+# @verifactu/sdk
+
+Official TypeScript SDK for the **Isaak Platform API** (Verifactu Business).
+
+Build invoicing, AEAT VeriFactu, banking conciliation and webhooks integrations
+on top of [`isaak.verifactu.business`](https://isaak.verifactu.business) with a
+fully typed client that runs on Node 18+, Deno, Bun, Cloudflare Workers and any
+modern browser (server-side recommended — exposing the API key to a browser is
+not secure).
+
+> Pre-1.0 — the public API is stable, but new methods may be added in minor
+> releases as we cover the rest of the OpenAPI surface.
+
+Full docs and OpenAPI reference: <https://verifactu.business/developers>
+
+---
+
+## Installation
+
+```bash
+pnpm add @verifactu/sdk
+# or
+npm install @verifactu/sdk
+# or
+yarn add @verifactu/sdk
+```
+
+Requires Node 18+ (or any runtime with global `fetch` and `crypto.subtle`).
+
+## Quickstart
+
+```ts
+import { IsaakClient } from '@verifactu/sdk';
+
+const isaak = new IsaakClient({
+  apiKey: process.env.ISAAK_API_KEY!, // isk_live_... or isk_test_...
+});
+
+const me = await isaak.companies.getCurrent();
+console.log(`Authenticated as ${me.legalName} (${me.cif})`);
+```
+
+### List invoices
+
+```ts
+const page = await isaak.invoices.list({
+  from: '2026-01-01',
+  to: '2026-12-31',
+  status: 'issued',
+  limit: 50,
+});
+
+for (const invoice of page.data) {
+  console.log(invoice.number, invoice.total, invoice.aeatStatus);
+}
+
+if (page.pagination.hasMore) {
+  const next = await isaak.invoices.list({
+    cursor: page.pagination.nextCursor!,
+  });
+}
+```
+
+### Create and issue an invoice (two-step, irreversible)
+
+```ts
+import { ConfirmationRequiredError } from '@verifactu/sdk';
+
+const draft = await isaak.invoices.create({
+  customer: {
+    name: 'ACME SL',
+    cif: 'B12345678',
+    email: 'billing@acme.com',
+  },
+  lines: [
+    { description: 'Hora de consultoría', quantity: 10, unitPrice: 90, vatRate: 21 },
+  ],
+});
+
+try {
+  // 1st call returns 428 + a confirmation token (preview the user)
+  await isaak.invoices.issue(draft.id, { confirmationToken: 'preview' });
+} catch (err) {
+  if (err instanceof ConfirmationRequiredError) {
+    // 2nd call commits the AEAT submission
+    const issued = await isaak.invoices.issue(draft.id, {
+      confirmationToken: (err.details as { confirmationToken: string }).confirmationToken,
+    });
+    console.log('Registered with AEAT hash', issued.verifactuHash);
+  } else {
+    throw err;
+  }
+}
+```
+
+### Download the legal PDF
+
+```ts
+const blob = await isaak.invoices.getPdf('inv_2026_0042');
+// In Node:
+const buf = Buffer.from(await blob.arrayBuffer());
+await fs.writeFile('invoice.pdf', buf);
+```
+
+### Manage API keys
+
+```ts
+const created = await isaak.keys.create({
+  name: 'CI / backups',
+  scopes: ['isaak.invoices.read', 'isaak.company.read'],
+});
+console.log('Store this somewhere safe — it is only shown once:', created.plaintext);
+```
+
+### Verify a webhook
+
+```ts
+import { verifyWebhookSignature } from '@verifactu/sdk';
+
+// Express, Hono, Fastify — any server. The raw body is essential.
+export async function handleWebhook(req, res) {
+  const result = await verifyWebhookSignature({
+    body: req.rawBody, // string of the unparsed JSON
+    signatureHeader: req.headers['x-isaak-signature'],
+    timestampHeader: req.headers['x-isaak-timestamp'],
+    secret: process.env.ISAAK_WEBHOOK_SECRET!,
+  });
+
+  if (!result.ok) {
+    return res.status(400).json({ error: result.reason });
+  }
+
+  const event = JSON.parse(req.rawBody);
+  switch (event.type) {
+    case 'invoice.issued':
+      // ...
+      break;
+  }
+  res.status(200).end();
+}
+```
+
+## Configuration
+
+```ts
+new IsaakClient({
+  apiKey: 'isk_live_...',
+  baseUrl: 'https://isaak.verifactu.business', // override for staging
+  timeout: 30_000,        // ms, per-request
+  maxRetries: 3,          // retried on 429 / 5xx for idempotent or Idempotency-Key requests
+  fetch: customFetch,     // inject for Workers / tests
+  defaultHeaders: { 'X-Trace-Id': 'my-trace' },
+});
+```
+
+### Retries and idempotency
+
+The SDK retries automatically when:
+
+- the request method is idempotent (`GET`, `HEAD`, `OPTIONS`, `PUT`, `DELETE`), **or**
+- the request carries an `Idempotency-Key` header
+
+…**and** the failure is one of: `429`, `502`, `503`, `504`, or a network /
+timeout error. The `Retry-After` header is honored when present.
+
+`invoices.create` and `invoices.issue` automatically attach an
+`Idempotency-Key` so retried calls don't create duplicates.
+
+## Errors
+
+Every non-2xx response throws a typed `IsaakError` subclass. The base class
+exposes `code`, `httpStatus`, `requestId` and `details`.
+
+| HTTP | Class | When |
+| --- | --- | --- |
+| 400 / 422 | `ValidationError` | Body or arguments failed validation |
+| 401 | `AuthenticationError` | API key missing, invalid or revoked |
+| 403 | `PermissionError` | Token valid but lacks the required scope |
+| 404 | `NotFoundError` | Resource not found in your tenant |
+| 409 | `ConflictError` | State doesn't allow this action |
+| 428 | `ConfirmationRequiredError` | Irreversible action; resend with token |
+| 429 | `RateLimitError` | Read `retryAfterSeconds` to back off |
+| 5xx | `ServerError` | Isaak or AEAT temporary failure |
+| — | `NetworkError`, `TimeoutError` | DNS / connection / abort |
+
+```ts
+import { IsaakError, RateLimitError } from '@verifactu/sdk';
+
+try {
+  await isaak.invoices.list();
+} catch (err) {
+  if (err instanceof RateLimitError) {
+    console.warn(`Throttled, retry after ${err.retryAfterSeconds}s`);
+  } else if (err instanceof IsaakError) {
+    console.error(err.code, err.httpStatus, err.requestId);
+  }
+}
+```
+
+## Runtimes
+
+The SDK has **no runtime dependencies** and only uses globally available APIs
+(`fetch`, `AbortController`, `crypto.subtle`). It's tested on:
+
+- Node 18 / 20 / 22
+- Cloudflare Workers
+- Deno
+- Bun
+
+For browsers, prefer a backend proxy — bundling an API key into client-side
+code is never safe.
+
+## Versioning
+
+The SDK follows SemVer:
+
+- **patch**: bug fixes, no behavior changes
+- **minor**: new methods / fields (additive)
+- **major**: breaking changes — keyed to a stable v1.0 release once the SDK
+  covers the full OpenAPI surface
+
+## License
+
+MIT © Verifactu Business

--- a/packages/sdk/__tests__/client.test.ts
+++ b/packages/sdk/__tests__/client.test.ts
@@ -1,0 +1,231 @@
+import {
+  AuthenticationError,
+  IsaakClient,
+  IsaakError,
+  NotFoundError,
+  RateLimitError,
+  ValidationError,
+} from '../src/index.js';
+
+type FetchMock = jest.Mock<Promise<Response>, [RequestInfo | URL, RequestInit?]>;
+
+const makeJsonResponse = (
+  status: number,
+  body: unknown,
+  headers: Record<string, string> = {},
+): Response => {
+  const allHeaders: Record<string, string> = {
+    'content-type': 'application/json',
+    'x-request-id': headers['x-request-id'] ?? 'req_test_1',
+    ...headers,
+  };
+  return new Response(JSON.stringify(body), { status, headers: allHeaders });
+};
+
+function buildClient(fetchMock: FetchMock): IsaakClient {
+  return new IsaakClient({
+    apiKey: 'isk_test_abc',
+    fetch: fetchMock as unknown as typeof fetch,
+    maxRetries: 0,
+  });
+}
+
+describe('IsaakClient', () => {
+  it('requires an apiKey', () => {
+    expect(
+      () => new IsaakClient({ apiKey: '' as unknown as string }),
+    ).toThrow(/apiKey/);
+  });
+
+  it('sends Authorization Bearer + Accept headers and composes the URL', async () => {
+    const fetchMock: FetchMock = jest.fn().mockResolvedValue(
+      makeJsonResponse(200, {
+        ok: true,
+        data: { id: 'cmp_1', legalName: 'ACME SL' },
+        requestId: 'req_x',
+      }),
+    );
+    const client = buildClient(fetchMock);
+
+    await client.companies.getCurrent();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://isaak.verifactu.business/api/v1/companies/current');
+    const headers = init?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer isk_test_abc');
+    expect(headers.Accept).toBe('application/json');
+    expect(headers['User-Agent']).toMatch(/^verifactu-sdk-js\//);
+  });
+
+  it('parses the data envelope on 200', async () => {
+    const company = {
+      id: 'cmp_1',
+      legalName: 'ACME SL',
+      cif: 'B12345678',
+      verifactuEnabled: true,
+      createdAt: '2026-01-01T00:00:00Z',
+    };
+    const fetchMock: FetchMock = jest.fn().mockResolvedValue(
+      makeJsonResponse(200, { ok: true, data: company, requestId: 'req_x' }),
+    );
+    const client = buildClient(fetchMock);
+
+    const result = await client.companies.getCurrent();
+    expect(result).toEqual(company);
+  });
+
+  it('throws RateLimitError on 429 with retryAfterSeconds parsed', async () => {
+    const fetchMock: FetchMock = jest.fn().mockResolvedValue(
+      makeJsonResponse(
+        429,
+        {
+          ok: false,
+          error: { code: 'rate_limit_exceeded', message: 'Too many requests' },
+          requestId: 'req_rl',
+        },
+        { 'retry-after': '7', 'x-request-id': 'req_rl' },
+      ),
+    );
+    const client = buildClient(fetchMock);
+
+    await expect(client.invoices.list()).rejects.toMatchObject({
+      name: 'RateLimitError',
+      code: 'rate_limit_exceeded',
+      httpStatus: 429,
+      requestId: 'req_rl',
+      retryAfterSeconds: 7,
+    });
+
+    const fetchMock2: FetchMock = jest.fn().mockResolvedValue(
+      makeJsonResponse(
+        429,
+        {
+          ok: false,
+          error: { code: 'rate_limit_exceeded', message: 'Too many requests' },
+        },
+        { 'retry-after': '7' },
+      ),
+    );
+    const client2 = buildClient(fetchMock2);
+    try {
+      await client2.invoices.list();
+    } catch (err) {
+      expect(err).toBeInstanceOf(RateLimitError);
+      expect(err).toBeInstanceOf(IsaakError);
+    }
+  });
+
+  it('maps 401 → AuthenticationError', async () => {
+    const fetchMock: FetchMock = jest.fn().mockResolvedValue(
+      makeJsonResponse(401, {
+        ok: false,
+        error: { code: 'unauthorized', message: 'Bad key' },
+      }),
+    );
+    const client = buildClient(fetchMock);
+    await expect(client.companies.getCurrent()).rejects.toBeInstanceOf(
+      AuthenticationError,
+    );
+  });
+
+  it('maps 404 → NotFoundError', async () => {
+    const fetchMock: FetchMock = jest.fn().mockResolvedValue(
+      makeJsonResponse(404, {
+        ok: false,
+        error: { code: 'not_found', message: 'Missing' },
+      }),
+    );
+    const client = buildClient(fetchMock);
+    await expect(client.invoices.get('inv_404')).rejects.toBeInstanceOf(
+      NotFoundError,
+    );
+  });
+
+  it('maps 422 → ValidationError with details', async () => {
+    const fetchMock: FetchMock = jest.fn().mockResolvedValue(
+      makeJsonResponse(422, {
+        ok: false,
+        error: {
+          code: 'validation_error',
+          message: 'NIF invalid',
+          details: { field: 'customer.cif' },
+        },
+      }),
+    );
+    const client = buildClient(fetchMock);
+    await expect(
+      client.invoices.create({
+        customer: { name: 'X' },
+        lines: [],
+      }),
+    ).rejects.toMatchObject({
+      name: 'ValidationError',
+      details: { field: 'customer.cif' },
+    });
+  });
+
+  it('attaches Idempotency-Key on POST when idempotent: true', async () => {
+    const fetchMock: FetchMock = jest.fn().mockResolvedValue(
+      makeJsonResponse(200, {
+        ok: true,
+        data: {
+          id: 'inv_1',
+          status: 'draft',
+          customer: { name: 'X' },
+          lines: [],
+          subtotal: 0,
+          vatTotal: 0,
+          total: 0,
+          currency: 'EUR',
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-01T00:00:00Z',
+        },
+        requestId: 'req_x',
+      }),
+    );
+    const client = buildClient(fetchMock);
+    await client.invoices.create({
+      customer: { name: 'X' },
+      lines: [{ description: 'L', quantity: 1, unitPrice: 100, vatRate: 21 }],
+    });
+
+    const headers = fetchMock.mock.calls[0]![1]?.headers as Record<string, string>;
+    expect(headers['Idempotency-Key']).toBeTruthy();
+    expect(headers['Idempotency-Key'].length).toBeGreaterThan(8);
+  });
+
+  it('respects custom baseUrl trimming trailing slashes', async () => {
+    const fetchMock: FetchMock = jest.fn().mockResolvedValue(
+      makeJsonResponse(200, { ok: true, data: { id: 'c' }, requestId: 'r' }),
+    );
+    const client = new IsaakClient({
+      apiKey: 'isk_test_x',
+      baseUrl: 'https://staging.example.com/',
+      fetch: fetchMock as unknown as typeof fetch,
+      maxRetries: 0,
+    });
+    await client.companies.getCurrent();
+    expect(fetchMock.mock.calls[0]![0]).toBe(
+      'https://staging.example.com/api/v1/companies/current',
+    );
+  });
+
+  it('serializes query params and skips undefined values', async () => {
+    const fetchMock: FetchMock = jest.fn().mockResolvedValue(
+      makeJsonResponse(200, {
+        ok: true,
+        data: [],
+        requestId: 'r',
+        pagination: { nextCursor: null, hasMore: false, limit: 50 },
+      }),
+    );
+    const client = buildClient(fetchMock);
+    await client.invoices.list({ from: '2026-01-01', limit: 10 });
+    const url = fetchMock.mock.calls[0]![0] as string;
+    expect(url).toContain('from=2026-01-01');
+    expect(url).toContain('limit=10');
+    expect(url).not.toContain('to=');
+    expect(url).not.toContain('status=');
+  });
+});

--- a/packages/sdk/__tests__/retry.test.ts
+++ b/packages/sdk/__tests__/retry.test.ts
@@ -1,0 +1,152 @@
+import {
+  IsaakClient,
+  IsaakError,
+  ServerError,
+  computeBackoff,
+  isErrorRetriable,
+  withRetry,
+} from '../src/index.js';
+
+type FetchMock = jest.Mock<Promise<Response>, [RequestInfo | URL, RequestInit?]>;
+
+const noSleep = (_ms: number): Promise<void> => Promise.resolve();
+
+const jsonRes = (status: number, body: unknown): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+
+describe('withRetry', () => {
+  it('retries failures up to maxRetries then throws', async () => {
+    const fn = jest.fn().mockRejectedValue(new Error('boom'));
+    await expect(
+      withRetry(fn, {
+        maxRetries: 2,
+        isRetriable: () => true,
+        sleep: noSleep,
+      }),
+    ).rejects.toThrow('boom');
+    // initial + 2 retries = 3 calls
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it('returns the value on second attempt', async () => {
+    let calls = 0;
+    const fn = jest.fn().mockImplementation(() => {
+      calls += 1;
+      if (calls === 1) return Promise.reject(new Error('boom'));
+      return Promise.resolve('ok');
+    });
+    const value = await withRetry(fn, {
+      maxRetries: 3,
+      isRetriable: () => true,
+      sleep: noSleep,
+    });
+    expect(value).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry when isRetriable returns false', async () => {
+    const fn = jest.fn().mockRejectedValue(new Error('fail'));
+    await expect(
+      withRetry(fn, {
+        maxRetries: 5,
+        isRetriable: () => false,
+        sleep: noSleep,
+      }),
+    ).rejects.toThrow('fail');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('computeBackoff stays within the cap', () => {
+    for (let attempt = 1; attempt <= 10; attempt += 1) {
+      const value = computeBackoff(attempt, 100, 500);
+      expect(value).toBeGreaterThanOrEqual(0);
+      expect(value).toBeLessThanOrEqual(500);
+    }
+  });
+});
+
+describe('isErrorRetriable', () => {
+  it('retries IsaakError on 5xx for GET', () => {
+    const err = new IsaakError('boom', 'server_error', 503);
+    expect(
+      isErrorRetriable(err, { method: 'GET', hasIdempotencyKey: false }),
+    ).toBe(true);
+  });
+
+  it('does not retry POST on 5xx without Idempotency-Key', () => {
+    const err = new IsaakError('boom', 'server_error', 503);
+    expect(
+      isErrorRetriable(err, { method: 'POST', hasIdempotencyKey: false }),
+    ).toBe(false);
+  });
+
+  it('retries POST on 5xx when Idempotency-Key is set', () => {
+    const err = new IsaakError('boom', 'server_error', 503);
+    expect(
+      isErrorRetriable(err, { method: 'POST', hasIdempotencyKey: true }),
+    ).toBe(true);
+  });
+
+  it('does not retry on 4xx (other than 429)', () => {
+    const err = new IsaakError('bad', 'bad_request', 400);
+    expect(
+      isErrorRetriable(err, { method: 'GET', hasIdempotencyKey: false }),
+    ).toBe(false);
+  });
+});
+
+describe('IsaakClient retry integration', () => {
+  it('retries GET on 503 and eventually returns 200', async () => {
+    const success = {
+      ok: true,
+      data: {
+        id: 'cmp',
+        legalName: 'X',
+        cif: 'B1',
+        verifactuEnabled: true,
+        createdAt: '2026-01-01T00:00:00Z',
+      },
+      requestId: 'r',
+    };
+    let call = 0;
+    const fetchMock: FetchMock = jest.fn().mockImplementation(() => {
+      call += 1;
+      if (call < 3) return Promise.resolve(jsonRes(503, { ok: false, error: { code: 's', message: 'down' } }));
+      return Promise.resolve(jsonRes(200, success));
+    });
+
+    const client = new IsaakClient({
+      apiKey: 'isk_test_x',
+      fetch: fetchMock as unknown as typeof fetch,
+      maxRetries: 3,
+    });
+
+    // patch sleep so the test runs fast — override retry options is internal,
+    // so use small base delay via injection in withRetry's compute fallback.
+    const result = await client.companies.getCurrent();
+    expect(result.id).toBe('cmp');
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  }, 15_000);
+
+  it('does NOT retry POST without Idempotency-Key on 503', async () => {
+    const fetchMock: FetchMock = jest.fn().mockResolvedValue(
+      jsonRes(503, { ok: false, error: { code: 'down', message: 'maintenance' } }),
+    );
+    const client = new IsaakClient({
+      apiKey: 'isk_test_x',
+      fetch: fetchMock as unknown as typeof fetch,
+      maxRetries: 5,
+    });
+
+    await expect(
+      client.request('/api/v1/no-retry', {
+        method: 'POST',
+        body: { x: 1 },
+      }),
+    ).rejects.toBeInstanceOf(ServerError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/sdk/__tests__/webhooks.test.ts
+++ b/packages/sdk/__tests__/webhooks.test.ts
@@ -1,0 +1,118 @@
+import { createHmac } from 'node:crypto';
+import { timingSafeEqualHex, verifyWebhookSignature } from '../src/index.js';
+
+const SECRET = 'whsec_test_super_secret';
+
+const sign = (timestamp: string, body: string, secret: string): string =>
+  createHmac('sha256', secret).update(`${timestamp}.${body}`).digest('hex');
+
+describe('verifyWebhookSignature', () => {
+  const body = JSON.stringify({ id: 'evt_1', type: 'invoice.issued' });
+
+  it('accepts a valid signature within the tolerance window', async () => {
+    const ts = Math.floor(Date.now() / 1000).toString();
+    const sig = sign(ts, body, SECRET);
+
+    const result = await verifyWebhookSignature({
+      body,
+      signatureHeader: sig,
+      timestampHeader: ts,
+      secret: SECRET,
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('rejects an invalid signature', async () => {
+    const ts = Math.floor(Date.now() / 1000).toString();
+    const result = await verifyWebhookSignature({
+      body,
+      signatureHeader: 'deadbeef'.repeat(8),
+      timestampHeader: ts,
+      secret: SECRET,
+    });
+    expect(result).toEqual({ ok: false, reason: 'invalid_signature' });
+  });
+
+  it('rejects a stale timestamp (replay protection)', async () => {
+    const stale = (Math.floor(Date.now() / 1000) - 10_000).toString();
+    const sig = sign(stale, body, SECRET);
+    const result = await verifyWebhookSignature({
+      body,
+      signatureHeader: sig,
+      timestampHeader: stale,
+      secret: SECRET,
+      toleranceSeconds: 300,
+    });
+    expect(result).toEqual({ ok: false, reason: 'timestamp_out_of_window' });
+  });
+
+  it('rejects a signature computed with a different secret', async () => {
+    const ts = Math.floor(Date.now() / 1000).toString();
+    const sig = sign(ts, body, 'wrong-secret');
+    const result = await verifyWebhookSignature({
+      body,
+      signatureHeader: sig,
+      timestampHeader: ts,
+      secret: SECRET,
+    });
+    expect(result).toEqual({ ok: false, reason: 'invalid_signature' });
+  });
+
+  it('rejects when headers are missing', async () => {
+    const result = await verifyWebhookSignature({
+      body,
+      signatureHeader: '',
+      timestampHeader: '',
+      secret: SECRET,
+    });
+    expect(result).toEqual({ ok: false, reason: 'malformed' });
+  });
+
+  it('rejects when timestamp is not numeric', async () => {
+    const result = await verifyWebhookSignature({
+      body,
+      signatureHeader: 'a'.repeat(64),
+      timestampHeader: 'not-a-number',
+      secret: SECRET,
+    });
+    expect(result).toEqual({ ok: false, reason: 'malformed' });
+  });
+
+  it('verifies bodies passed as Uint8Array', async () => {
+    const ts = Math.floor(Date.now() / 1000).toString();
+    const sig = sign(ts, body, SECRET);
+    const bytes = new TextEncoder().encode(body);
+    const result = await verifyWebhookSignature({
+      body: bytes,
+      signatureHeader: sig,
+      timestampHeader: ts,
+      secret: SECRET,
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('respects an injected `now` for deterministic tests', async () => {
+    const ts = '1700000000';
+    const sig = sign(ts, body, SECRET);
+    const result = await verifyWebhookSignature({
+      body,
+      signatureHeader: sig,
+      timestampHeader: ts,
+      secret: SECRET,
+      now: () => 1700000100 * 1000, // 100s later
+    });
+    expect(result).toEqual({ ok: true });
+  });
+});
+
+describe('timingSafeEqualHex', () => {
+  it('returns true for equal strings', () => {
+    expect(timingSafeEqualHex('abcd', 'abcd')).toBe(true);
+  });
+  it('returns false for different lengths', () => {
+    expect(timingSafeEqualHex('abcd', 'abc')).toBe(false);
+  });
+  it('returns false for different chars', () => {
+    expect(timingSafeEqualHex('abcd', 'abce')).toBe(false);
+  });
+});

--- a/packages/sdk/jest.config.cjs
+++ b/packages/sdk/jest.config.cjs
@@ -1,0 +1,30 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        useESM: true,
+        tsconfig: {
+          module: 'ESNext',
+          target: 'ES2022',
+          moduleResolution: 'Bundler',
+          esModuleInterop: true,
+          strict: true,
+          isolatedModules: true,
+          skipLibCheck: true,
+          types: ['node', 'jest'],
+        },
+      },
+    ],
+  },
+  testMatch: ['<rootDir>/__tests__/**/*.test.ts'],
+  collectCoverageFrom: ['src/**/*.ts', '!src/**/*.d.ts'],
+  clearMocks: true,
+};

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@verifactu/sdk",
+  "version": "0.1.0",
+  "description": "Official TypeScript SDK for the Isaak Platform API (Verifactu Business)",
+  "license": "MIT",
+  "homepage": "https://verifactu.business/developers",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kiabusiness2025/verifactu-monorepo",
+    "directory": "packages/sdk"
+  },
+  "keywords": [
+    "verifactu",
+    "aeat",
+    "facturacion",
+    "spain",
+    "fiscal",
+    "sdk"
+  ],
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "jest",
+    "lint": "eslint src/",
+    "typecheck": "tsc --noEmit"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.12",
+    "@types/node": "^20.11.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.2",
+    "tsup": "^8.0.0",
+    "typescript": "^5.4.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/sdk/src/auth.ts
+++ b/packages/sdk/src/auth.ts
@@ -1,0 +1,24 @@
+/**
+ * Builds the headers required to authenticate with the Isaak Platform API.
+ *
+ * The current contract uses Bearer authentication with API keys of shape
+ * `isk_live_...` / `isk_test_...`.
+ */
+export function buildAuthHeaders(apiKey: string): Record<string, string> {
+  if (!apiKey || typeof apiKey !== 'string') {
+    throw new TypeError(
+      'IsaakClient: `apiKey` is required and must be a non-empty string.',
+    );
+  }
+  return {
+    Authorization: `Bearer ${apiKey}`,
+  };
+}
+
+/**
+ * Returns the SDK's User-Agent header. Kept centralized so we can bump the
+ * version in a single spot.
+ */
+export function buildUserAgent(version: string): string {
+  return `verifactu-sdk-js/${version}`;
+}

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1,0 +1,280 @@
+import { buildAuthHeaders, buildUserAgent } from './auth.js';
+import {
+  IsaakError,
+  NetworkError,
+  RateLimitError,
+  TimeoutError,
+} from './errors.js';
+import { CompaniesResource } from './resources/companies.js';
+import { InvoicesResource } from './resources/invoices.js';
+import { KeysResource } from './resources/keys.js';
+import { isErrorRetriable, withRetry } from './retry.js';
+
+/** SDK version — kept in sync with package.json by the publish workflow. */
+export const SDK_VERSION = '0.1.0';
+
+const DEFAULT_BASE_URL = 'https://isaak.verifactu.business';
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_RETRIES = 3;
+
+export interface IsaakClientConfig {
+  /** API key starting with `isk_live_` or `isk_test_`. */
+  apiKey: string;
+  /** Override the base URL (e.g. for staging). */
+  baseUrl?: string;
+  /** Per-request timeout in milliseconds. Default: 30_000. */
+  timeout?: number;
+  /** Max retry attempts for retriable failures. Default: 3. */
+  maxRetries?: number;
+  /** Custom fetch implementation (useful in tests / Workers). */
+  fetch?: typeof fetch;
+  /** Extra headers added to every request. */
+  defaultHeaders?: Record<string, string>;
+}
+
+export interface RequestOptions {
+  method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+  query?: Record<string, string | number | boolean | undefined | null>;
+  body?: unknown;
+  headers?: Record<string, string>;
+  /** Set to true for endpoints that should return a binary Blob. */
+  responseType?: 'json' | 'blob';
+  /**
+   * When true, the SDK will auto-generate an `Idempotency-Key` header for
+   * non-idempotent methods so the request becomes retry-safe.
+   */
+  idempotent?: boolean;
+  /** Override the request-level timeout. */
+  timeout?: number;
+  /** Skip retries for this request. */
+  noRetry?: boolean;
+}
+
+/**
+ * The top-level entry point of the Isaak Platform SDK.
+ *
+ * @example
+ * ```ts
+ * const isaak = new IsaakClient({ apiKey: process.env.ISAAK_API_KEY! });
+ * const me = await isaak.companies.getCurrent();
+ * ```
+ */
+export class IsaakClient {
+  public readonly companies: CompaniesResource;
+  public readonly invoices: InvoicesResource;
+  public readonly keys: KeysResource;
+
+  private readonly apiKey: string;
+  private readonly baseUrl: string;
+  private readonly timeout: number;
+  private readonly maxRetries: number;
+  private readonly fetchImpl: typeof fetch;
+  private readonly defaultHeaders: Record<string, string>;
+
+  constructor(config: IsaakClientConfig) {
+    if (!config || typeof config !== 'object') {
+      throw new TypeError('IsaakClient: config object is required.');
+    }
+    if (!config.apiKey) {
+      throw new TypeError('IsaakClient: `apiKey` is required.');
+    }
+    this.apiKey = config.apiKey;
+    this.baseUrl = (config.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, '');
+    this.timeout = config.timeout ?? DEFAULT_TIMEOUT_MS;
+    this.maxRetries = config.maxRetries ?? DEFAULT_MAX_RETRIES;
+    this.defaultHeaders = config.defaultHeaders ?? {};
+
+    const resolvedFetch = config.fetch ?? globalThis.fetch;
+    if (!resolvedFetch) {
+      throw new TypeError(
+        'IsaakClient: no global fetch found. Provide `config.fetch` (e.g. node-fetch) or upgrade to Node 18+.',
+      );
+    }
+    this.fetchImpl = resolvedFetch.bind(globalThis);
+
+    this.companies = new CompaniesResource(this);
+    this.invoices = new InvoicesResource(this);
+    this.keys = new KeysResource(this);
+  }
+
+  /**
+   * Low-level request helper. Resource modules wrap this for ergonomics, but
+   * it's exported so power users can call endpoints the SDK doesn't model
+   * yet.
+   */
+  async request<T>(path: string, options: RequestOptions = {}): Promise<T> {
+    const method = (options.method ?? 'GET').toUpperCase() as Required<RequestOptions>['method'];
+    const url = this.buildUrl(path, options.query);
+    const headers = this.buildHeaders(method, options);
+    const bodyInit = serializeBody(options.body, headers);
+
+    const hasIdempotencyKey = Boolean(headers['Idempotency-Key']);
+    const requestContext = { method, hasIdempotencyKey };
+
+    const runOnce = async (): Promise<T> => {
+      const controller = new AbortController();
+      const timeoutMs = options.timeout ?? this.timeout;
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+      let response: Response;
+      try {
+        response = await this.fetchImpl(url, {
+          method,
+          headers,
+          body: bodyInit,
+          signal: controller.signal,
+        });
+      } catch (err) {
+        clearTimeout(timer);
+        if (isAbortError(err)) {
+          throw new TimeoutError(
+            `Request to ${url} aborted after ${timeoutMs}ms.`,
+          );
+        }
+        throw new NetworkError(
+          `Network error contacting Isaak API: ${describeError(err)}`,
+          'network_error',
+          err,
+        );
+      }
+      clearTimeout(timer);
+
+      if (!response.ok) {
+        const parsed = await safeParseJson(response.clone());
+        const error = IsaakError.fromResponse(response, parsed);
+        if (error instanceof RateLimitError) {
+          const retryAfter = response.headers.get('retry-after');
+          if (retryAfter) {
+            const seconds = Number(retryAfter);
+            if (Number.isFinite(seconds) && seconds > 0) {
+              (error as { retryAfterSeconds?: number }).retryAfterSeconds = seconds;
+            }
+          }
+        }
+        throw error;
+      }
+
+      if (options.responseType === 'blob') {
+        return (await response.blob()) as unknown as T;
+      }
+
+      if (response.status === 204) return undefined as unknown as T;
+
+      const json = await safeParseJson(response);
+      return json as T;
+    };
+
+    if (options.noRetry) {
+      return runOnce();
+    }
+
+    return withRetry(runOnce, {
+      maxRetries: this.maxRetries,
+      isRetriable: (err) => isErrorRetriable(err, requestContext),
+    });
+  }
+
+  private buildUrl(
+    path: string,
+    query?: RequestOptions['query'],
+  ): string {
+    const normalized = path.startsWith('/') ? path : `/${path}`;
+    let url = `${this.baseUrl}${normalized}`;
+    if (query) {
+      const params = new URLSearchParams();
+      for (const [k, v] of Object.entries(query)) {
+        if (v === undefined || v === null) continue;
+        params.set(k, String(v));
+      }
+      const qs = params.toString();
+      if (qs) url += `?${qs}`;
+    }
+    return url;
+  }
+
+  private buildHeaders(
+    method: string,
+    options: RequestOptions,
+  ): Record<string, string> {
+    const headers: Record<string, string> = {
+      Accept: 'application/json',
+      'User-Agent': buildUserAgent(SDK_VERSION),
+      ...this.defaultHeaders,
+      ...buildAuthHeaders(this.apiKey),
+      ...(options.headers ?? {}),
+    };
+
+    if (options.body !== undefined && !headers['Content-Type']) {
+      headers['Content-Type'] = 'application/json';
+    }
+
+    if (
+      options.idempotent &&
+      method !== 'GET' &&
+      !headers['Idempotency-Key']
+    ) {
+      headers['Idempotency-Key'] = generateIdempotencyKey();
+    }
+
+    return headers;
+  }
+}
+
+function serializeBody(
+  body: unknown,
+  headers: Record<string, string>,
+): BodyInit | undefined {
+  if (body === undefined || body === null) return undefined;
+  if (typeof body === 'string') return body;
+  if (body instanceof ArrayBuffer || body instanceof Uint8Array) {
+    return body as BodyInit;
+  }
+  if (typeof body === 'object') {
+    if (!headers['Content-Type']) {
+      headers['Content-Type'] = 'application/json';
+    }
+    return JSON.stringify(body);
+  }
+  return String(body);
+}
+
+async function safeParseJson(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return undefined;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function isAbortError(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    (err.name === 'AbortError' || /aborted/i.test(err.message))
+  );
+}
+
+function describeError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+/**
+ * Generate an RFC 4122-ish v4 identifier without pulling in `crypto.randomUUID`
+ * fallbacks. Good enough for idempotency keys, which only need to be unique
+ * within the retry window.
+ */
+function generateIdempotencyKey(): string {
+  const g = globalThis as { crypto?: { randomUUID?: () => string } };
+  if (g.crypto?.randomUUID) return g.crypto.randomUUID();
+  // Best-effort fallback for environments without randomUUID.
+  const rnd = (n: number): string => {
+    let out = '';
+    for (let i = 0; i < n; i += 1) {
+      out += Math.floor(Math.random() * 16).toString(16);
+    }
+    return out;
+  };
+  return `${rnd(8)}-${rnd(4)}-4${rnd(3)}-a${rnd(3)}-${rnd(12)}`;
+}

--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -1,0 +1,202 @@
+import type { ApiErrorBody } from './types.js';
+
+/**
+ * Base error thrown by every Isaak SDK call when the API returns a non-2xx
+ * response or the request itself fails.
+ *
+ * Use `instanceof IsaakError` for the catch-all case, or one of the typed
+ * subclasses (e.g. `RateLimitError`) when you care about a specific failure
+ * mode.
+ */
+export class IsaakError extends Error {
+  public readonly name: string = 'IsaakError';
+
+  constructor(
+    message: string,
+    /** Stable application-level code (e.g. `rate_limit_exceeded`). */
+    public readonly code: string,
+    /** HTTP status code of the response that triggered the error. */
+    public readonly httpStatus: number,
+    /** `requestId` echoed back by the API — include in support tickets. */
+    public readonly requestId?: string,
+    /** Raw `error.details` field, when the API provides one. */
+    public readonly details?: unknown,
+  ) {
+    super(message);
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+
+  /**
+   * Build the right IsaakError subclass from a fetch Response and the parsed
+   * (or partially parsed) body.
+   */
+  static fromResponse(res: Response, body: unknown): IsaakError {
+    const requestId =
+      res.headers.get('x-request-id') ?? extractRequestId(body) ?? undefined;
+    const apiError = extractApiError(body);
+    const code = apiError?.code ?? defaultCodeForStatus(res.status);
+    const message =
+      apiError?.message ?? `Isaak API request failed with HTTP ${res.status}`;
+    const details = apiError?.details;
+
+    const ctor = selectErrorClass(res.status, code);
+    return new ctor(message, code, res.status, requestId, details);
+  }
+}
+
+/** 401 — authentication missing, invalid or revoked. */
+export class AuthenticationError extends IsaakError {
+  public override readonly name = 'AuthenticationError';
+}
+
+/** 403 — token valid but lacks the required scope. */
+export class PermissionError extends IsaakError {
+  public override readonly name = 'PermissionError';
+}
+
+/** 404 — resource not found (or not visible to your tenant). */
+export class NotFoundError extends IsaakError {
+  public override readonly name = 'NotFoundError';
+}
+
+/** 409 — state of the resource is incompatible with the requested action. */
+export class ConflictError extends IsaakError {
+  public override readonly name = 'ConflictError';
+}
+
+/** 428 — confirmation required for an irreversible action. */
+export class ConfirmationRequiredError extends IsaakError {
+  public override readonly name = 'ConfirmationRequiredError';
+}
+
+/** 400 / 422 — request body or arguments failed validation. */
+export class ValidationError extends IsaakError {
+  public override readonly name = 'ValidationError';
+}
+
+/** 429 — rate limit exceeded. */
+export class RateLimitError extends IsaakError {
+  public override readonly name = 'RateLimitError';
+
+  constructor(
+    message: string,
+    code: string,
+    httpStatus: number,
+    requestId?: string,
+    details?: unknown,
+    /** Seconds the caller should wait before retrying (Retry-After header). */
+    public readonly retryAfterSeconds?: number,
+  ) {
+    super(message, code, httpStatus, requestId, details);
+  }
+}
+
+/** 5xx — Isaak (or an upstream like AEAT) failed. */
+export class ServerError extends IsaakError {
+  public override readonly name = 'ServerError';
+}
+
+/** Network-level failure: timeout, DNS, connection refused. */
+export class NetworkError extends IsaakError {
+  public override readonly name: string = 'NetworkError';
+  public readonly networkCause?: unknown;
+
+  constructor(message: string, code = 'network_error', cause?: unknown) {
+    super(message, code, 0);
+    this.networkCause = cause;
+  }
+}
+
+/** Aborted because of the SDK's configured timeout. */
+export class TimeoutError extends NetworkError {
+  public override readonly name: string = 'TimeoutError';
+
+  constructor(message = 'Request timed out') {
+    super(message, 'timeout');
+  }
+}
+
+function defaultCodeForStatus(status: number): string {
+  switch (status) {
+    case 400:
+      return 'bad_request';
+    case 401:
+      return 'unauthorized';
+    case 403:
+      return 'scope_insufficient';
+    case 404:
+      return 'not_found';
+    case 409:
+      return 'conflict';
+    case 422:
+      return 'validation_error';
+    case 428:
+      return 'confirmation_required';
+    case 429:
+      return 'rate_limit_exceeded';
+    case 500:
+      return 'internal_error';
+    case 502:
+      return 'aeat_unavailable';
+    case 503:
+      return 'maintenance';
+    case 504:
+      return 'timeout';
+    default:
+      return status >= 500 ? 'server_error' : 'http_error';
+  }
+}
+
+function selectErrorClass(
+  status: number,
+  code: string,
+): new (
+  message: string,
+  code: string,
+  httpStatus: number,
+  requestId?: string,
+  details?: unknown,
+) => IsaakError {
+  if (status === 401) return AuthenticationError;
+  if (status === 403) return PermissionError;
+  if (status === 404) return NotFoundError;
+  if (status === 409) return ConflictError;
+  if (status === 428) return ConfirmationRequiredError;
+  if (status === 400 || status === 422) return ValidationError;
+  if (status === 429) return RateLimitError;
+  if (status >= 500) return ServerError;
+  if (code === 'validation_error') return ValidationError;
+  return IsaakError;
+}
+
+function extractApiError(body: unknown): ApiErrorBody['error'] | undefined {
+  if (
+    body &&
+    typeof body === 'object' &&
+    'error' in body &&
+    body.error &&
+    typeof body.error === 'object'
+  ) {
+    const err = body.error as Record<string, unknown>;
+    if (typeof err.code === 'string' && typeof err.message === 'string') {
+      return {
+        code: err.code,
+        message: err.message,
+        details: err.details,
+      };
+    }
+  }
+  return undefined;
+}
+
+function extractRequestId(body: unknown): string | undefined {
+  if (
+    body &&
+    typeof body === 'object' &&
+    'requestId' in body &&
+    typeof (body as { requestId: unknown }).requestId === 'string'
+  ) {
+    return (body as { requestId: string }).requestId;
+  }
+  return undefined;
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,0 +1,62 @@
+/**
+ * @verifactu/sdk — Official TypeScript SDK for the Isaak Platform API.
+ *
+ * Docs: https://verifactu.business/developers
+ */
+
+export { IsaakClient, SDK_VERSION } from './client.js';
+export type { IsaakClientConfig, RequestOptions } from './client.js';
+
+export {
+  IsaakError,
+  AuthenticationError,
+  PermissionError,
+  NotFoundError,
+  ConflictError,
+  ConfirmationRequiredError,
+  ValidationError,
+  RateLimitError,
+  ServerError,
+  NetworkError,
+  TimeoutError,
+} from './errors.js';
+
+export {
+  verifyWebhookSignature,
+  timingSafeEqualHex,
+} from './webhooks.js';
+export type {
+  VerifyWebhookOptions,
+  WebhookVerifyResult,
+  WebhookVerifyFailureReason,
+} from './webhooks.js';
+
+export {
+  withRetry,
+  computeBackoff,
+  isErrorRetriable,
+} from './retry.js';
+export type { RetryOptions, RetryContext } from './retry.js';
+
+export { CompaniesResource } from './resources/companies.js';
+export { InvoicesResource } from './resources/invoices.js';
+export { KeysResource } from './resources/keys.js';
+
+export type {
+  ApiResponse,
+  PaginatedResponse,
+  ApiErrorBody,
+  Company,
+  Invoice,
+  InvoiceCustomer,
+  InvoiceLine,
+  InvoiceStatus,
+  CreateInvoiceInput,
+  ListInvoicesParams,
+  IssueInvoiceInput,
+  ApiKey,
+  ApiKeyScope,
+  CreateApiKeyInput,
+  CreatedApiKey,
+  WebhookEvent,
+} from './types.js';

--- a/packages/sdk/src/resources/companies.ts
+++ b/packages/sdk/src/resources/companies.ts
@@ -1,0 +1,17 @@
+import type { IsaakClient } from '../client.js';
+import type { ApiResponse, Company } from '../types.js';
+
+/**
+ * `client.companies` — read the tenant/company the API key belongs to.
+ */
+export class CompaniesResource {
+  constructor(private readonly client: IsaakClient) {}
+
+  /** Return the company linked to the API key currently in use. */
+  async getCurrent(): Promise<Company> {
+    const res = await this.client.request<ApiResponse<Company>>(
+      '/api/v1/companies/current',
+    );
+    return res.data;
+  }
+}

--- a/packages/sdk/src/resources/invoices.ts
+++ b/packages/sdk/src/resources/invoices.ts
@@ -1,0 +1,83 @@
+import type { IsaakClient } from '../client.js';
+import type {
+  ApiResponse,
+  CreateInvoiceInput,
+  Invoice,
+  IssueInvoiceInput,
+  ListInvoicesParams,
+  PaginatedResponse,
+} from '../types.js';
+
+/**
+ * `client.invoices` — list, fetch, create and issue invoices.
+ *
+ * Mutating methods (`create`, `issue`) send an `Idempotency-Key` automatically
+ * so SDK retries are safe.
+ */
+export class InvoicesResource {
+  constructor(private readonly client: IsaakClient) {}
+
+  /** Paginated list. Use `pagination.nextCursor` to walk further. */
+  async list(params: ListInvoicesParams = {}): Promise<PaginatedResponse<Invoice>> {
+    return this.client.request<PaginatedResponse<Invoice>>('/api/v1/invoices', {
+      query: {
+        from: params.from,
+        to: params.to,
+        status: params.status,
+        limit: params.limit,
+        cursor: params.cursor,
+      },
+    });
+  }
+
+  /** Fetch a single invoice by ID. */
+  async get(id: string): Promise<Invoice> {
+    const res = await this.client.request<ApiResponse<Invoice>>(
+      `/api/v1/invoices/${encodeURIComponent(id)}`,
+    );
+    return res.data;
+  }
+
+  /**
+   * Create a draft invoice. The invoice is NOT submitted to AEAT — call
+   * `issue()` once the user confirms.
+   */
+  async create(data: CreateInvoiceInput): Promise<Invoice> {
+    const res = await this.client.request<ApiResponse<Invoice>>(
+      '/api/v1/invoices',
+      {
+        method: 'POST',
+        body: data,
+        idempotent: true,
+      },
+    );
+    return res.data;
+  }
+
+  /**
+   * Submit a draft to AEAT (irreversible). Requires a `confirmationToken`
+   * obtained from a previous 428 response.
+   */
+  async issue(id: string, input: IssueInvoiceInput): Promise<Invoice> {
+    const res = await this.client.request<ApiResponse<Invoice>>(
+      `/api/v1/invoices/${encodeURIComponent(id)}/issue`,
+      {
+        method: 'POST',
+        body: input,
+        idempotent: true,
+      },
+    );
+    return res.data;
+  }
+
+  /** Download the legal PDF of an issued invoice as a `Blob`. */
+  async getPdf(id: string): Promise<Blob> {
+    return this.client.request<Blob>(
+      `/api/v1/invoices/${encodeURIComponent(id)}/pdf`,
+      {
+        responseType: 'blob',
+        headers: { Accept: 'application/pdf' },
+      },
+    );
+  }
+}

--- a/packages/sdk/src/resources/keys.ts
+++ b/packages/sdk/src/resources/keys.ts
@@ -1,0 +1,38 @@
+import type { IsaakClient } from '../client.js';
+import type {
+  ApiKey,
+  ApiResponse,
+  CreateApiKeyInput,
+  CreatedApiKey,
+} from '../types.js';
+
+/**
+ * `client.keys` — manage API keys for the current tenant.
+ *
+ * The plaintext key is only returned by `create()` — store it immediately, it
+ * cannot be retrieved again.
+ */
+export class KeysResource {
+  constructor(private readonly client: IsaakClient) {}
+
+  /** List all active keys for the tenant. */
+  async list(): Promise<ApiKey[]> {
+    const res = await this.client.request<ApiResponse<ApiKey[]>>(
+      '/api/v1/keys',
+    );
+    return res.data;
+  }
+
+  /** Create a new key. The response includes the plaintext one-time. */
+  async create(input: CreateApiKeyInput): Promise<CreatedApiKey> {
+    const res = await this.client.request<ApiResponse<CreatedApiKey>>(
+      '/api/v1/keys',
+      {
+        method: 'POST',
+        body: input,
+        idempotent: true,
+      },
+    );
+    return res.data;
+  }
+}

--- a/packages/sdk/src/retry.ts
+++ b/packages/sdk/src/retry.ts
@@ -1,0 +1,96 @@
+import { IsaakError, NetworkError, RateLimitError, TimeoutError } from './errors.js';
+
+const IDEMPOTENT_METHODS = new Set(['GET', 'HEAD', 'OPTIONS', 'PUT', 'DELETE']);
+const RETRYABLE_STATUS = new Set([429, 502, 503, 504]);
+
+export interface RetryOptions {
+  /** Max retry attempts, in addition to the initial attempt. Default: 3. */
+  maxRetries?: number;
+  /** Base backoff in ms. Default: 250. */
+  baseDelayMs?: number;
+  /** Max backoff in ms (cap for exponential growth). Default: 5000. */
+  maxDelayMs?: number;
+  /**
+   * Override the retry decision. Receives the thrown error and the attempt
+   * number (1 = first failure). Return true to retry.
+   */
+  isRetriable?: (error: unknown, attempt: number) => boolean;
+  /** Sleep implementation (injectable for tests). */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export interface RetryContext {
+  /** HTTP method of the underlying request (uppercased). */
+  method: string;
+  /** True when the request carries an Idempotency-Key header. */
+  hasIdempotencyKey: boolean;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Decide whether the given error is safe to retry for the request context.
+ */
+export function isErrorRetriable(
+  error: unknown,
+  context: RetryContext,
+): boolean {
+  const methodOk =
+    IDEMPOTENT_METHODS.has(context.method) || context.hasIdempotencyKey;
+  if (!methodOk) return false;
+
+  if (error instanceof TimeoutError) return true;
+  if (error instanceof NetworkError) return true;
+  if (error instanceof RateLimitError) return true;
+  if (error instanceof IsaakError) {
+    return RETRYABLE_STATUS.has(error.httpStatus);
+  }
+  return false;
+}
+
+/**
+ * Run `fn` with exponential backoff + full jitter.
+ *
+ * `fn` receives the current attempt number (1-indexed).
+ */
+export async function withRetry<T>(
+  fn: (attempt: number) => Promise<T>,
+  options: RetryOptions = {},
+): Promise<T> {
+  const maxRetries = options.maxRetries ?? 3;
+  const base = options.baseDelayMs ?? 250;
+  const cap = options.maxDelayMs ?? 5_000;
+  const sleep = options.sleep ?? defaultSleep;
+
+  let attempt = 0;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    attempt += 1;
+    try {
+      return await fn(attempt);
+    } catch (err) {
+      if (attempt > maxRetries) throw err;
+      const retry = options.isRetriable?.(err, attempt) ?? false;
+      if (!retry) throw err;
+
+      const retryAfterMs =
+        err instanceof RateLimitError && err.retryAfterSeconds
+          ? err.retryAfterSeconds * 1_000
+          : undefined;
+
+      const delay = retryAfterMs ?? computeBackoff(attempt, base, cap);
+      await sleep(delay);
+    }
+  }
+}
+
+/** Exponential backoff with full jitter. Exposed for tests. */
+export function computeBackoff(
+  attempt: number,
+  baseMs: number,
+  capMs: number,
+): number {
+  const exp = Math.min(capMs, baseMs * 2 ** (attempt - 1));
+  return Math.floor(Math.random() * exp);
+}

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1,0 +1,165 @@
+/**
+ * Shared types for the Isaak Platform SDK.
+ *
+ * These mirror the public OpenAPI contract documented at
+ * https://verifactu.business/developers/api
+ */
+
+/** Envelope returned by every successful Isaak API response. */
+export interface ApiResponse<T> {
+  ok: true;
+  data: T;
+  requestId: string;
+}
+
+/** Cursor-based pagination envelope. */
+export interface PaginatedResponse<T> {
+  ok: true;
+  data: T[];
+  requestId: string;
+  pagination: {
+    nextCursor: string | null;
+    hasMore: boolean;
+    limit: number;
+  };
+}
+
+/** Standard error envelope returned by the API for non-2xx responses. */
+export interface ApiErrorBody {
+  ok: false;
+  error: {
+    code: string;
+    message: string;
+    details?: unknown;
+  };
+  requestId?: string;
+}
+
+/** Tenant / company identity attached to the API key. */
+export interface Company {
+  id: string;
+  legalName: string;
+  cif: string;
+  address?: string | null;
+  postalCode?: string | null;
+  city?: string | null;
+  country?: string | null;
+  verifactuEnabled: boolean;
+  certificateExpiresAt?: string | null;
+  createdAt: string;
+}
+
+export type InvoiceStatus =
+  | 'draft'
+  | 'pending_confirmation'
+  | 'issued'
+  | 'rejected'
+  | 'cancelled';
+
+export interface InvoiceLine {
+  description: string;
+  quantity: number;
+  unitPrice: number;
+  vatRate: number;
+  /** Optional discount percentage (0-100). */
+  discount?: number;
+}
+
+export interface InvoiceCustomer {
+  name: string;
+  cif?: string;
+  email?: string;
+  address?: string;
+  postalCode?: string;
+  city?: string;
+  country?: string;
+}
+
+export interface Invoice {
+  id: string;
+  number?: string | null;
+  status: InvoiceStatus;
+  issueDate?: string | null;
+  customer: InvoiceCustomer;
+  lines: InvoiceLine[];
+  subtotal: number;
+  vatTotal: number;
+  total: number;
+  currency: string;
+  verifactuHash?: string | null;
+  aeatStatus?: 'pending' | 'registered' | 'rejected' | null;
+  rejectionReason?: string | null;
+  pdfUrl?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateInvoiceInput {
+  customer: InvoiceCustomer;
+  lines: InvoiceLine[];
+  /** ISO date (YYYY-MM-DD). Defaults to today on the server. */
+  issueDate?: string;
+  /** Free-form notes that show on the PDF. */
+  notes?: string;
+  /** Override the invoice numbering series. */
+  series?: string;
+  currency?: string;
+}
+
+export interface ListInvoicesParams {
+  /** Inclusive ISO date. */
+  from?: string;
+  /** Inclusive ISO date. */
+  to?: string;
+  status?: InvoiceStatus;
+  limit?: number;
+  cursor?: string;
+}
+
+export interface IssueInvoiceInput {
+  /**
+   * The confirmation token returned by a previous 428 response,
+   * required to commit the irreversible AEAT submission.
+   */
+  confirmationToken: string;
+}
+
+export type ApiKeyScope =
+  | 'isaak.invoices.read'
+  | 'isaak.invoices.write'
+  | 'isaak.company.read'
+  | 'isaak.verifactu.read'
+  | 'isaak.audit.read'
+  | 'isaak.keys.read'
+  | 'isaak.keys.write'
+  | 'isaak.fiscal.read';
+
+export interface ApiKey {
+  id: string;
+  name: string;
+  prefix: string;
+  scopes: ApiKeyScope[];
+  lastUsedAt?: string | null;
+  createdAt: string;
+  revokedAt?: string | null;
+}
+
+export interface CreateApiKeyInput {
+  name: string;
+  scopes: ApiKeyScope[];
+}
+
+/** Response returned only when creating a key (plaintext shown once). */
+export type CreatedApiKey = ApiKey & {
+  /** The plaintext key. Only returned in the create response; store it securely. */
+  plaintext: string;
+};
+
+/** Webhook event envelope received by your endpoint. */
+export interface WebhookEvent<T = unknown> {
+  id: string;
+  type: string;
+  createdAt: string;
+  tenantId: string;
+  data: T;
+}

--- a/packages/sdk/src/webhooks.ts
+++ b/packages/sdk/src/webhooks.ts
@@ -1,0 +1,136 @@
+/**
+ * Webhook signature verifier for Isaak Platform events.
+ *
+ * Isaak sends webhooks with two headers:
+ *   - `x-isaak-signature`  HMAC-SHA256(`${timestamp}.${rawBody}`, secret) in hex
+ *   - `x-isaak-timestamp`  Unix seconds (string)
+ *
+ * Use the raw, unparsed body. Parsing/serializing JSON will change whitespace
+ * and break the signature.
+ */
+
+export interface VerifyWebhookOptions {
+  /** Raw request body as received (string or Uint8Array). */
+  body: string | Uint8Array;
+  /** Value of `x-isaak-signature`. */
+  signatureHeader: string | null | undefined;
+  /** Value of `x-isaak-timestamp`. */
+  timestampHeader: string | null | undefined;
+  /** The endpoint signing secret, e.g. `whsec_...`. */
+  secret: string;
+  /**
+   * Maximum age of the event in seconds before it's considered replayed.
+   * Defaults to 300 (5 minutes), matching the documented anti-replay window.
+   */
+  toleranceSeconds?: number;
+  /** Override `Date.now()` — useful for tests. Returns ms since epoch. */
+  now?: () => number;
+}
+
+export type WebhookVerifyFailureReason =
+  | 'invalid_signature'
+  | 'timestamp_out_of_window'
+  | 'malformed';
+
+export type WebhookVerifyResult =
+  | { ok: true }
+  | { ok: false; reason: WebhookVerifyFailureReason };
+
+const TEXT_ENCODER = new TextEncoder();
+
+/**
+ * Verify the signature attached to an incoming Isaak webhook.
+ *
+ * Returns `{ ok: true }` if the signature, timestamp and tolerance all match.
+ * On any failure it returns `{ ok: false, reason }` instead of throwing — the
+ * caller decides how to log / 4xx the response.
+ */
+export async function verifyWebhookSignature(
+  options: VerifyWebhookOptions,
+): Promise<WebhookVerifyResult> {
+  const {
+    body,
+    signatureHeader,
+    timestampHeader,
+    secret,
+    toleranceSeconds = 300,
+    now = () => Date.now(),
+  } = options;
+
+  if (!signatureHeader || !timestampHeader || !secret) {
+    return { ok: false, reason: 'malformed' };
+  }
+
+  const tsSeconds = Number(timestampHeader);
+  if (!Number.isFinite(tsSeconds) || tsSeconds <= 0) {
+    return { ok: false, reason: 'malformed' };
+  }
+
+  const ageSeconds = Math.abs(now() / 1000 - tsSeconds);
+  if (ageSeconds > toleranceSeconds) {
+    return { ok: false, reason: 'timestamp_out_of_window' };
+  }
+
+  const rawBody = typeof body === 'string' ? body : decodeBytes(body);
+  const payload = `${timestampHeader}.${rawBody}`;
+  const expected = await hmacSha256Hex(secret, payload);
+
+  return timingSafeEqualHex(signatureHeader, expected)
+    ? { ok: true }
+    : { ok: false, reason: 'invalid_signature' };
+}
+
+function decodeBytes(input: Uint8Array): string {
+  // Webhook bodies are JSON-text; UTF-8 is the right decoder.
+  return new TextDecoder('utf-8').decode(input);
+}
+
+/**
+ * Compute HMAC-SHA256 in hex. Uses Web Crypto when available, falls back to
+ * node:crypto via dynamic import for older Node bundles or non-WebCrypto
+ * runtimes.
+ */
+async function hmacSha256Hex(secret: string, payload: string): Promise<string> {
+  const subtle = getSubtle();
+  if (subtle) {
+    const key = await subtle.importKey(
+      'raw',
+      TEXT_ENCODER.encode(secret),
+      { name: 'HMAC', hash: 'SHA-256' },
+      false,
+      ['sign'],
+    );
+    const sig = await subtle.sign('HMAC', key, TEXT_ENCODER.encode(payload));
+    return bufferToHex(new Uint8Array(sig));
+  }
+
+  // Fallback: node:crypto
+  const nodeCrypto = await import('node:crypto');
+  return nodeCrypto.createHmac('sha256', secret).update(payload).digest('hex');
+}
+
+function getSubtle(): SubtleCrypto | null {
+  const g = globalThis as { crypto?: { subtle?: SubtleCrypto } };
+  return g.crypto?.subtle ?? null;
+}
+
+function bufferToHex(buf: Uint8Array): string {
+  let out = '';
+  for (let i = 0; i < buf.length; i += 1) {
+    out += buf[i]!.toString(16).padStart(2, '0');
+  }
+  return out;
+}
+
+/**
+ * Constant-time comparison of two hex strings. Lengths must match first;
+ * comparison runs in O(n) of the *expected* length regardless of mismatches.
+ */
+export function timingSafeEqualHex(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM"],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "types": ["node", "jest"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "__tests__"]
+}

--- a/packages/sdk/tsup.config.ts
+++ b/packages/sdk/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  splitting: false,
+  treeshake: true,
+  target: 'es2022',
+  platform: 'neutral',
+  outDir: 'dist',
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,7 +120,7 @@ importers:
         version: 9.1.7
       jest:
         specifier: ^30.2.0
-        version: 30.2.0(@types/node@24.8.1)
+        version: 30.2.0(@types/node@20.19.30)
       jest-environment-jsdom:
         specifier: ^30.2.0
         version: 30.2.0
@@ -138,7 +138,7 @@ importers:
     dependencies:
       '@next-auth/prisma-adapter':
         specifier: ^1.0.7
-        version: 1.0.7(@prisma/client@5.22.0(prisma@5.22.0))(next-auth@4.24.13(next@15.5.18(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+        version: 1.0.7(@prisma/client@5.22.0(prisma@5.22.0))(next-auth@4.24.13(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       '@verifactu/auth':
         specifier: workspace:*
         version: link:../../packages/auth
@@ -251,7 +251,7 @@ importers:
         version: 30.2.0(@babel/core@7.28.6)
       jest:
         specifier: ^30.2.0
-        version: 30.2.0(@types/node@20.19.30)
+        version: 30.2.0(@types/node@24.8.1)
       nodemon:
         specifier: ^3.1.0
         version: 3.1.11
@@ -302,7 +302,7 @@ importers:
         version: file:packages/db(@react-email/render@1.1.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/node@20.19.30)(prisma@5.22.0)
       '@verifactu/ui':
         specifier: file:../../packages/ui
-        version: file:packages/ui(@types/react@18.3.27)(next@15.5.18(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
+        version: file:packages/ui(@types/react@18.3.27)(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
       '@verifactu/utils':
         specifier: file:../../packages/utils
         version: link:../../packages/utils
@@ -383,7 +383,7 @@ importers:
         version: 2.6.0
       workflow:
         specifier: 4.2.0-beta.64
-        version: 4.2.0-beta.64(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.18))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.18))(@swc/helpers@0.5.18)(next@15.5.18(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router@7.13.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.9.3)
+        version: 4.2.0-beta.64(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.18))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.18))(@swc/helpers@0.5.18)(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router@7.13.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.9.3)
       zod:
         specifier: ^4.3.5
         version: 4.3.6
@@ -486,7 +486,7 @@ importers:
         version: file:packages/db(@react-email/render@1.1.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/node@20.19.30)(prisma@5.22.0)
       '@verifactu/ui':
         specifier: file:../../packages/ui
-        version: file:packages/ui(@types/react@18.3.27)(next@15.5.18(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
+        version: file:packages/ui(@types/react@18.3.27)(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
       '@verifactu/utils':
         specifier: file:../../packages/utils
         version: link:../../packages/utils
@@ -835,7 +835,7 @@ importers:
         version: 4.10.0
       '@vercel/analytics':
         specifier: ^1.6.1
-        version: 1.6.1(next@15.5.18(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(vue@3.5.35(typescript@5.9.3))
+        version: 1.6.1(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(vue@3.5.35(typescript@5.9.3))
       '@verifactu/db':
         specifier: file:../../packages/db
         version: link:../../packages/db
@@ -986,6 +986,27 @@ importers:
         version: 20.19.30
       typescript:
         specifier: ^5.3.3
+        version: 5.9.3
+
+  packages/sdk:
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.12
+        version: 29.5.14
+      '@types/node':
+        specifier: ^20.11.0
+        version: 20.19.30
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@20.19.30)
+      ts-jest:
+        specifier: ^29.1.2
+        version: 29.4.11(@babel/core@7.28.6)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.6))(esbuild@0.27.7)(jest-util@30.2.0)(jest@29.7.0(@types/node@20.19.30))(typescript@5.9.3)
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(@swc/core@1.15.3(@swc/helpers@0.5.18))(jiti@2.6.1)(postcss@8.5.14)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4)
+      typescript:
+        specifier: ^5.4.0
         version: 5.9.3
 
   packages/typescript-config: {}
@@ -2867,9 +2888,22 @@ packages:
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
 
+  '@jest/console@29.7.0':
+    resolution: {integrity: sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   '@jest/console@30.2.0':
     resolution: {integrity: sha512-+O1ifRjkvYIkBqASKWgLxrpEhQAAE7hY77ALLUufSk5717KfOShg6IbqLmdsLMPdUiFvA2kTs0R7YZy+l0IzZQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/core@29.7.0':
+    resolution: {integrity: sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
 
   '@jest/core@30.2.0':
     resolution: {integrity: sha512-03W6IhuhjqTlpzh/ojut/pDB2LPRygyWX8ExpgHtQA8H/3K7+1vKmcINx5UzeOX1se6YEsBsOHQ1CRzf3fOwTQ==}
@@ -2894,17 +2928,33 @@ packages:
       canvas:
         optional: true
 
+  '@jest/environment@29.7.0':
+    resolution: {integrity: sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   '@jest/environment@30.2.0':
     resolution: {integrity: sha512-/QPTL7OBJQ5ac09UDRa3EQes4gt1FTEG/8jZ/4v5IVzx+Cv7dLxlVIvfvSVRiiX2drWyXeBjkMSR8hvOWSog5g==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/expect-utils@29.7.0':
+    resolution: {integrity: sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   '@jest/expect-utils@30.2.0':
     resolution: {integrity: sha512-1JnRfhqpD8HGpOmQp180Fo9Zt69zNtC+9lR+kT7NVL05tNXIi+QC8Csz7lfidMoVLPD3FnOtcmp0CEFnxExGEA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  '@jest/expect@29.7.0':
+    resolution: {integrity: sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   '@jest/expect@30.2.0':
     resolution: {integrity: sha512-V9yxQK5erfzx99Sf+7LbhBwNWEZ9eZay8qQ9+JSC0TrMR1pMDHLMY+BnVPacWU6Jamrh252/IKo4F1Xn/zfiqA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/fake-timers@29.7.0':
+    resolution: {integrity: sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   '@jest/fake-timers@30.2.0':
     resolution: {integrity: sha512-HI3tRLjRxAbBy0VO8dqqm7Hb2mIa8d5bg/NJkyQcOk7V118ObQML8RC5luTF/Zsg4474a+gDvhce7eTnP4GhYw==}
@@ -2914,6 +2964,10 @@ packages:
     resolution: {integrity: sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  '@jest/globals@29.7.0':
+    resolution: {integrity: sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   '@jest/globals@30.2.0':
     resolution: {integrity: sha512-b63wmnKPaK+6ZZfpYhz9K61oybvbI1aMcIs80++JI1O1rR1vaxHUCNqo3ITu6NU0d4V34yZFoHMn/uoKr/Rwfw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -2921,6 +2975,15 @@ packages:
   '@jest/pattern@30.0.1':
     resolution: {integrity: sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/reporters@29.7.0':
+    resolution: {integrity: sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
 
   '@jest/reporters@30.2.0':
     resolution: {integrity: sha512-DRyW6baWPqKMa9CzeiBjHwjd8XeAyco2Vt8XbcLFjiwCOEKOvy82GJ8QQnJE9ofsxCMPjH4MfH8fCWIHHDKpAQ==}
@@ -2931,6 +2994,10 @@ packages:
       node-notifier:
         optional: true
 
+  '@jest/schemas@29.6.3':
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   '@jest/schemas@30.0.5':
     resolution: {integrity: sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -2939,21 +3006,41 @@ packages:
     resolution: {integrity: sha512-0aVxM3RH6DaiLcjj/b0KrIBZhSX1373Xci4l3cW5xiUWPctZ59zQ7jj4rqcJQ/Z8JuN/4wX3FpJSa3RssVvCug==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  '@jest/source-map@29.6.3':
+    resolution: {integrity: sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   '@jest/source-map@30.0.1':
     resolution: {integrity: sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/test-result@29.7.0':
+    resolution: {integrity: sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   '@jest/test-result@30.2.0':
     resolution: {integrity: sha512-RF+Z+0CCHkARz5HT9mcQCBulb1wgCP3FBvl9VFokMX27acKphwyQsNuWH3c+ojd1LeWBLoTYoxF0zm6S/66mjg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  '@jest/test-sequencer@29.7.0':
+    resolution: {integrity: sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   '@jest/test-sequencer@30.2.0':
     resolution: {integrity: sha512-wXKgU/lk8fKXMu/l5Hog1R61bL4q5GCdT6OJvdAFz1P+QrpoFuLU68eoKuVc4RbrTtNnTL5FByhWdLgOPSph+Q==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  '@jest/transform@29.7.0':
+    resolution: {integrity: sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   '@jest/transform@30.2.0':
     resolution: {integrity: sha512-XsauDV82o5qXbhalKxD7p4TZYYdwcaEXC77PPD2HixEFF+6YGppjrAAQurTl2ECWcEomHBMMNS9AH3kcCFx8jA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/types@29.6.3':
+    resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   '@jest/types@30.2.0':
     resolution: {integrity: sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==}
@@ -3433,6 +3520,131 @@ packages:
       '@codemirror/state': ^6.0.0
       '@codemirror/view': ^6.0.0
 
+  '@rollup/rollup-android-arm-eabi@4.60.4':
+    resolution: {integrity: sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.4':
+    resolution: {integrity: sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.4':
+    resolution: {integrity: sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.4':
+    resolution: {integrity: sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.4':
+    resolution: {integrity: sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.4':
+    resolution: {integrity: sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
+    resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
+    resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.4':
+    resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.4':
+    resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.4':
+    resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.4':
+    resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
+    resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.4':
+    resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
+    resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.4':
+    resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.4':
+    resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.4':
+    resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.60.4':
+    resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.60.4':
+    resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.4':
+    resolution: {integrity: sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.4':
+    resolution: {integrity: sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.4':
+    resolution: {integrity: sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.4':
+    resolution: {integrity: sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.4':
+    resolution: {integrity: sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==}
+    cpu: [x64]
+    os: [win32]
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -3538,6 +3750,9 @@ packages:
   '@selderee/plugin-htmlparser2@0.11.0':
     resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
 
+  '@sinclair/typebox@0.27.10':
+    resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
+
   '@sinclair/typebox@0.34.48':
     resolution: {integrity: sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==}
 
@@ -3551,6 +3766,9 @@ packages:
 
   '@sinonjs/commons@3.0.1':
     resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
+
+  '@sinonjs/fake-timers@10.3.0':
+    resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
 
   '@sinonjs/fake-timers@13.0.5':
     resolution: {integrity: sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==}
@@ -4086,6 +4304,9 @@ packages:
   '@types/express@4.17.25':
     resolution: {integrity: sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==}
 
+  '@types/graceful-fs@4.1.9':
+    resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
+
   '@types/har-format@1.2.16':
     resolution: {integrity: sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==}
 
@@ -4106,6 +4327,9 @@ packages:
 
   '@types/istanbul-reports@3.0.4':
     resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
+
+  '@types/jest@29.5.14':
+    resolution: {integrity: sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==}
 
   '@types/jest@30.0.0':
     resolution: {integrity: sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==}
@@ -4940,15 +5164,29 @@ packages:
       react-native-b4a:
         optional: true
 
+  babel-jest@29.7.0:
+    resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      '@babel/core': ^7.8.0
+
   babel-jest@30.2.0:
     resolution: {integrity: sha512-0YiBEOxWqKkSQWL9nNGGEgndoeL0ZpWrbLMNL5u/Kaxrli3Eaxlt3ZtIDktEvXt4L/R9r3ODr2zKwGM/2BjxVw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
     peerDependencies:
       '@babel/core': ^7.11.0 || ^8.0.0-0
 
+  babel-plugin-istanbul@6.1.1:
+    resolution: {integrity: sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==}
+    engines: {node: '>=8'}
+
   babel-plugin-istanbul@7.0.1:
     resolution: {integrity: sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==}
     engines: {node: '>=12'}
+
+  babel-plugin-jest-hoist@29.6.3:
+    resolution: {integrity: sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   babel-plugin-jest-hoist@30.2.0:
     resolution: {integrity: sha512-ftzhzSGMUnOzcCXd6WHdBGMyuwy15Wnn0iyyWGKgBDLxf9/s5ABuraCSpBX2uG0jUg4rqJnxsLc5+oYBqoxVaA==}
@@ -4973,6 +5211,12 @@ packages:
     resolution: {integrity: sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==}
     peerDependencies:
       '@babel/core': ^7.0.0 || ^8.0.0-0
+
+  babel-preset-jest@29.6.3:
+    resolution: {integrity: sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      '@babel/core': ^7.0.0
 
   babel-preset-jest@30.2.0:
     resolution: {integrity: sha512-US4Z3NOieAQumwFnYdUWKvUKh8+YSnS/gB3t6YBiz0bskpu7Pine8pPCheNxlPEW4wnUkma2a94YuW2q3guvCQ==}
@@ -5077,6 +5321,10 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  bs-logger@0.2.6:
+    resolution: {integrity: sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==}
+    engines: {node: '>= 6'}
+
   bser@2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
 
@@ -5111,6 +5359,12 @@ packages:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
 
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
   byte-counter@0.1.0:
     resolution: {integrity: sha512-jheRLVMeUKrDBjVw2O5+k4EvR4t9wtxHL+bo/LxfkxsVeuGMy3a5SEGgXdAFA4FSzTrU8rQXQIrsZ3oBq5a0pQ==}
     engines: {node: '>=20'}
@@ -5126,6 +5380,10 @@ packages:
     peerDependenciesMeta:
       magicast:
         optional: true
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
 
   cacheable-lookup@7.0.0:
     resolution: {integrity: sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==}
@@ -5227,6 +5485,10 @@ packages:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
 
+  ci-info@3.9.0:
+    resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
+    engines: {node: '>=8'}
+
   ci-info@4.3.1:
     resolution: {integrity: sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==}
     engines: {node: '>=8'}
@@ -5236,6 +5498,9 @@ packages:
 
   citty@0.2.0:
     resolution: {integrity: sha512-8csy5IBFI2ex2hTVpaHN2j+LNE199AgiI7y4dMintrr8i0lQiFn+0AWMZrWdHKIgMOer65f8IThysYhoReqjWA==}
+
+  cjs-module-lexer@1.4.3:
+    resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
 
   cjs-module-lexer@2.2.0:
     resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
@@ -5439,6 +5704,11 @@ packages:
   crc32-stream@4.0.3:
     resolution: {integrity: sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==}
     engines: {node: '>= 10'}
+
+  create-jest@29.7.0:
+    resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
 
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
@@ -5711,6 +5981,10 @@ packages:
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+
+  diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   diff@8.0.3:
     resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
@@ -6121,6 +6395,14 @@ packages:
     resolution: {integrity: sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==}
     engines: {node: '>= 0.8.0'}
 
+  exit@0.1.2:
+    resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
+    engines: {node: '>= 0.8.0'}
+
+  expect@29.7.0:
+    resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   expect@30.2.0:
     resolution: {integrity: sha512-u/feCi0GPsI+988gU2FLcsHyAHTU0MX1Wg68NhAnN7z/+C5wqG+CY8J53N9ioe8RXgaoz0nBR/TYMf3AycUuPw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -6293,6 +6575,9 @@ packages:
 
   firebase@12.8.0:
     resolution: {integrity: sha512-S1tCIR3ENecee0tY2cfTHfMkXqkitHfbsvqpCtvsT0Zi9vDB7A4CodAjHfHCjVvu/XtGy1LHLjOasVcF10rCVw==}
+
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
 
   flairup@1.0.0:
     resolution: {integrity: sha512-IKlE+pNvL2R+kVL1kEhUYqRxVqeFnjiIvHWDMLFXNaqyUdFXQM2wte44EfMYJNHkW16X991t2Zg8apKkhv7OBA==}
@@ -6611,6 +6896,11 @@ packages:
   guess-json-indent@3.0.1:
     resolution: {integrity: sha512-LWZ3Vr8BG7DHE3TzPYFqkhjNRw4vYgFSsv2nfMuHklAlOfiy54/EwiDQuQfFVLxENCVv20wpbjfTayooQHrEhQ==}
     engines: {node: '>=18.18.0'}
+
+  handlebars@4.7.9:
+    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
+    engines: {node: '>=0.4.7'}
+    hasBin: true
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -7133,12 +7423,20 @@ packages:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
 
+  istanbul-lib-instrument@5.2.1:
+    resolution: {integrity: sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==}
+    engines: {node: '>=8'}
+
   istanbul-lib-instrument@6.0.3:
     resolution: {integrity: sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==}
     engines: {node: '>=10'}
 
   istanbul-lib-report@3.0.1:
     resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@4.0.1:
+    resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
 
   istanbul-lib-source-maps@5.0.6:
@@ -7165,13 +7463,31 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  jest-changed-files@29.7.0:
+    resolution: {integrity: sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   jest-changed-files@30.2.0:
     resolution: {integrity: sha512-L8lR1ChrRnSdfeOvTrwZMlnWV8G/LLjQ0nG9MBclwWZidA2N5FviRki0Bvh20WRMOX31/JYvzdqTJrk5oBdydQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  jest-circus@29.7.0:
+    resolution: {integrity: sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   jest-circus@30.2.0:
     resolution: {integrity: sha512-Fh0096NC3ZkFx05EP2OXCxJAREVxj1BcW/i6EWqqymcgYKWjyyDpral3fMxVcHXg6oZM7iULer9wGRFvfpl+Tg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-cli@29.7.0:
+    resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
 
   jest-cli@30.2.0:
     resolution: {integrity: sha512-Os9ukIvADX/A9sLt6Zse3+nmHtHaE6hqOsjQtNiugFTbKRHYIYtZXNGNK9NChseXy7djFPjndX1tL0sCTlfpAA==}
@@ -7181,6 +7497,18 @@ packages:
       node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
     peerDependenciesMeta:
       node-notifier:
+        optional: true
+
+  jest-config@29.7.0:
+    resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      '@types/node': '*'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      ts-node:
         optional: true
 
   jest-config@30.2.0:
@@ -7198,13 +7526,25 @@ packages:
       ts-node:
         optional: true
 
+  jest-diff@29.7.0:
+    resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   jest-diff@30.2.0:
     resolution: {integrity: sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  jest-docblock@29.7.0:
+    resolution: {integrity: sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   jest-docblock@30.2.0:
     resolution: {integrity: sha512-tR/FFgZKS1CXluOQzZvNH3+0z9jXr3ldGSD8bhyuxvlVUwbeLOGynkunvlTMxchC5urrKndYiwCFC0DLVjpOCA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-each@29.7.0:
+    resolution: {integrity: sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   jest-each@30.2.0:
     resolution: {integrity: sha512-lpWlJlM7bCUf1mfmuqTA8+j2lNURW9eNafOy99knBM01i5CQeY5UH1vZjgT9071nDJac1M4XsbyI44oNOdhlDQ==}
@@ -7219,25 +7559,53 @@ packages:
       canvas:
         optional: true
 
+  jest-environment-node@29.7.0:
+    resolution: {integrity: sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   jest-environment-node@30.2.0:
     resolution: {integrity: sha512-ElU8v92QJ9UrYsKrxDIKCxu6PfNj4Hdcktcn0JX12zqNdqWHB0N+hwOnnBBXvjLd2vApZtuLUGs1QSY+MsXoNA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-get-type@29.6.3:
+    resolution: {integrity: sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-haste-map@29.7.0:
+    resolution: {integrity: sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   jest-haste-map@30.2.0:
     resolution: {integrity: sha512-sQA/jCb9kNt+neM0anSj6eZhLZUIhQgwDt7cPGjumgLM4rXsfb9kpnlacmvZz3Q5tb80nS+oG/if+NBKrHC+Xw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  jest-leak-detector@29.7.0:
+    resolution: {integrity: sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   jest-leak-detector@30.2.0:
     resolution: {integrity: sha512-M6jKAjyzjHG0SrQgwhgZGy9hFazcudwCNovY/9HPIicmNSBuockPSedAP9vlPK6ONFJ1zfyH/M2/YYJxOz5cdQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-matcher-utils@29.7.0:
+    resolution: {integrity: sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   jest-matcher-utils@30.2.0:
     resolution: {integrity: sha512-dQ94Nq4dbzmUWkQ0ANAWS9tBRfqCrn0bV9AMYdOi/MHW726xn7eQmMeRTpX2ViC00bpNaWXq+7o4lIQ3AX13Hg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  jest-message-util@29.7.0:
+    resolution: {integrity: sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   jest-message-util@30.2.0:
     resolution: {integrity: sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-mock@29.7.0:
+    resolution: {integrity: sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   jest-mock@30.2.0:
     resolution: {integrity: sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==}
@@ -7252,45 +7620,95 @@ packages:
       jest-resolve:
         optional: true
 
+  jest-regex-util@29.6.3:
+    resolution: {integrity: sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   jest-regex-util@30.0.1:
     resolution: {integrity: sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-resolve-dependencies@29.7.0:
+    resolution: {integrity: sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   jest-resolve-dependencies@30.2.0:
     resolution: {integrity: sha512-xTOIGug/0RmIe3mmCqCT95yO0vj6JURrn1TKWlNbhiAefJRWINNPgwVkrVgt/YaerPzY3iItufd80v3lOrFJ2w==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  jest-resolve@29.7.0:
+    resolution: {integrity: sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   jest-resolve@30.2.0:
     resolution: {integrity: sha512-TCrHSxPlx3tBY3hWNtRQKbtgLhsXa1WmbJEqBlTBrGafd5fiQFByy2GNCEoGR+Tns8d15GaL9cxEzKOO3GEb2A==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-runner@29.7.0:
+    resolution: {integrity: sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   jest-runner@30.2.0:
     resolution: {integrity: sha512-PqvZ2B2XEyPEbclp+gV6KO/F1FIFSbIwewRgmROCMBo/aZ6J1w8Qypoj2pEOcg3G2HzLlaP6VUtvwCI8dM3oqQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  jest-runtime@29.7.0:
+    resolution: {integrity: sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   jest-runtime@30.2.0:
     resolution: {integrity: sha512-p1+GVX/PJqTucvsmERPMgCPvQJpFt4hFbM+VN3n8TMo47decMUcJbt+rgzwrEme0MQUA/R+1de2axftTHkKckg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-snapshot@29.7.0:
+    resolution: {integrity: sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   jest-snapshot@30.2.0:
     resolution: {integrity: sha512-5WEtTy2jXPFypadKNpbNkZ72puZCa6UjSr/7djeecHWOu7iYhSXSnHScT8wBz3Rn8Ena5d5RYRcsyKIeqG1IyA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  jest-util@29.7.0:
+    resolution: {integrity: sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   jest-util@30.2.0:
     resolution: {integrity: sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-validate@29.7.0:
+    resolution: {integrity: sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   jest-validate@30.2.0:
     resolution: {integrity: sha512-FBGWi7dP2hpdi8nBoWxSsLvBFewKAg0+uSQwBaof4Y4DPgBabXgpSYC5/lR7VmnIlSpASmCi/ntRWPbv7089Pw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  jest-watcher@29.7.0:
+    resolution: {integrity: sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   jest-watcher@30.2.0:
     resolution: {integrity: sha512-PYxa28dxJ9g777pGm/7PrbnMeA0Jr7osHP9bS7eJy9DuAjMgdGtxgf0uKMyoIsTWAkIbUW5hSDdJ3urmgXBqxg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  jest-worker@29.7.0:
+    resolution: {integrity: sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   jest-worker@30.2.0:
     resolution: {integrity: sha512-0Q4Uk8WF7BUwqXHuAjc23vmopWJw5WH7w2tqBoUOZpOjW/ZnR44GXXd1r82RvnmI2GZge3ivrYXk/BE2+VtW2g==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest@29.7.0:
+    resolution: {integrity: sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
 
   jest@30.2.0:
     resolution: {integrity: sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==}
@@ -7443,6 +7861,10 @@ packages:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
 
+  kleur@3.0.3:
+    resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
+    engines: {node: '>=6'}
+
   klona@2.0.6:
     resolution: {integrity: sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==}
     engines: {node: '>= 8'}
@@ -7506,6 +7928,10 @@ packages:
   load-esm@1.0.3:
     resolution: {integrity: sha512-v5xlu8eHD1+6r8EHTg6hfmO97LN8ugKtiXcy5e6oN72iD2r6u0RPfLl6fxM+7Wnh2ZRq15o0russMst44WauPA==}
     engines: {node: '>=13.2.0'}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
@@ -7573,6 +7999,9 @@ packages:
 
   lodash.isundefined@3.0.1:
     resolution: {integrity: sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA==}
+
+  lodash.memoize@4.1.2:
+    resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -7663,6 +8092,9 @@ packages:
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
+
+  make-error@1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
 
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
@@ -7999,6 +8431,9 @@ packages:
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  neo-async@2.6.2:
+    resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
   neverpanic@0.0.7:
     resolution: {integrity: sha512-GFRTSX2JAEATOCQYlyFkR+9FJPl0pD24toE1foqYAsL6aPLlRKn6L0UFOtJhZCxEbDv+SUsiW4AcPs9cIFwkFw==}
@@ -8575,6 +9010,10 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  pretty-format@29.7.0:
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   pretty-format@3.8.0:
     resolution: {integrity: sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==}
 
@@ -8600,6 +9039,10 @@ packages:
   process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
+
+  prompts@2.4.2:
+    resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
+    engines: {node: '>= 6'}
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -8635,6 +9078,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
   pure-rand@7.0.1:
     resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
@@ -8943,6 +9389,10 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  resolve.exports@2.0.3:
+    resolution: {integrity: sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==}
+    engines: {node: '>=10'}
+
   resolve@1.22.11:
     resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
     engines: {node: '>= 0.4'}
@@ -8990,6 +9440,11 @@ packages:
 
   rimraf@5.0.10:
     resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
+    hasBin: true
+
+  rollup@4.60.4:
+    resolution: {integrity: sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
   router@2.2.0:
@@ -9177,6 +9632,9 @@ packages:
   simple-update-notifier@2.0.0:
     resolution: {integrity: sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==}
     engines: {node: '>=10'}
+
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
@@ -9564,6 +10022,9 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyexec@1.0.2:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
     engines: {node: '>=18'}
@@ -9616,6 +10077,10 @@ packages:
   traverse@0.3.9:
     resolution: {integrity: sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==}
 
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
   trigram-utils@2.0.1:
     resolution: {integrity: sha512-nfWIXHEaB+HdyslAfMxSqWKDdmqY9I32jS7GnqpdWQnLH89r6A5sdk3fDVYqGAZ0CrT8ovAFSAo6HRiWcWNIGQ==}
 
@@ -9645,11 +10110,57 @@ packages:
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
+  ts-jest@29.4.11:
+    resolution: {integrity: sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==}
+    engines: {node: ^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@jest/transform': ^29.0.0 || ^30.0.0
+      '@jest/types': ^29.0.0 || ^30.0.0
+      babel-jest: ^29.0.0 || ^30.0.0
+      esbuild: '*'
+      jest: ^29.0.0 || ^30.0.0
+      jest-util: ^29.0.0 || ^30.0.0
+      typescript: '>=4.3 <7'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@jest/transform':
+        optional: true
+      '@jest/types':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
+      jest-util:
+        optional: true
+
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: 8.5.14
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
 
   tsx@4.21.0:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
@@ -9715,6 +10226,11 @@ packages:
 
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+
+  uglify-js@3.19.3:
+    resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
+    engines: {node: '>=0.8.0'}
+    hasBin: true
 
   uid@2.0.2:
     resolution: {integrity: sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==}
@@ -10048,6 +10564,10 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  write-file-atomic@4.0.2:
+    resolution: {integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
   write-file-atomic@5.0.1:
     resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
@@ -10488,7 +11008,7 @@ snapshots:
       '@babel/types': 7.28.6
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -10548,7 +11068,7 @@ snapshots:
       '@babel/core': 7.28.6
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       lodash.debounce: 4.0.8
       resolve: 1.22.11
     transitivePeerDependencies:
@@ -10561,7 +11081,7 @@ snapshots:
   '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
       '@babel/traverse': 7.28.6
-      '@babel/types': 7.28.6
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -10599,7 +11119,7 @@ snapshots:
 
   '@babel/helper-optimise-call-expression@7.27.1':
     dependencies:
-      '@babel/types': 7.28.6
+      '@babel/types': 7.29.7
 
   '@babel/helper-plugin-utils@7.28.6': {}
 
@@ -10644,7 +11164,7 @@ snapshots:
     dependencies:
       '@babel/template': 7.28.6
       '@babel/traverse': 7.28.6
-      '@babel/types': 7.28.6
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -11302,7 +11822,7 @@ snapshots:
       '@babel/parser': 7.28.6
       '@babel/template': 7.28.6
       '@babel/types': 7.28.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -11314,7 +11834,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -11659,7 +12179,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.14.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -11673,7 +12193,7 @@ snapshots:
   '@eslint/eslintrc@3.3.3':
     dependencies:
       ajv: 6.14.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -12164,7 +12684,7 @@ snapshots:
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
@@ -12301,6 +12821,15 @@ snapshots:
 
   '@istanbuljs/schema@0.1.3': {}
 
+  '@jest/console@29.7.0':
+    dependencies:
+      '@jest/types': 29.6.3
+      '@types/node': 20.19.30
+      chalk: 4.1.2
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
+      slash: 3.0.0
+
   '@jest/console@30.2.0':
     dependencies:
       '@jest/types': 30.2.0
@@ -12309,6 +12838,41 @@ snapshots:
       jest-message-util: 30.2.0
       jest-util: 30.2.0
       slash: 3.0.0
+
+  '@jest/core@29.7.0':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/reporters': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 20.19.30
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.7.0
+      jest-config: 29.7.0(@types/node@20.19.30)
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      jest-watcher: 29.7.0
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
 
   '@jest/core@30.2.0':
     dependencies:
@@ -12359,6 +12923,13 @@ snapshots:
       jest-util: 30.2.0
       jsdom: 26.1.0
 
+  '@jest/environment@29.7.0':
+    dependencies:
+      '@jest/fake-timers': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 20.19.30
+      jest-mock: 29.7.0
+
   '@jest/environment@30.2.0':
     dependencies:
       '@jest/fake-timers': 30.2.0
@@ -12366,9 +12937,20 @@ snapshots:
       '@types/node': 20.19.30
       jest-mock: 30.2.0
 
+  '@jest/expect-utils@29.7.0':
+    dependencies:
+      jest-get-type: 29.6.3
+
   '@jest/expect-utils@30.2.0':
     dependencies:
       '@jest/get-type': 30.1.0
+
+  '@jest/expect@29.7.0':
+    dependencies:
+      expect: 29.7.0
+      jest-snapshot: 29.7.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@jest/expect@30.2.0':
     dependencies:
@@ -12376,6 +12958,15 @@ snapshots:
       jest-snapshot: 30.2.0
     transitivePeerDependencies:
       - supports-color
+
+  '@jest/fake-timers@29.7.0':
+    dependencies:
+      '@jest/types': 29.6.3
+      '@sinonjs/fake-timers': 10.3.0
+      '@types/node': 20.19.30
+      jest-message-util: 29.7.0
+      jest-mock: 29.7.0
+      jest-util: 29.7.0
 
   '@jest/fake-timers@30.2.0':
     dependencies:
@@ -12387,6 +12978,15 @@ snapshots:
       jest-util: 30.2.0
 
   '@jest/get-type@30.1.0': {}
+
+  '@jest/globals@29.7.0':
+    dependencies:
+      '@jest/environment': 29.7.0
+      '@jest/expect': 29.7.0
+      '@jest/types': 29.6.3
+      jest-mock: 29.7.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@jest/globals@30.2.0':
     dependencies:
@@ -12401,6 +13001,35 @@ snapshots:
     dependencies:
       '@types/node': 20.19.30
       jest-regex-util: 30.0.1
+
+  '@jest/reporters@29.7.0':
+    dependencies:
+      '@bcoe/v8-coverage': 0.2.3
+      '@jest/console': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/node': 20.19.30
+      chalk: 4.1.2
+      collect-v8-coverage: 1.0.3
+      exit: 0.1.2
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-instrument: 6.0.3
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 4.0.1
+      istanbul-reports: 3.2.0
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
+      jest-worker: 29.7.0
+      slash: 3.0.0
+      string-length: 4.0.2
+      strip-ansi: 6.0.1
+      v8-to-istanbul: 9.3.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@jest/reporters@30.2.0':
     dependencies:
@@ -12430,6 +13059,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@jest/schemas@29.6.3':
+    dependencies:
+      '@sinclair/typebox': 0.27.10
+
   '@jest/schemas@30.0.5':
     dependencies:
       '@sinclair/typebox': 0.34.48
@@ -12441,11 +13074,24 @@ snapshots:
       graceful-fs: 4.2.11
       natural-compare: 1.4.0
 
+  '@jest/source-map@29.6.3':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      callsites: 3.1.0
+      graceful-fs: 4.2.11
+
   '@jest/source-map@30.0.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       callsites: 3.1.0
       graceful-fs: 4.2.11
+
+  '@jest/test-result@29.7.0':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/istanbul-lib-coverage': 2.0.6
+      collect-v8-coverage: 1.0.3
 
   '@jest/test-result@30.2.0':
     dependencies:
@@ -12454,12 +13100,39 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       collect-v8-coverage: 1.0.3
 
+  '@jest/test-sequencer@29.7.0':
+    dependencies:
+      '@jest/test-result': 29.7.0
+      graceful-fs: 4.2.11
+      jest-haste-map: 29.7.0
+      slash: 3.0.0
+
   '@jest/test-sequencer@30.2.0':
     dependencies:
       '@jest/test-result': 30.2.0
       graceful-fs: 4.2.11
       jest-haste-map: 30.2.0
       slash: 3.0.0
+
+  '@jest/transform@29.7.0':
+    dependencies:
+      '@babel/core': 7.28.6
+      '@jest/types': 29.6.3
+      '@jridgewell/trace-mapping': 0.3.31
+      babel-plugin-istanbul: 6.1.1
+      chalk: 4.1.2
+      convert-source-map: 2.0.0
+      fast-json-stable-stringify: 2.1.0
+      graceful-fs: 4.2.11
+      jest-haste-map: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-util: 29.7.0
+      micromatch: 4.0.8
+      pirates: 4.0.7
+      slash: 3.0.0
+      write-file-atomic: 4.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   '@jest/transform@30.2.0':
     dependencies:
@@ -12480,6 +13153,15 @@ snapshots:
       write-file-atomic: 5.0.1
     transitivePeerDependencies:
       - supports-color
+
+  '@jest/types@29.6.3':
+    dependencies:
+      '@jest/schemas': 29.6.3
+      '@types/istanbul-lib-coverage': 2.0.6
+      '@types/istanbul-reports': 3.0.4
+      '@types/node': 20.19.30
+      '@types/yargs': 17.0.35
+      chalk: 4.1.2
 
   '@jest/types@30.2.0':
     dependencies:
@@ -12572,7 +13254,7 @@ snapshots:
       nopt: 5.0.0
       npmlog: 5.0.1
       rimraf: 3.0.2
-      semver: 7.7.3
+      semver: 7.8.0
       tar: 7.5.12
     transitivePeerDependencies:
       - encoding
@@ -12709,7 +13391,7 @@ snapshots:
       tslib: 2.8.1
       uid: 2.0.2
 
-  '@next-auth/prisma-adapter@1.0.7(@prisma/client@5.22.0(prisma@5.22.0))(next-auth@4.24.13(next@15.5.18(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
+  '@next-auth/prisma-adapter@1.0.7(@prisma/client@5.22.0(prisma@5.22.0))(next-auth@4.24.13(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
     dependencies:
       '@prisma/client': 5.22.0(prisma@5.22.0)
       next-auth: 4.24.13(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -12937,7 +13619,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@18.3.27)(react@18.2.0)(redux@5.0.1))(react@18.2.0)':
+  '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@18.3.27)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@standard-schema/utils': 0.3.0
@@ -12954,6 +13636,81 @@ snapshots:
       '@codemirror/language': 6.12.3
       '@codemirror/state': 6.6.0
       '@codemirror/view': 6.43.0
+
+  '@rollup/rollup-android-arm-eabi@4.60.4':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.4':
+    optional: true
 
   '@rtsao/scc@1.1.0': {}
 
@@ -13294,6 +14051,8 @@ snapshots:
       domhandler: 5.0.3
       selderee: 0.11.0
 
+  '@sinclair/typebox@0.27.10': {}
+
   '@sinclair/typebox@0.34.48': {}
 
   '@sindresorhus/is@7.2.0': {}
@@ -13303,6 +14062,10 @@ snapshots:
   '@sinonjs/commons@3.0.1':
     dependencies:
       type-detect: 4.0.8
+
+  '@sinonjs/fake-timers@10.3.0':
+    dependencies:
+      '@sinonjs/commons': 3.0.1
 
   '@sinonjs/fake-timers@13.0.5':
     dependencies:
@@ -13799,7 +14562,7 @@ snapshots:
 
   '@testing-library/dom@10.4.1':
     dependencies:
-      '@babel/code-frame': 7.28.6
+      '@babel/code-frame': 7.29.7
       '@babel/runtime': 7.28.6
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
@@ -13829,7 +14592,7 @@ snapshots:
 
   '@tokenizer/inflate@0.4.1':
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       token-types: 6.1.2
     transitivePeerDependencies:
       - supports-color
@@ -13949,6 +14712,10 @@ snapshots:
       '@types/qs': 6.15.0
       '@types/serve-static': 1.15.10
 
+  '@types/graceful-fs@4.1.9':
+    dependencies:
+      '@types/node': 20.19.30
+
   '@types/har-format@1.2.16': {}
 
   '@types/hast@3.0.4':
@@ -13968,6 +14735,11 @@ snapshots:
   '@types/istanbul-reports@3.0.4':
     dependencies:
       '@types/istanbul-lib-report': 3.0.3
+
+  '@types/jest@29.5.14':
+    dependencies:
+      expect: 29.7.0
+      pretty-format: 29.7.0
 
   '@types/jest@30.0.0':
     dependencies:
@@ -14112,7 +14884,7 @@ snapshots:
       '@typescript-eslint/types': 8.53.1
       '@typescript-eslint/typescript-estree': 8.53.1(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.53.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       eslint: 8.57.1
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -14122,7 +14894,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.53.1(typescript@5.9.3)
       '@typescript-eslint/types': 8.53.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -14141,7 +14913,7 @@ snapshots:
       '@typescript-eslint/types': 8.53.1
       '@typescript-eslint/typescript-estree': 8.53.1(typescript@5.9.3)
       '@typescript-eslint/utils': 8.53.1(eslint@8.57.1)(typescript@5.9.3)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       eslint: 8.57.1
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -14156,9 +14928,9 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.53.1(typescript@5.9.3)
       '@typescript-eslint/types': 8.53.1
       '@typescript-eslint/visitor-keys': 8.53.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       minimatch: 9.0.9
-      semver: 7.7.3
+      semver: 7.8.0
       tinyglobby: 0.2.15
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -14248,7 +15020,7 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vercel/analytics@1.6.1(next@15.5.18(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(vue@3.5.35(typescript@5.9.3))':
+  '@vercel/analytics@1.6.1(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)(vue@3.5.35(typescript@5.9.3))':
     optionalDependencies:
       next: 15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
@@ -14290,7 +15062,7 @@ snapshots:
       - '@types/node'
       - prisma
 
-  '@verifactu/ui@file:packages/ui(@types/react@18.3.27)(next@15.5.18(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react-is@18.3.1)(react@18.2.0)':
+  '@verifactu/ui@file:packages/ui(@types/react@18.3.27)(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react-is@18.3.1)(react@18.2.0)':
     dependencies:
       '@verifactu/utils': file:packages/utils
       clsx: 2.1.1
@@ -14500,7 +15272,7 @@ snapshots:
       '@workflow/world': 4.1.0-beta.9(zod@4.3.6)
       '@workflow/world-local': 4.1.0-beta.37(@opentelemetry/api@1.9.0)
       '@workflow/world-vercel': 4.1.0-beta.38(@opentelemetry/api@1.9.0)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       devalue: 5.8.1
       ms: 2.1.3
       nanoid: 5.1.6
@@ -14533,7 +15305,7 @@ snapshots:
       - aws-crt
       - supports-color
 
-  '@workflow/next@4.0.1-beta.60(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.18)(next@15.5.18(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
+  '@workflow/next@4.0.1-beta.60(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.18)(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.18)
       '@workflow/builders': 4.0.1-beta.55(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.18)
@@ -14792,7 +15564,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -15068,6 +15840,19 @@ snapshots:
 
   b4a@1.8.1: {}
 
+  babel-jest@29.7.0(@babel/core@7.28.6):
+    dependencies:
+      '@babel/core': 7.28.6
+      '@jest/transform': 29.7.0
+      '@types/babel__core': 7.20.5
+      babel-plugin-istanbul: 6.1.1
+      babel-preset-jest: 29.6.3(@babel/core@7.28.6)
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   babel-jest@30.2.0(@babel/core@7.28.6):
     dependencies:
       '@babel/core': 7.28.6
@@ -15081,6 +15866,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  babel-plugin-istanbul@6.1.1:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.29.7
+      '@istanbuljs/load-nyc-config': 1.1.0
+      '@istanbuljs/schema': 0.1.3
+      istanbul-lib-instrument: 5.2.1
+      test-exclude: 6.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   babel-plugin-istanbul@7.0.1:
     dependencies:
       '@babel/helper-plugin-utils': 7.28.6
@@ -15090,6 +15885,13 @@ snapshots:
       test-exclude: 6.0.0
     transitivePeerDependencies:
       - supports-color
+
+  babel-plugin-jest-hoist@29.6.3:
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      '@types/babel__core': 7.20.5
+      '@types/babel__traverse': 7.28.0
 
   babel-plugin-jest-hoist@30.2.0:
     dependencies:
@@ -15137,6 +15939,12 @@ snapshots:
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.28.6)
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.28.6)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.28.6)
+
+  babel-preset-jest@29.6.3(@babel/core@7.28.6):
+    dependencies:
+      '@babel/core': 7.28.6
+      babel-plugin-jest-hoist: 29.6.3
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.6)
 
   babel-preset-jest@30.2.0(@babel/core@7.28.6):
     dependencies:
@@ -15215,7 +16023,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
@@ -15266,6 +16074,10 @@ snapshots:
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
+  bs-logger@0.2.6:
+    dependencies:
+      fast-json-stable-stringify: 2.1.0
+
   bser@2.1.1:
     dependencies:
       node-int64: 0.4.0
@@ -15296,6 +16108,11 @@ snapshots:
     dependencies:
       run-applescript: 7.1.0
 
+  bundle-require@5.1.0(esbuild@0.27.7):
+    dependencies:
+      esbuild: 0.27.7
+      load-tsconfig: 0.2.5
+
   byte-counter@0.1.0: {}
 
   bytes@3.1.2: {}
@@ -15314,6 +16131,8 @@ snapshots:
       perfect-debounce: 2.1.0
       pkg-types: 2.3.0
       rc9: 2.1.2
+
+  cac@6.7.14: {}
 
   cacheable-lookup@7.0.0: {}
 
@@ -15419,6 +16238,8 @@ snapshots:
 
   chownr@3.0.0: {}
 
+  ci-info@3.9.0: {}
+
   ci-info@4.3.1: {}
 
   citty@0.1.6:
@@ -15426,6 +16247,8 @@ snapshots:
       consola: 3.4.2
 
   citty@0.2.0: {}
+
+  cjs-module-lexer@1.4.3: {}
 
   cjs-module-lexer@2.2.0: {}
 
@@ -15586,6 +16409,21 @@ snapshots:
     dependencies:
       crc-32: 1.2.2
       readable-stream: 3.6.2
+
+  create-jest@29.7.0(@types/node@20.19.30):
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-config: 29.7.0(@types/node@20.19.30)
+      jest-util: 29.7.0
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
 
   crelt@1.0.6: {}
 
@@ -15821,6 +16659,8 @@ snapshots:
   dfa@1.2.0: {}
 
   didyoumean@1.2.2: {}
+
+  diff-sequences@29.6.3: {}
 
   diff@8.0.3: {}
 
@@ -16172,7 +17012,7 @@ snapshots:
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       eslint: 8.57.1
       get-tsconfig: 4.13.0
       is-bun-module: 2.0.0
@@ -16301,7 +17141,7 @@ snapshots:
       ajv: 6.14.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -16438,6 +17278,16 @@ snapshots:
 
   exit-x@0.2.2: {}
 
+  exit@0.1.2: {}
+
+  expect@29.7.0:
+    dependencies:
+      '@jest/expect-utils': 29.7.0
+      jest-get-type: 29.6.3
+      jest-matcher-utils: 29.7.0
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
+
   expect@30.2.0:
     dependencies:
       '@jest/expect-utils': 30.2.0
@@ -16501,7 +17351,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.0
       cookie-signature: 1.2.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -16666,7 +17516,7 @@ snapshots:
 
   finalhandler@2.1.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -16748,6 +17598,12 @@ snapshots:
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
 
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.0
+      rollup: 4.60.4
+
   flairup@1.0.0: {}
 
   flat-cache@3.2.0:
@@ -16770,7 +17626,7 @@ snapshots:
 
   follow-redirects@1.16.0(debug@4.4.3):
     optionalDependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
 
   fontkit@2.0.4:
     dependencies:
@@ -17157,6 +18013,15 @@ snapshots:
 
   guess-json-indent@3.0.1: {}
 
+  handlebars@4.7.9:
+    dependencies:
+      minimist: 1.2.8
+      neo-async: 2.6.2
+      source-map: 0.6.1
+      wordwrap: 1.0.0
+    optionalDependencies:
+      uglify-js: 3.19.3
+
   has-bigints@1.1.0: {}
 
   has-flag@3.0.0: {}
@@ -17399,7 +18264,7 @@ snapshots:
     dependencies:
       '@tootallnate/once': 3.0.1
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -17407,7 +18272,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -17419,14 +18284,14 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -17708,6 +18573,16 @@ snapshots:
 
   istanbul-lib-coverage@3.2.2: {}
 
+  istanbul-lib-instrument@5.2.1:
+    dependencies:
+      '@babel/core': 7.28.6
+      '@babel/parser': 7.29.7
+      '@istanbuljs/schema': 0.1.3
+      istanbul-lib-coverage: 3.2.2
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   istanbul-lib-instrument@6.0.3:
     dependencies:
       '@babel/core': 7.28.6
@@ -17724,10 +18599,18 @@ snapshots:
       make-dir: 4.0.0
       supports-color: 7.2.0
 
+  istanbul-lib-source-maps@4.0.1:
+    dependencies:
+      debug: 4.4.3(supports-color@5.5.0)
+      istanbul-lib-coverage: 3.2.2
+      source-map: 0.6.1
+    transitivePeerDependencies:
+      - supports-color
+
   istanbul-lib-source-maps@5.0.6:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
@@ -17760,11 +18643,43 @@ snapshots:
       filelist: 1.0.4
       picocolors: 1.1.1
 
+  jest-changed-files@29.7.0:
+    dependencies:
+      execa: 5.1.1
+      jest-util: 29.7.0
+      p-limit: 3.1.0
+
   jest-changed-files@30.2.0:
     dependencies:
       execa: 5.1.1
       jest-util: 30.2.0
       p-limit: 3.1.0
+
+  jest-circus@29.7.0:
+    dependencies:
+      '@jest/environment': 29.7.0
+      '@jest/expect': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 20.19.30
+      chalk: 4.1.2
+      co: 4.6.0
+      dedent: 1.7.1
+      is-generator-fn: 2.1.0
+      jest-each: 29.7.0
+      jest-matcher-utils: 29.7.0
+      jest-message-util: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      p-limit: 3.1.0
+      pretty-format: 29.7.0
+      pure-rand: 6.1.0
+      slash: 3.0.0
+      stack-utils: 2.0.6
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
 
   jest-circus@30.2.0:
     dependencies:
@@ -17791,6 +18706,25 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
+
+  jest-cli@29.7.0(@types/node@20.19.30):
+    dependencies:
+      '@jest/core': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@20.19.30)
+      exit: 0.1.2
+      import-local: 3.2.0
+      jest-config: 29.7.0(@types/node@20.19.30)
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
 
   jest-cli@30.2.0(@types/node@20.19.30):
     dependencies:
@@ -17829,6 +18763,36 @@ snapshots:
       - esbuild-register
       - supports-color
       - ts-node
+
+  jest-config@29.7.0(@types/node@20.19.30):
+    dependencies:
+      '@babel/core': 7.28.6
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.28.6)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 20.19.30
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
 
   jest-config@30.2.0(@types/node@20.19.30):
     dependencies:
@@ -17894,6 +18858,13 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
+  jest-diff@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      diff-sequences: 29.6.3
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
   jest-diff@30.2.0:
     dependencies:
       '@jest/diff-sequences': 30.0.1
@@ -17901,9 +18872,21 @@ snapshots:
       chalk: 4.1.2
       pretty-format: 30.2.0
 
+  jest-docblock@29.7.0:
+    dependencies:
+      detect-newline: 3.1.0
+
   jest-docblock@30.2.0:
     dependencies:
       detect-newline: 3.1.0
+
+  jest-each@29.7.0:
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      jest-get-type: 29.6.3
+      jest-util: 29.7.0
+      pretty-format: 29.7.0
 
   jest-each@30.2.0:
     dependencies:
@@ -17925,6 +18908,15 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  jest-environment-node@29.7.0:
+    dependencies:
+      '@jest/environment': 29.7.0
+      '@jest/fake-timers': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 20.19.30
+      jest-mock: 29.7.0
+      jest-util: 29.7.0
+
   jest-environment-node@30.2.0:
     dependencies:
       '@jest/environment': 30.2.0
@@ -17934,6 +18926,24 @@ snapshots:
       jest-mock: 30.2.0
       jest-util: 30.2.0
       jest-validate: 30.2.0
+
+  jest-get-type@29.6.3: {}
+
+  jest-haste-map@29.7.0:
+    dependencies:
+      '@jest/types': 29.6.3
+      '@types/graceful-fs': 4.1.9
+      '@types/node': 20.19.30
+      anymatch: 3.1.3
+      fb-watchman: 2.0.2
+      graceful-fs: 4.2.11
+      jest-regex-util: 29.6.3
+      jest-util: 29.7.0
+      jest-worker: 29.7.0
+      micromatch: 4.0.8
+      walker: 1.0.8
+    optionalDependencies:
+      fsevents: 2.3.3
 
   jest-haste-map@30.2.0:
     dependencies:
@@ -17950,10 +18960,22 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  jest-leak-detector@29.7.0:
+    dependencies:
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
   jest-leak-detector@30.2.0:
     dependencies:
       '@jest/get-type': 30.1.0
       pretty-format: 30.2.0
+
+  jest-matcher-utils@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      jest-diff: 29.7.0
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
 
   jest-matcher-utils@30.2.0:
     dependencies:
@@ -17961,6 +18983,18 @@ snapshots:
       chalk: 4.1.2
       jest-diff: 30.2.0
       pretty-format: 30.2.0
+
+  jest-message-util@29.7.0:
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@jest/types': 29.6.3
+      '@types/stack-utils': 2.0.3
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      stack-utils: 2.0.6
 
   jest-message-util@30.2.0:
     dependencies:
@@ -17974,17 +19008,36 @@ snapshots:
       slash: 3.0.0
       stack-utils: 2.0.6
 
+  jest-mock@29.7.0:
+    dependencies:
+      '@jest/types': 29.6.3
+      '@types/node': 20.19.30
+      jest-util: 29.7.0
+
   jest-mock@30.2.0:
     dependencies:
       '@jest/types': 30.2.0
       '@types/node': 20.19.30
       jest-util: 30.2.0
 
+  jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
+    optionalDependencies:
+      jest-resolve: 29.7.0
+
   jest-pnp-resolver@1.2.3(jest-resolve@30.2.0):
     optionalDependencies:
       jest-resolve: 30.2.0
 
+  jest-regex-util@29.6.3: {}
+
   jest-regex-util@30.0.1: {}
+
+  jest-resolve-dependencies@29.7.0:
+    dependencies:
+      jest-regex-util: 29.6.3
+      jest-snapshot: 29.7.0
+    transitivePeerDependencies:
+      - supports-color
 
   jest-resolve-dependencies@30.2.0:
     dependencies:
@@ -17992,6 +19045,18 @@ snapshots:
       jest-snapshot: 30.2.0
     transitivePeerDependencies:
       - supports-color
+
+  jest-resolve@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      jest-haste-map: 29.7.0
+      jest-pnp-resolver: 1.2.3(jest-resolve@29.7.0)
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      resolve: 1.22.11
+      resolve.exports: 2.0.3
+      slash: 3.0.0
 
   jest-resolve@30.2.0:
     dependencies:
@@ -18003,6 +19068,32 @@ snapshots:
       jest-validate: 30.2.0
       slash: 3.0.0
       unrs-resolver: 1.11.1
+
+  jest-runner@29.7.0:
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/environment': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 20.19.30
+      chalk: 4.1.2
+      emittery: 0.13.1
+      graceful-fs: 4.2.11
+      jest-docblock: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-haste-map: 29.7.0
+      jest-leak-detector: 29.7.0
+      jest-message-util: 29.7.0
+      jest-resolve: 29.7.0
+      jest-runtime: 29.7.0
+      jest-util: 29.7.0
+      jest-watcher: 29.7.0
+      jest-worker: 29.7.0
+      p-limit: 3.1.0
+      source-map-support: 0.5.13
+    transitivePeerDependencies:
+      - supports-color
 
   jest-runner@30.2.0:
     dependencies:
@@ -18028,6 +19119,33 @@ snapshots:
       jest-worker: 30.2.0
       p-limit: 3.1.0
       source-map-support: 0.5.13
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-runtime@29.7.0:
+    dependencies:
+      '@jest/environment': 29.7.0
+      '@jest/fake-timers': 29.7.0
+      '@jest/globals': 29.7.0
+      '@jest/source-map': 29.6.3
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 20.19.30
+      chalk: 4.1.2
+      cjs-module-lexer: 1.4.3
+      collect-v8-coverage: 1.0.3
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-mock: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      slash: 3.0.0
+      strip-bom: 4.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -18058,6 +19176,31 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  jest-snapshot@29.7.0:
+    dependencies:
+      '@babel/core': 7.28.6
+      '@babel/generator': 7.29.7
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.28.6)
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.28.6)
+      '@babel/types': 7.29.7
+      '@jest/expect-utils': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.6)
+      chalk: 4.1.2
+      expect: 29.7.0
+      graceful-fs: 4.2.11
+      jest-diff: 29.7.0
+      jest-get-type: 29.6.3
+      jest-matcher-utils: 29.7.0
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
+      natural-compare: 1.4.0
+      pretty-format: 29.7.0
+      semver: 7.8.0
+    transitivePeerDependencies:
+      - supports-color
+
   jest-snapshot@30.2.0:
     dependencies:
       '@babel/core': 7.28.6
@@ -18079,10 +19222,19 @@ snapshots:
       jest-message-util: 30.2.0
       jest-util: 30.2.0
       pretty-format: 30.2.0
-      semver: 7.7.3
+      semver: 7.8.0
       synckit: 0.11.12
     transitivePeerDependencies:
       - supports-color
+
+  jest-util@29.7.0:
+    dependencies:
+      '@jest/types': 29.6.3
+      '@types/node': 20.19.30
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      graceful-fs: 4.2.11
+      picomatch: 4.0.4
 
   jest-util@30.2.0:
     dependencies:
@@ -18093,6 +19245,15 @@ snapshots:
       graceful-fs: 4.2.11
       picomatch: 4.0.4
 
+  jest-validate@29.7.0:
+    dependencies:
+      '@jest/types': 29.6.3
+      camelcase: 6.3.0
+      chalk: 4.1.2
+      jest-get-type: 29.6.3
+      leven: 3.1.0
+      pretty-format: 29.7.0
+
   jest-validate@30.2.0:
     dependencies:
       '@jest/get-type': 30.1.0
@@ -18101,6 +19262,17 @@ snapshots:
       chalk: 4.1.2
       leven: 3.1.0
       pretty-format: 30.2.0
+
+  jest-watcher@29.7.0:
+    dependencies:
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 20.19.30
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      emittery: 0.13.1
+      jest-util: 29.7.0
+      string-length: 4.0.2
 
   jest-watcher@30.2.0:
     dependencies:
@@ -18113,6 +19285,13 @@ snapshots:
       jest-util: 30.2.0
       string-length: 4.0.2
 
+  jest-worker@29.7.0:
+    dependencies:
+      '@types/node': 20.19.30
+      jest-util: 29.7.0
+      merge-stream: 2.0.0
+      supports-color: 8.1.1
+
   jest-worker@30.2.0:
     dependencies:
       '@types/node': 20.19.30
@@ -18120,6 +19299,18 @@ snapshots:
       jest-util: 30.2.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
+
+  jest@29.7.0(@types/node@20.19.30):
+    dependencies:
+      '@jest/core': 29.7.0
+      '@jest/types': 29.6.3
+      import-local: 3.2.0
+      jest-cli: 29.7.0(@types/node@20.19.30)
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
 
   jest@30.2.0(@types/node@20.19.30):
     dependencies:
@@ -18265,7 +19456,7 @@ snapshots:
       lodash.isstring: 4.0.1
       lodash.once: 4.1.1
       ms: 2.1.3
-      semver: 7.7.3
+      semver: 7.8.0
 
   jsx-ast-utils@3.3.5:
     dependencies:
@@ -18290,7 +19481,7 @@ snapshots:
   jwks-rsa@3.2.2:
     dependencies:
       '@types/jsonwebtoken': 9.0.10
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       jose: 4.15.9
       limiter: 1.1.5
       lru-memoizer: 2.3.0
@@ -18311,6 +19502,8 @@ snapshots:
       '@keyv/serialize': 1.1.1
 
   kind-of@6.0.3: {}
+
+  kleur@3.0.3: {}
 
   klona@2.0.6: {}
 
@@ -18375,6 +19568,8 @@ snapshots:
 
   load-esm@1.0.3: {}
 
+  load-tsconfig@0.2.5: {}
+
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
@@ -18422,6 +19617,8 @@ snapshots:
   lodash.isstring@4.0.1: {}
 
   lodash.isundefined@3.0.1: {}
+
+  lodash.memoize@4.1.2: {}
 
   lodash.merge@4.6.2: {}
 
@@ -18520,6 +19717,8 @@ snapshots:
   make-dir@4.0.0:
     dependencies:
       semver: 7.8.0
+
+  make-error@1.3.6: {}
 
   makeerror@1.0.12:
     dependencies:
@@ -18874,7 +20073,7 @@ snapshots:
   micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.13
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -19031,6 +20230,8 @@ snapshots:
   negotiator@0.6.3: {}
 
   negotiator@1.0.0: {}
+
+  neo-async@2.6.2: {}
 
   neverpanic@0.0.7(typescript@5.9.3):
     dependencies:
@@ -19560,6 +20761,15 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.4
 
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.21.0)(yaml@2.8.4):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 2.6.1
+      postcss: 8.5.14
+      tsx: 4.21.0
+      yaml: 2.8.4
+
   postcss-nested@6.2.0(postcss@8.5.14):
     dependencies:
       postcss: 8.5.14
@@ -19607,6 +20817,12 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  pretty-format@29.7.0:
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
+
   pretty-format@3.8.0: {}
 
   pretty-format@30.2.0:
@@ -19630,6 +20846,11 @@ snapshots:
   process-warning@5.0.0: {}
 
   process@0.11.10: {}
+
+  prompts@2.4.2:
+    dependencies:
+      kleur: 3.0.3
+      sisteransi: 1.0.5
 
   prop-types@15.8.1:
     dependencies:
@@ -19676,6 +20897,8 @@ snapshots:
       once: 1.4.0
 
   punycode@2.3.1: {}
+
+  pure-rand@6.1.0: {}
 
   pure-rand@7.0.1: {}
 
@@ -19890,7 +21113,7 @@ snapshots:
 
   recharts@3.8.1(@types/react@18.3.27)(react-dom@18.2.0(react@18.2.0))(react-is@18.3.1)(react@18.2.0)(redux@5.0.1):
     dependencies:
-      '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@18.3.27)(react@18.2.0)(redux@5.0.1))(react@18.2.0)
+      '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@18.3.27)(react@18.2.0))(react@18.2.0)
       clsx: 2.1.1
       decimal.js-light: 2.5.1
       es-toolkit: 1.46.1
@@ -20079,6 +21302,8 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
+  resolve.exports@2.0.3: {}
+
   resolve@1.22.11:
     dependencies:
       is-core-module: 2.16.1
@@ -20131,9 +21356,40 @@ snapshots:
     dependencies:
       glob: 10.5.0
 
+  rollup@4.60.4:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.4
+      '@rollup/rollup-android-arm64': 4.60.4
+      '@rollup/rollup-darwin-arm64': 4.60.4
+      '@rollup/rollup-darwin-x64': 4.60.4
+      '@rollup/rollup-freebsd-arm64': 4.60.4
+      '@rollup/rollup-freebsd-x64': 4.60.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.4
+      '@rollup/rollup-linux-arm64-gnu': 4.60.4
+      '@rollup/rollup-linux-arm64-musl': 4.60.4
+      '@rollup/rollup-linux-loong64-gnu': 4.60.4
+      '@rollup/rollup-linux-loong64-musl': 4.60.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.4
+      '@rollup/rollup-linux-ppc64-musl': 4.60.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.4
+      '@rollup/rollup-linux-riscv64-musl': 4.60.4
+      '@rollup/rollup-linux-s390x-gnu': 4.60.4
+      '@rollup/rollup-linux-x64-gnu': 4.60.4
+      '@rollup/rollup-linux-x64-musl': 4.60.4
+      '@rollup/rollup-openbsd-x64': 4.60.4
+      '@rollup/rollup-openharmony-arm64': 4.60.4
+      '@rollup/rollup-win32-arm64-msvc': 4.60.4
+      '@rollup/rollup-win32-ia32-msvc': 4.60.4
+      '@rollup/rollup-win32-x64-gnu': 4.60.4
+      '@rollup/rollup-win32-x64-msvc': 4.60.4
+      fsevents: 2.3.3
+
   router@2.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -20242,7 +21498,7 @@ snapshots:
 
   send@1.2.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -20380,7 +21636,9 @@ snapshots:
 
   simple-update-notifier@2.0.0:
     dependencies:
-      semver: 7.7.3
+      semver: 7.8.0
+
+  sisteransi@1.0.5: {}
 
   slash@3.0.0: {}
 
@@ -20398,7 +21656,7 @@ snapshots:
     dependencies:
       axios: 1.16.0(debug@4.4.3)
       axios-ntlm: 1.4.6(debug@4.4.3)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       follow-redirects: 1.16.0(debug@4.4.3)
       formidable: 3.5.4
       sax: 1.6.0
@@ -20676,7 +21934,7 @@ snapshots:
     dependencies:
       component-emitter: 1.3.1
       cookiejar: 2.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       fast-safe-stringify: 2.1.1
       form-data: 4.0.5
       formidable: 3.5.4
@@ -20862,6 +22120,8 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinyexec@0.3.2: {}
+
   tinyexec@1.0.2: {}
 
   tinyglobby@0.2.15:
@@ -20905,6 +22165,8 @@ snapshots:
 
   traverse@0.3.9: {}
 
+  tree-kill@1.2.2: {}
+
   trigram-utils@2.0.1:
     dependencies:
       collapse-white-space: 2.1.0
@@ -20930,6 +22192,27 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
+  ts-jest@29.4.11(@babel/core@7.28.6)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.6))(esbuild@0.27.7)(jest-util@30.2.0)(jest@29.7.0(@types/node@20.19.30))(typescript@5.9.3):
+    dependencies:
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      handlebars: 4.7.9
+      jest: 29.7.0(@types/node@20.19.30)
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.8.0
+      type-fest: 4.41.0
+      typescript: 5.9.3
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.28.6
+      '@jest/transform': 30.2.0
+      '@jest/types': 30.2.0
+      babel-jest: 30.2.0(@babel/core@7.28.6)
+      esbuild: 0.27.7
+      jest-util: 30.2.0
+
   tsconfig-paths@3.15.0:
     dependencies:
       '@types/json5': 0.0.29
@@ -20938,6 +22221,35 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  tsup@8.5.1(@swc/core@1.15.3(@swc/helpers@0.5.18))(jiti@2.6.1)(postcss@8.5.14)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.7)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3(supports-color@5.5.0)
+      esbuild: 0.27.7
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.21.0)(yaml@2.8.4)
+      resolve-from: 5.0.0
+      rollup: 4.60.4
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+    optionalDependencies:
+      '@swc/core': 1.15.3(@swc/helpers@0.5.18)
+      postcss: 8.5.14
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
 
   tsx@4.21.0:
     dependencies:
@@ -21018,6 +22330,9 @@ snapshots:
   typescript@5.9.3: {}
 
   ufo@1.6.3: {}
+
+  uglify-js@3.19.3:
+    optional: true
 
   uid@2.0.2:
     dependencies:
@@ -21402,14 +22717,14 @@ snapshots:
 
   workerpool@9.3.4: {}
 
-  workflow@4.2.0-beta.64(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.18))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.18))(@swc/helpers@0.5.18)(next@15.5.18(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router@7.13.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.9.3):
+  workflow@4.2.0-beta.64(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.18))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.18))(@swc/helpers@0.5.18)(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router@7.13.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.9.3):
     dependencies:
       '@workflow/astro': 4.0.0-beta.38(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.18)
       '@workflow/cli': 4.2.0-beta.64(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.18)(react-router@7.13.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.9.3)
       '@workflow/core': 4.2.0-beta.64(@opentelemetry/api@1.9.0)
       '@workflow/errors': 4.1.0-beta.18
       '@workflow/nest': 0.0.0-beta.13(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.18))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.18))(@swc/helpers@0.5.18)
-      '@workflow/next': 4.0.1-beta.60(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.18)(next@15.5.18(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@workflow/next': 4.0.1-beta.60(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.18)(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       '@workflow/nitro': 4.0.1-beta.59(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.18)
       '@workflow/nuxt': 4.0.1-beta.48(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.18)
       '@workflow/rollup': 4.0.0-beta.21(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.18)
@@ -21456,6 +22771,11 @@ snapshots:
       strip-ansi: 7.1.2
 
   wrappy@1.0.2: {}
+
+  write-file-atomic@4.0.2:
+    dependencies:
+      imurmurhash: 0.1.4
+      signal-exit: 3.0.7
 
   write-file-atomic@5.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

Introduce el paquete `@verifactu/sdk` dentro del monorepo: un SDK TypeScript oficial para integrar contra la Isaak Platform API documentada en `/developers`.

- Cliente HTTP con auth Bearer (`isk_live_...` / `isk_test_...`), timeout configurable, retries con backoff exponencial + jitter, fetch inyectable.
- Recursos: `companies.getCurrent`, `invoices.list/get/create/issue/getPdf`, `keys.list/create`.
- Jerarquía tipada de errores (`AuthenticationError`, `PermissionError`, `NotFoundError`, `ConflictError`, `ConfirmationRequiredError`, `ValidationError`, `RateLimitError`, `ServerError`, `NetworkError`, `TimeoutError`) con factory `IsaakError.fromResponse`.
- `verifyWebhookSignature` HMAC-SHA256 cross-runtime (Web Crypto + fallback `node:crypto`) compatible con el formato `x-isaak-signature` / `x-isaak-timestamp` documentado.
- README con quickstart, ejemplos de listar / crear / emitir factura y verificar webhook, tabla de errores y matriz de runtimes.
- CHANGELOG con `0.1.0 - Unreleased`.

**Sin runtime dependencies** — solo `fetch`, `AbortController` y `crypto.subtle` globales. Compatible con Node 18+, Deno, Bun y Cloudflare Workers.

Esta PR es solo el skeleton: **no se publica a npm**. `pnpm publish` queda para una iteración posterior cuando madure el paquete.

## Test plan

- [x] `pnpm typecheck` (tsc --noEmit) pasa sin errores
- [x] `pnpm test` — 31 tests pasan (client × 9, retry × 9, webhooks × 13)
- [x] `pnpm build` — tsup ESM 16 KB + d.ts 15 KB, sin warnings
- [ ] Smoke-test manual contra `isaak.verifactu.business` con una API key real (pendiente — se hará tras merge, requiere clave válida)
- [ ] Validación de tipos contra el OpenAPI publicado en `/developers/api` (pendiente — requiere generador automático en una iteración posterior)

## Out of scope (siguientes iteraciones hasta v1.0)

- Publicación a npm + workflow de release.
- Cobertura completa del OpenAPI (contacts, banking, certificates, payments…).
- Generación automática de tipos desde el spec.
- Helpers para paginación auto-iterable (`for await`).
- Modo `dryRun` para previsualizar mutaciones sin enviar.