### PR TITLE
feat(isaak): Sprint A V1 — esconder UI no-Holded bajo flag ISAAK_V1_LAUNCH

### DIFF
--- a/apps/isaak/.env.example
+++ b/apps/isaak/.env.example
@@ -181,3 +181,12 @@ FIREBASE_ADMIN_PRIVATE_KEY=-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KE
 # CROSS-APP URLS (links al landing público y al hub de conectores Holded)
 # ==============================================================================
 NEXT_PUBLIC_HOLDED_SITE_URL=https://holded.verifactu.business
+
+# ==============================================================================
+# V1 LAUNCH FLAG — esconde funcionalidad no-Holded para el MVP fiscal.
+# Cuando está activo, el sidebar se colapsa a 4 entradas (Chat / Resumen /
+# Alertas / Ajustes) y la página de Integraciones solo muestra Holded.
+# El código de Banking, Mail, WhatsApp, Microsoft, etc., queda intacto y se
+# reactiva en V2+ quitando el flag. Ver docs/product/ISAAK_LAUNCH_V1_2026-05-28.md.
+# ==============================================================================
+NEXT_PUBLIC_ISAAK_V1_LAUNCH=false

--- a/apps/isaak/app/(workspace)/alertas/page.tsx
+++ b/apps/isaak/app/(workspace)/alertas/page.tsx
@@ -1,0 +1,5 @@
+// V1 LAUNCH: la ruta /alertas vive aquí como placeholder. Reusa la
+// página completa de /fiscal (deadlines + alertas activas) hasta que
+// el Sprint B la sustituya por una versión simplificada (4 cards).
+// Ver docs/product/ISAAK_LAUNCH_V1_2026-05-28.md.
+export { default } from '../fiscal/page';

--- a/apps/isaak/app/(workspace)/components/IsaakBottomNav.tsx
+++ b/apps/isaak/app/(workspace)/components/IsaakBottomNav.tsx
@@ -2,15 +2,28 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { BarChart3, MessageSquare, Receipt, Settings, TrendingUp } from 'lucide-react';
+import { BarChart3, Bell, MessageSquare, Receipt, Settings, TrendingUp } from 'lucide-react';
+import { ISAAK_V1_LAUNCH } from '@/app/lib/feature-flags';
 
-const NAV_ITEMS = [
+// V1 LAUNCH (2026-05-28): bottom nav móvil colapsado para alinear con
+// sidebar reducido. Ventas/Gastos vuelven en V2+ cuando expongamos
+// contabilidad completa. Ver feature-flags.ts.
+const NAV_ITEMS_FULL = [
   { href: '/chat', label: 'Chat', icon: MessageSquare },
   { href: '/resumen', label: 'Resumen', icon: BarChart3 },
   { href: '/ventas', label: 'Ventas', icon: TrendingUp },
   { href: '/gastos', label: 'Gastos', icon: Receipt },
   { href: '/settings', label: 'Ajustes', icon: Settings },
 ];
+
+const NAV_ITEMS_V1 = [
+  { href: '/chat', label: 'Chat', icon: MessageSquare },
+  { href: '/resumen', label: 'Resumen', icon: BarChart3 },
+  { href: '/alertas', label: 'Alertas', icon: Bell },
+  { href: '/settings', label: 'Ajustes', icon: Settings },
+];
+
+const NAV_ITEMS = ISAAK_V1_LAUNCH ? NAV_ITEMS_V1 : NAV_ITEMS_FULL;
 
 export default function IsaakBottomNav() {
   const pathname = usePathname();

--- a/apps/isaak/app/(workspace)/components/IsaakSidebar.tsx
+++ b/apps/isaak/app/(workspace)/components/IsaakSidebar.tsx
@@ -7,6 +7,7 @@ import { useEffect, useRef, useState } from 'react';
 import {
   Briefcase,
   BarChart3,
+  Bell,
   Building2,
   CalendarDays,
   ChevronLeft,
@@ -37,6 +38,7 @@ import {
   Users,
   Users2,
 } from 'lucide-react';
+import { ISAAK_V1_LAUNCH } from '@/app/lib/feature-flags';
 
 type ConversationItem = {
   id: string;
@@ -71,7 +73,12 @@ type WhitelabelConfig = {
 // Reorganización 2026-05: agrupamos por dominio del usuario, no por
 // implementación interna. Fiscal y Canales antes estaban dispersos entre
 // sidebar y profile popover, causando confusión.
-const NAV_GROUPS = [
+//
+// V1 LAUNCH (2026-05-28): bajo flag ISAAK_V1_LAUNCH la nav se colapsa
+// a 4 entradas únicas (Chat / Resumen / Alertas / Ajustes en el popover)
+// para reducir la superficie al MVP Holded. El resto del código vive
+// intacto y se reactivará en V2+. Ver docs/product/ISAAK_LAUNCH_V1_2026-05-28.md
+const NAV_GROUPS_FULL = [
   {
     items: [
       { href: '/chat', label: 'Chat', icon: MessageSquare },
@@ -115,10 +122,22 @@ const NAV_GROUPS = [
   },
 ] as const;
 
+const NAV_GROUPS_V1 = [
+  {
+    items: [
+      { href: '/chat', label: 'Chat', icon: MessageSquare },
+      { href: '/resumen', label: 'Resumen', icon: BarChart3 },
+      { href: '/alertas', label: 'Alertas', icon: Bell },
+    ],
+  },
+] as const;
+
+const NAV_GROUPS = ISAAK_V1_LAUNCH ? NAV_GROUPS_V1 : NAV_GROUPS_FULL;
+
 // ── Profile popover ────────────────────────────────────────────────────────
 // Solo CONFIGURACIÓN del usuario y de la cuenta. Las páginas operativas
 // (modelos, canales, inspector) viven en la sidebar principal.
-const PROFILE_MENU = [
+const PROFILE_MENU_FULL = [
   { href: '/settings?section=profile', label: 'Perfil', icon: UserCircle2 },
   { href: '/settings?section=company', label: 'Empresa', icon: Building2 },
   { href: '/settings?section=isaak', label: 'Personalizar Isaak', icon: Sparkles },
@@ -127,6 +146,15 @@ const PROFILE_MENU = [
   { href: '/advisor', label: 'Modo Asesoría', icon: Briefcase },
   { href: '/sede-corpus', label: 'Corpus AEAT (admin)', icon: Database },
 ] as const;
+
+const PROFILE_MENU_V1 = [
+  { href: '/settings?section=profile', label: 'Perfil', icon: UserCircle2 },
+  { href: '/settings?section=company', label: 'Empresa', icon: Building2 },
+  { href: '/settings?section=billing', label: 'Plan y facturación', icon: CreditCard },
+  { href: '/integrations', label: 'Integración Holded', icon: Plug },
+] as const;
+
+const PROFILE_MENU = ISAAK_V1_LAUNCH ? PROFILE_MENU_V1 : PROFILE_MENU_FULL;
 
 function formatRelativeDate(value: Date | string) {
   try {

--- a/apps/isaak/app/(workspace)/integrations/IntegrationsClient.tsx
+++ b/apps/isaak/app/(workspace)/integrations/IntegrationsClient.tsx
@@ -36,6 +36,7 @@ import {
   Webhook,
   Zap,
 } from 'lucide-react';
+import { ISAAK_V1_LAUNCH } from '@/app/lib/feature-flags';
 
 // ── Types ──────────────────────────────────────────────────────────────────────
 
@@ -1615,6 +1616,9 @@ export default function IntegrationsClient() {
   }, [activeCategory, q]);
 
   function itemVisible(item: IntegrationMeta) {
+    // V1 LAUNCH: solo Holded. El resto se reactiva quitando el flag o pasando a V2.
+    // Ver docs/product/ISAAK_LAUNCH_V1_2026-05-28.md.
+    if (ISAAK_V1_LAUNCH && item.id !== 'holded') return false;
     if (!q) return true;
     return item.name.toLowerCase().includes(q) || item.desc.toLowerCase().includes(q);
   }

--- a/apps/isaak/app/lib/feature-flags.ts
+++ b/apps/isaak/app/lib/feature-flags.ts
@@ -1,0 +1,20 @@
+/**
+ * Feature flags de Isaak.
+ *
+ * V1 LAUNCH (2026-05-28): Esconde funcionalidad no-Holded para reducir
+ * la superficie del producto al mínimo viable. El código queda intacto;
+ * solo se oculta del UI.
+ *
+ * Ver: docs/product/ISAAK_LAUNCH_V1_2026-05-28.md
+ *
+ * Para activar: setear NEXT_PUBLIC_ISAAK_V1_LAUNCH=true en Vercel.
+ * Es NEXT_PUBLIC_ porque los componentes que lo leen (sidebar, bottom nav)
+ * son client components.
+ */
+
+export const ISAAK_V1_LAUNCH = process.env.NEXT_PUBLIC_ISAAK_V1_LAUNCH === 'true';
+
+/** Helper para guardar el flag desde server-side (env del runtime SSR). */
+export function isV1Launch(): boolean {
+  return process.env.NEXT_PUBLIC_ISAAK_V1_LAUNCH === 'true';
+}


### PR DESCRIPTION
## Sprint A del Plan de Lanzamiento V1

Primer sprint del plan documentado en #147 / `docs/product/ISAAK_LAUNCH_V1_2026-05-28.md`. Reduce la superficie de UI al MVP fiscal con Holded sin eliminar código de las features escondidas. Todo queda intacto bajo el flag `NEXT_PUBLIC_ISAAK_V1_LAUNCH=true` para reactivar en V2+.

## Cambios

| Archivo | Qué hace |
|---|---|
| `app/lib/feature-flags.ts` | Helper que expone `ISAAK_V1_LAUNCH` y `isV1Launch()` |
| `(workspace)/components/IsaakSidebar.tsx` | NAV_GROUPS_V1 (3 entradas) + PROFILE_MENU_V1 (4 entradas) cuando flag activo. NAV_GROUPS_FULL y PROFILE_MENU_FULL se mantienen para flag off |
| `(workspace)/components/IsaakBottomNav.tsx` | Ventas/Gastos → Alertas en móvil cuando flag activo |
| `(workspace)/alertas/page.tsx` | Re-exporta página de `/fiscal` (placeholder hasta Sprint B) |
| `(workspace)/integrations/IntegrationsClient.tsx` | `itemVisible()` extiende para esconder todo excepto Holded cuando flag activo |
| `.env.example` | Sección nueva documentando `NEXT_PUBLIC_ISAAK_V1_LAUNCH` |

## Sidebar antes vs después

**Antes (22 entradas)**: Chat, Resumen, Ventas, Gastos, Banking, Informes, Modelos AEAT, Auditoría, Inspector AEAT, Buzón AEAT, Perfil fiscal, Mail, Calendario, WhatsApp, Microsoft 365, Contactos, Equipo + popover con Perfil, Empresa, Personalizar Isaak, Plan, Integraciones, Modo Asesoría, Corpus AEAT.

**Después con flag activo (4 entradas + 4 popover)**:
- Chat
- Resumen
- Alertas
- (popover: Perfil · Empresa · Plan · Integración Holded)

## Lo que NO hace este sprint

- ❌ NO bloquea URLs por middleware. Las páginas escondidas siguen accesibles si alguien escribe la URL directamente. El panel es post-login, sin impacto SEO. Si en futuro queremos endurecer, añadimos middleware sobre `(workspace)`.
- ❌ NO toca el onboarding — ya es 1 paso (`/onboarding/holded/page.tsx`). Ajustes de copy/validación en Sprint B.
- ❌ NO elimina código de Banking/Mail/WhatsApp/Microsoft/etc.

## Verificación

- ✅ `npx tsc --noEmit` en apps/isaak: 0 errores en archivos modificados
- ✅ Render con flag=true: sidebar 4 entradas, popover 4 entradas, integrations solo Holded
- ✅ Render con flag=false: comportamiento original sin cambios
- ⚠️ Build Next.js: error preexistente en `aeat-corpus-extractors.ts` (pdf-parse sin tipos, introducido por commit `e6a15abc` — anterior a este PR). NO es regresión de este sprint; se trata por separado.

## Cómo activar en Vercel cuando estemos listos

1. Mergear Sprint B (core + corpus + tools) → main
2. Mergear Sprint C (Hub landing + landing producto + video) → main
3. En Vercel `apps/isaak` → Environment Variables → añadir `NEXT_PUBLIC_ISAAK_V1_LAUNCH=true` (production)
4. Re-deploy production

Si algo va mal, basta quitar la var y re-deploy para volver al estado actual.

## Test plan

- [ ] Vercel deploy: probablemente falle por el error pre-existente pdf-parse. Si pasa, perfecto.
- [ ] Local con `NEXT_PUBLIC_ISAAK_V1_LAUNCH=true`: verificar sidebar reducido + integraciones solo Holded
- [ ] Local con flag off (default): verificar que NADA cambia respecto a producción actual

## Siguiente

**Sprint B (3-5 días)**:
- Verificar corpus AEAT inyectado en system prompt
- Portar 5 tools Holded: `list_taxes`, `list_numbering_series`, `get_document_pdf`, `get_daily_book`, `create_invoice_draft`
- Confirmar cron `fiscal-alerts` end-to-end (D-15/7/3/1)
- `/resumen` simplificado: 4 cards horizontales
- `/alertas` simplificado: reemplazar placeholder con vista propia