### PR TITLE
feat(isaak): Sprint B V1 — tools Holded ampliadas + páginas /resumen y /alertas simplificadas

### DIFF
--- a/apps/isaak/app/(workspace)/alertas/page.tsx
+++ b/apps/isaak/app/(workspace)/alertas/page.tsx
@@ -1,5 +1,223 @@
-// V1 LAUNCH: la ruta /alertas vive aquí como placeholder. Reusa la
-// página completa de /fiscal (deadlines + alertas activas) hasta que
-// el Sprint B la sustituya por una versión simplificada (4 cards).
+// V1 LAUNCH (2026-05-28) — Sprint B
+//
+// Página de alertas simplificada: solo próximos vencimientos AEAT y las
+// alertas enviadas por el cron `fiscal-alerts`. Reemplaza al placeholder
+// del Sprint A que reusaba `/fiscal`.
+//
+// Para flag off (V2+), `/fiscal` sigue siendo la página completa con
+// auditoría e inspector. En V1 ese contenido queda oculto.
+//
 // Ver docs/product/ISAAK_LAUNCH_V1_2026-05-28.md.
-export { default } from '../fiscal/page';
+
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Bell, CalendarDays, CheckCircle2, Clock, Loader2 } from 'lucide-react';
+
+type Deadline = {
+  id: string;
+  title: string;
+  modelo: string;
+  date: string;
+  daysUntil: number;
+  category: 'iva' | 'irpf' | 'is' | 'resumen_anual';
+  description: string;
+};
+
+type AlertRecord = {
+  id: string;
+  type: string;
+  title: string;
+  body: string | null;
+  dueDate: string | null;
+  channel: string;
+  status: string;
+  sentAt: string | null;
+  createdAt: string;
+  daysLeft: number | null;
+};
+
+type ApiResponse = {
+  deadlines: Deadline[];
+  alerts: AlertRecord[];
+};
+
+const CATEGORY_COLOR: Record<Deadline['category'], { bg: string; text: string; label: string }> = {
+  iva: { bg: 'bg-sky-100', text: 'text-sky-700', label: 'IVA' },
+  irpf: { bg: 'bg-amber-100', text: 'text-amber-700', label: 'IRPF' },
+  is: { bg: 'bg-violet-100', text: 'text-violet-700', label: 'Sociedades' },
+  resumen_anual: { bg: 'bg-slate-100', text: 'text-slate-700', label: 'Resumen' },
+};
+
+function urgencyClass(daysUntil: number): string {
+  if (daysUntil <= 3) return 'text-rose-600';
+  if (daysUntil <= 7) return 'text-amber-600';
+  return 'text-slate-600';
+}
+
+function formatRelDate(iso: string) {
+  try {
+    return new Date(iso).toLocaleDateString('es-ES', {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+export default function AlertasPage() {
+  const [data, setData] = useState<ApiResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch('/api/isaak/fiscal/alerts', { credentials: 'include' });
+        if (!res.ok) {
+          setError(`No se pudieron cargar las alertas (status ${res.status}).`);
+          return;
+        }
+        const json = (await res.json()) as ApiResponse;
+        if (!cancelled) setData(json);
+      } catch {
+        if (!cancelled) setError('Error de red al cargar alertas.');
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (error) {
+    return (
+      <div className="flex h-full flex-col">
+        <Header />
+        <div className="px-5 py-6 text-sm text-rose-600">{error}</div>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="flex h-full flex-col">
+        <Header />
+        <div className="flex items-center gap-2 px-5 py-8 text-sm text-slate-500">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Cargando alertas…
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col overflow-y-auto">
+      <Header />
+
+      <section className="px-5 py-5">
+        <SectionTitle icon={CalendarDays} title="Próximos vencimientos AEAT" />
+        {data.deadlines.length === 0 ? (
+          <EmptyState text="No hay vencimientos en los próximos 120 días." />
+        ) : (
+          <ul className="space-y-2">
+            {data.deadlines.slice(0, 8).map((d) => {
+              const cat = CATEGORY_COLOR[d.category];
+              return (
+                <li
+                  key={d.id}
+                  className="flex items-start gap-3 rounded-xl border border-slate-100 bg-white p-3 shadow-sm"
+                >
+                  <span
+                    className={`inline-flex items-center rounded-md px-2 py-0.5 text-[10px] font-semibold ${cat.bg} ${cat.text}`}
+                  >
+                    {cat.label} {d.modelo}
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <p className="text-[13px] font-semibold text-slate-800">{d.title}</p>
+                    <p className="mt-0.5 text-[11px] text-slate-500 line-clamp-2">{d.description}</p>
+                  </div>
+                  <div className="flex-shrink-0 text-right">
+                    <p className="text-[11px] text-slate-400">{formatRelDate(d.date)}</p>
+                    <p className={`text-[12px] font-semibold ${urgencyClass(d.daysUntil)}`}>
+                      {d.daysUntil === 0 ? 'Hoy' : `en ${d.daysUntil} d`}
+                    </p>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
+
+      <section className="px-5 py-5">
+        <SectionTitle icon={Bell} title="Alertas enviadas" />
+        {data.alerts.length === 0 ? (
+          <EmptyState text="Aún no hay alertas enviadas. Te avisaremos D-15, D-7, D-3 y D-1 antes de cada vencimiento." />
+        ) : (
+          <ul className="space-y-2">
+            {data.alerts.slice(0, 10).map((a) => (
+              <li
+                key={a.id}
+                className="flex items-start gap-3 rounded-xl border border-slate-100 bg-white p-3 shadow-sm"
+              >
+                <div className="mt-0.5">
+                  {a.status === 'sent' ? (
+                    <CheckCircle2 className="h-4 w-4 text-emerald-500" />
+                  ) : (
+                    <Clock className="h-4 w-4 text-amber-500" />
+                  )}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="text-[13px] font-semibold text-slate-800">{a.title}</p>
+                  {a.body && (
+                    <p className="mt-0.5 text-[11px] text-slate-500 line-clamp-2">{a.body}</p>
+                  )}
+                  <p className="mt-1 text-[10px] text-slate-400">
+                    {a.sentAt ? `Enviada ${formatRelDate(a.sentAt)}` : 'Programada'}
+                    {a.channel ? ` · ${a.channel}` : ''}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function Header() {
+  return (
+    <div className="border-b border-slate-100 bg-[#fafbff] px-5 py-4">
+      <h1 className="text-[16px] font-semibold text-[#011c67]">Alertas fiscales</h1>
+      <p className="text-[12px] text-slate-500">
+        Te avisamos automáticamente 15, 7, 3 y 1 días antes de cada vencimiento AEAT.
+      </p>
+    </div>
+  );
+}
+
+function SectionTitle({
+  icon: Icon,
+  title,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  title: string;
+}) {
+  return (
+    <h2 className="mb-3 flex items-center gap-1.5 text-[12px] font-semibold uppercase tracking-wider text-slate-500">
+      <Icon className="h-3.5 w-3.5" />
+      {title}
+    </h2>
+  );
+}
+
+function EmptyState({ text }: { text: string }) {
+  return (
+    <div className="rounded-xl border border-dashed border-slate-200 bg-slate-50 px-4 py-6 text-center">
+      <p className="text-[12px] text-slate-500">{text}</p>
+    </div>
+  );
+}

--- a/apps/isaak/app/(workspace)/resumen/page.tsx
+++ b/apps/isaak/app/(workspace)/resumen/page.tsx
@@ -18,6 +18,7 @@ import {
   loadIsaakWorkspaceSignals,
   type IsaakVerifactuSignal,
 } from '@/app/lib/isaak-workspace-signals';
+import { isV1Launch } from '@/app/lib/feature-flags';
 import { prisma } from '@/app/lib/prisma';
 import ResumenChart, { type MonthlyPoint } from './components/ResumenChart';
 import CashFlowChart, { type CashFlowPoint } from './components/CashFlowChart';
@@ -334,26 +335,37 @@ async function DashboardContent() {
   const hasChart =
     chartData.length > 0 && chartData.some((d) => d.sales > 0 || (d.expenses ?? 0) > 0);
 
+  // V1 LAUNCH: vista minimal. Solo el grid de 4 KPIs cards. Cash forecast,
+  // cash flow, banking warnings y los gráficos vuelven en V2+.
+  // Ver docs/product/ISAAK_LAUNCH_V1_2026-05-28.md.
+  const kpiGrid = (
+    <div className="grid grid-cols-2 gap-3 px-5 py-4 xl:grid-cols-4">
+      {displayKpis.map(({ icon: Icon, label, value, sub, color, bg }) => (
+        <div key={label} className="rounded-xl border border-slate-100 bg-white p-4 shadow-sm">
+          <div
+            className={`mb-2 inline-flex h-8 w-8 items-center justify-center rounded-lg ${bg}`}
+          >
+            <Icon size={16} className={color} />
+          </div>
+          <p className="text-[11px] font-medium text-slate-500">{label}</p>
+          <p
+            className={`mt-0.5 text-lg font-bold ${value === '—' ? 'text-slate-300' : 'text-slate-800'}`}
+          >
+            {value}
+          </p>
+          <p className="mt-1 text-[11px] text-slate-400">{sub}</p>
+        </div>
+      ))}
+    </div>
+  );
+
+  if (isV1Launch()) {
+    return kpiGrid;
+  }
+
   return (
     <>
-      <div className="grid grid-cols-2 gap-3 px-5 py-4 xl:grid-cols-4">
-        {displayKpis.map(({ icon: Icon, label, value, sub, color, bg }) => (
-          <div key={label} className="rounded-xl border border-slate-100 bg-white p-4 shadow-sm">
-            <div
-              className={`mb-2 inline-flex h-8 w-8 items-center justify-center rounded-lg ${bg}`}
-            >
-              <Icon size={16} className={color} />
-            </div>
-            <p className="text-[11px] font-medium text-slate-500">{label}</p>
-            <p
-              className={`mt-0.5 text-lg font-bold ${value === '—' ? 'text-slate-300' : 'text-slate-800'}`}
-            >
-              {value}
-            </p>
-            <p className="mt-1 text-[11px] text-slate-400">{sub}</p>
-          </div>
-        ))}
-      </div>
+      {kpiGrid}
 
       {/* ── Cash Forecast Widget ─────────────────────────────────────────── */}
       {cashForecast ? (

--- a/apps/isaak/app/lib/__tests__/inspector-aeat-bridge.test.ts
+++ b/apps/isaak/app/lib/__tests__/inspector-aeat-bridge.test.ts
@@ -6,7 +6,7 @@ import {
 
 describe('isInspectableWriteTool', () => {
   it('returns true for tools the bridge covers', () => {
-    expect(isInspectableWriteTool('holded_create_invoice')).toBe(true);
+    expect(isInspectableWriteTool('holded_create_invoice_draft')).toBe(true);
     expect(isInspectableWriteTool('isaak_ledger_create_entry')).toBe(true);
   });
 
@@ -22,10 +22,10 @@ describe('isInspectableWriteTool', () => {
   });
 });
 
-describe('toolUseToRuleContext — holded_create_invoice', () => {
+describe('toolUseToRuleContext — holded_create_invoice_draft', () => {
   it('aggregates items into amount/vatBase/vatAmount and firstTaxRate', () => {
     const ctx = toolUseToRuleContext({
-      toolName: 'holded_create_invoice',
+      toolName: 'holded_create_invoice_draft',
       toolInput: {
         contactId: 'c-1',
         items: [
@@ -50,7 +50,7 @@ describe('toolUseToRuleContext — holded_create_invoice', () => {
   it('returns null when no items are present', () => {
     expect(
       toolUseToRuleContext({
-        toolName: 'holded_create_invoice',
+        toolName: 'holded_create_invoice_draft',
         toolInput: { contactId: 'c-1', items: [] },
       }),
     ).toBeNull();
@@ -58,7 +58,7 @@ describe('toolUseToRuleContext — holded_create_invoice', () => {
 
   it('falls back to notes if no item names', () => {
     const ctx = toolUseToRuleContext({
-      toolName: 'holded_create_invoice',
+      toolName: 'holded_create_invoice_draft',
       toolInput: {
         contactId: 'c-1',
         items: [{ units: 1, subtotal: 100, tax: 21 }],
@@ -71,7 +71,7 @@ describe('toolUseToRuleContext — holded_create_invoice', () => {
 
   it('falls back to today when date is invalid', () => {
     const ctx = toolUseToRuleContext({
-      toolName: 'holded_create_invoice',
+      toolName: 'holded_create_invoice_draft',
       toolInput: {
         contactId: 'c-1',
         items: [{ name: 'x', units: 1, subtotal: 100, tax: 21 }],

--- a/apps/isaak/app/lib/__tests__/isaak-tools-registry.test.ts
+++ b/apps/isaak/app/lib/__tests__/isaak-tools-registry.test.ts
@@ -72,7 +72,7 @@ describe('buildReadOnlyToolsForContext', () => {
       ctx({ holdedConnected: true, holdedApiKey: 'sk-test' })
     );
     const names = tools.map((t) => t.name);
-    expect(names).not.toContain('holded_create_invoice');
+    expect(names).not.toContain('holded_create_invoice_draft');
     expect(names).not.toContain('holded_register_payment');
     expect(names).not.toContain('holded_create_contact');
     expect(names).not.toContain('holded_send_document');
@@ -149,7 +149,7 @@ describe('buildReadOnlyToolsForContext', () => {
 
   describe('writes (F4)', () => {
     it('isWriteToolName flags Holded write tools', () => {
-      expect(isWriteToolName('holded_create_invoice')).toBe(true);
+      expect(isWriteToolName('holded_create_invoice_draft')).toBe(true);
       expect(isWriteToolName('holded_register_payment')).toBe(true);
       expect(isWriteToolName('holded_create_contact')).toBe(true);
       expect(isWriteToolName('holded_send_document')).toBe(true);
@@ -166,7 +166,7 @@ describe('buildReadOnlyToolsForContext', () => {
         ctx({ holdedConnected: true, holdedApiKey: 'sk' })
       );
       const names = tools.map((t) => t.name);
-      expect(names).not.toContain('holded_create_invoice');
+      expect(names).not.toContain('holded_create_invoice_draft');
       expect(names).not.toContain('holded_register_payment');
     });
 
@@ -176,7 +176,7 @@ describe('buildReadOnlyToolsForContext', () => {
         { allowWrites: true }
       );
       const names = tools.map((t) => t.name);
-      expect(names).toContain('holded_create_invoice');
+      expect(names).toContain('holded_create_invoice_draft');
       expect(names).toContain('holded_register_payment');
       expect(names).toContain('holded_create_contact');
       expect(names).toContain('holded_send_document');
@@ -319,7 +319,7 @@ describe('buildReadOnlyToolsForContext', () => {
       const names = tools.map((t) => t.name);
       expect(names).toContain('isaak_ledger_create_entry');
       expect(names).toContain('isaak_ledger_import_holded');
-      expect(names).toContain('holded_create_invoice');
+      expect(names).toContain('holded_create_invoice_draft');
       expect(names).toContain('holded_list_documents');
     });
   });

--- a/apps/isaak/app/lib/holded-api.ts
+++ b/apps/isaak/app/lib/holded-api.ts
@@ -526,3 +526,101 @@ export async function holdedCreateContact(
     raw,
   };
 }
+
+// ─── V1 LAUNCH (2026-05-28) — tools nuevas ────────────────────────────────────
+//
+// Las siguientes funciones complementan el catálogo de tools para el lanzamiento
+// V1 (ver docs/product/ISAAK_LAUNCH_V1_2026-05-28.md). Cubren los huecos de
+// invoicing + contabilidad que necesitamos exponer al chat con Holded.
+
+/** Lista de impuestos (IVA, IRPF) configurados en el ERP. */
+export async function holdedListTaxes(apiKey: string) {
+  const raw = await holdedFetch(apiKey, '/api/invoicing/v1/taxes');
+  return Array.isArray(raw) ? raw : [];
+}
+
+/** Series de numeración para facturas y presupuestos. */
+export async function holdedListNumberingSeries(apiKey: string) {
+  // El endpoint base /numberingseries devuelve HTML; usamos los específicos
+  // por tipo, que sí devuelven JSON. Si Holded no tiene series configuradas
+  // usará la default automáticamente al crear documentos.
+  const [invoiceSeries, estimateSeries] = await Promise.all([
+    holdedFetch(apiKey, '/api/invoicing/v1/numberingseries/invoice').catch(() => []),
+    holdedFetch(apiKey, '/api/invoicing/v1/numberingseries/estimate').catch(() => []),
+  ]);
+  return [
+    ...(Array.isArray(invoiceSeries) ? invoiceSeries : []),
+    ...(Array.isArray(estimateSeries) ? estimateSeries : []),
+  ];
+}
+
+/**
+ * Devuelve el PDF de un documento Holded codificado en base64. Lo devolvemos
+ * como string para que la tool del chat pueda pasarlo directamente al modelo
+ * como `type: 'document'` content block.
+ */
+export async function holdedGetDocumentPdf(
+  apiKey: string,
+  docType: string,
+  documentId: string
+): Promise<{ base64: string; bytes: number }> {
+  const url = `${HOLDED_BASE}/api/invoicing/v1/documents/${docType}/${documentId}/pdf`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), HOLDED_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      headers: {
+        key: apiKey,
+        Accept: 'application/pdf,application/octet-stream,*/*',
+        'Accept-Encoding': 'identity',
+      },
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      throw new Error(`Holded API ${res.status} at /documents/${docType}/${documentId}/pdf`);
+    }
+    const buf = Buffer.from(await res.arrayBuffer());
+    return { base64: buf.toString('base64'), bytes: buf.byteLength };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Crea una factura en estado borrador (approveDoc: false). El usuario revisa
+ * y aprueba manualmente en Holded — Isaak NO emite a AEAT directamente.
+ * V1 reemplaza a holdedCreateInvoice como acción por defecto del chat.
+ */
+export async function holdedCreateInvoiceDraft(
+  apiKey: string,
+  params: CreateInvoiceParams
+): Promise<{ id: string; docNumber?: string; raw: unknown }> {
+  const payload: Record<string, unknown> = {
+    contactId: params.contactId,
+    date: params.date ?? Math.floor(Date.now() / 1000),
+    notes: params.notes ?? '',
+    currency: params.currency ?? 'EUR',
+    items: params.items.map((item) => ({
+      name: item.name,
+      units: item.units,
+      subtotal: item.subtotal,
+      tax: item.tax ?? 21,
+    })),
+    // approveDoc: false fuerza el documento a borrador a nivel de wire. NUNCA
+    // mover esta línea: si alguna llamada del modelo añadiera approveDoc:true
+    // por error, esto la sobrescribe.
+    approveDoc: false,
+  };
+
+  const raw = (await holdedPost(
+    apiKey,
+    '/api/invoicing/v1/documents/invoice',
+    payload
+  )) as Record<string, unknown>;
+
+  return {
+    id: String(raw?.id ?? raw?.docId ?? ''),
+    docNumber: raw?.docNumber as string | undefined,
+    raw,
+  };
+}

--- a/apps/isaak/app/lib/holded-tools.ts
+++ b/apps/isaak/app/lib/holded-tools.ts
@@ -2,23 +2,38 @@ import {
   holdedGetChartOfAccounts,
   holdedGetContact,
   holdedGetDocument,
+  holdedGetDocumentPdf,
   holdedGetJournal,
   holdedGetPnL,
   holdedGetVerifactuStatus,
   holdedListContacts,
   holdedListDocuments,
   holdedListEmployees,
+  holdedListNumberingSeries,
   holdedListPayments,
   holdedListProducts,
   holdedListProjects,
+  holdedListTaxes,
   holdedListTreasuryAccounts,
   holdedSendDocument,
-  holdedCreateInvoice,
+  holdedCreateInvoiceDraft,
   holdedRegisterPayment,
   holdedCreateContact,
 } from './holded-api';
 
-// Anthropic tool definitions for Isaak chat — 14 tools (10 lectura + 4 nuevas)
+// Anthropic tool definitions for Isaak chat.
+//
+// V1 LAUNCH (2026-05-28): 20 tools, todas centradas en invoicing + contabilidad.
+// CRM funnels, leads, stock, warehouses, time-records, project tasks quedan
+// fuera del MVP a propósito para no saturar el contexto del LLM.
+//
+// Cambios respecto a la versión previa:
+//   - holded_create_invoice → holded_create_invoice_draft (fuerza approveDoc=false)
+//   - + holded_list_taxes
+//   - + holded_list_numbering_series
+//   - + holded_get_document_pdf
+//
+// Ver docs/product/ISAAK_LAUNCH_V1_2026-05-28.md.
 export const HOLDED_CHAT_TOOLS = [
   {
     name: 'holded_list_documents',
@@ -104,7 +119,8 @@ export const HOLDED_CHAT_TOOLS = [
   },
   {
     name: 'holded_get_journal',
-    description: 'Devuelve asientos contables del libro diario de Holded en un rango de fechas.',
+    description:
+      'Devuelve asientos contables del libro diario (daily book) de Holded en un rango de fechas. Si el usuario pregunta por "libro diario", "diario contable" o "asientos del mes" responde con esta tool.',
     input_schema: {
       type: 'object',
       properties: {
@@ -198,9 +214,9 @@ export const HOLDED_CHAT_TOOLS = [
     },
   },
   {
-    name: 'holded_create_invoice',
+    name: 'holded_create_invoice_draft',
     description:
-      'Crea una factura de venta en Holded. IMPORTANTE: antes de ejecutar, muestra al usuario el resumen (cliente, líneas, importe total con IVA) y espera su confirmación explícita. Si no sabes el contactId, usa holded_list_contacts primero para buscarlo.',
+      'Crea una factura de venta en Holded en estado BORRADOR. El servidor fuerza approveDoc=false para que NUNCA se emita ni se firme automáticamente: el usuario debe aprobarla manualmente en Holded antes de que tenga efectos legales (Verifactu / AEAT). Antes de ejecutar, muestra al usuario el resumen (cliente, líneas, importe total con IVA) y espera su confirmación. Si no sabes el contactId, usa holded_list_contacts primero. Si necesitas el impuesto correcto del cliente, usa holded_list_taxes.',
     input_schema: {
       type: 'object',
       properties: {
@@ -235,6 +251,34 @@ export const HOLDED_CHAT_TOOLS = [
         },
       },
       required: ['contactId', 'items', 'confirmed'],
+    },
+  },
+  {
+    name: 'holded_list_taxes',
+    description:
+      'Lista los tipos de impuesto (IVA, IRPF, retenciones) configurados en el ERP del usuario. Úsalo cuando vayas a crear una factura y necesites saber qué porcentajes y nombres usar, o cuando el usuario pregunte qué impuestos aplica.',
+    input_schema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'holded_list_numbering_series',
+    description:
+      'Lista las series de numeración configuradas para facturas y presupuestos. Útil cuando el usuario emite documentos en varias series correlativas distintas (por sociedad, por delegación, etc.). Si la lista viene vacía, Holded usa una serie por defecto automáticamente.',
+    input_schema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'holded_get_document_pdf',
+    description:
+      'Devuelve el PDF de un documento de Holded (factura, presupuesto, abono) codificado en base64. Úsalo cuando el usuario te pida descargar o ver una factura concreta. Si el documentId no existe devuelve un error legible.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        docType: {
+          type: 'string',
+          enum: ['invoice', 'salesreceipt', 'creditnote', 'estimate', 'purchase', 'purchaseorder'],
+        },
+        documentId: { type: 'string', description: 'ID del documento en Holded.' },
+      },
+      required: ['docType', 'documentId'],
     },
   },
   {
@@ -428,12 +472,12 @@ export async function executeHoldedTool(
         });
       }
 
-      case 'holded_create_invoice': {
+      case 'holded_create_invoice_draft': {
         if (!input.confirmed) {
           return {
             error: 'confirmation_required',
             message:
-              'Esta acción requiere confirmación explícita. Muestra al usuario el resumen de la factura (cliente, líneas, total con IVA) y espera que confirme antes de proceder.',
+              'Esta acción requiere confirmación explícita. Muestra al usuario el resumen de la factura (cliente, líneas, total con IVA) y espera que confirme antes de proceder. La factura quedará en BORRADOR en Holded — el usuario la aprueba allí.',
           };
         }
         const contactId = String(input.contactId ?? '');
@@ -456,7 +500,7 @@ export async function executeHoldedTool(
         const dateUnix = input.date
           ? Math.floor(new Date(String(input.date)).getTime() / 1000)
           : Math.floor(Date.now() / 1000);
-        const result = await holdedCreateInvoice(apiKey, {
+        const result = await holdedCreateInvoiceDraft(apiKey, {
           contactId,
           date: dateUnix,
           notes: typeof input.notes === 'string' ? input.notes : undefined,
@@ -467,8 +511,39 @@ export async function executeHoldedTool(
           success: true,
           id: result.id,
           docNumber: result.docNumber,
-          message: `Factura ${result.docNumber ?? result.id} creada correctamente en Holded.`,
+          message: `Borrador de factura ${result.docNumber ?? result.id} creado en Holded. Apruébalo desde Holded para que tenga efectos legales (Verifactu / AEAT).`,
         };
+      }
+      case 'holded_list_taxes': {
+        const data = await holdedListTaxes(apiKey);
+        return { taxes: data };
+      }
+      case 'holded_list_numbering_series': {
+        const series = await holdedListNumberingSeries(apiKey);
+        if (series.length === 0) {
+          return {
+            series: [],
+            note: 'No hay series configuradas en Holded. Al crear documentos se usará la serie por defecto.',
+          };
+        }
+        return { series };
+      }
+      case 'holded_get_document_pdf': {
+        const docType = String(input.docType ?? 'invoice');
+        const documentId = String(input.documentId ?? '');
+        if (!documentId) {
+          return { error: 'invalid_input', message: 'Se requiere documentId.' };
+        }
+        try {
+          const { base64, bytes } = await holdedGetDocumentPdf(apiKey, docType, documentId);
+          return { base64, bytes, mimeType: 'application/pdf' };
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          if (msg.includes('404')) {
+            return { error: 'not_found', message: `Documento ${docType}/${documentId} no encontrado.` };
+          }
+          throw err;
+        }
       }
 
       case 'holded_register_payment': {

--- a/apps/isaak/app/lib/inspector-aeat-bridge.ts
+++ b/apps/isaak/app/lib/inspector-aeat-bridge.ts
@@ -90,7 +90,8 @@ export function toolUseToRuleContext(args: {
   const now = args.now ?? new Date();
   const input = (args.toolInput ?? {}) as Record<string, unknown>;
 
-  if (args.toolName === 'holded_create_invoice') {
+  // V1 LAUNCH: el tool se renombró a holded_create_invoice_draft.
+  if (args.toolName === 'holded_create_invoice_draft') {
     const items = Array.isArray(input.items)
       ? (input.items as HoldedInvoiceItem[])
       : [];
@@ -203,5 +204,5 @@ export const INSPECTOR_SKIPPED_TOOLS = new Set<string>([
 
 export function isInspectableWriteTool(toolName: string): boolean {
   if (INSPECTOR_SKIPPED_TOOLS.has(toolName)) return false;
-  return toolName === 'holded_create_invoice' || toolName === 'isaak_ledger_create_entry';
+  return toolName === 'holded_create_invoice_draft' || toolName === 'isaak_ledger_create_entry';
 }

--- a/apps/isaak/app/lib/isaak-sub-agents.ts
+++ b/apps/isaak/app/lib/isaak-sub-agents.ts
@@ -97,7 +97,7 @@ PRINCIPIOS (orden estricto):
 ESTILO: español claro, cercano, accionable. Listas con guiones cuando hay múltiples pasos. Sin tecnicismos contables salvo que el usuario los pida.
 
 ATAJOS HABITUALES:
-- "Factura X a Y por Z €" → invoke holded_create_invoice tras confirmación con concepto explícito
+- "Factura X a Y por Z €" → invoke holded_create_invoice_draft tras confirmación con concepto explícito (queda BORRADOR, el usuario aprueba en Holded)
 - "Recuérdale al cliente Y" → propón email con asunto y borrador; espera "sí" antes de holded_send_document
 - "¿Cuándo quedé con Z?" → busca en calendario por nombre + 30 días hacia adelante/atrás
 - "Mándame el PDF de la factura N" → holded_get_document + sugiere descarga

--- a/apps/isaak/app/lib/isaak-tools-registry.ts
+++ b/apps/isaak/app/lib/isaak-tools-registry.ts
@@ -38,7 +38,8 @@ const WRITE_TOOL_WEBHOOK_MAP: Partial<Record<string, IsaakWebhookEventType>> = {
 // block, or require user confirmation. Reads stay always-on for F2/F3.
 const WRITE_TOOL_NAMES = new Set<string>([
   // Holded write
-  'holded_create_invoice',
+  // V1 LAUNCH: create_invoice → create_invoice_draft (no emite, queda borrador).
+  'holded_create_invoice_draft',
   'holded_register_payment',
   'holded_create_contact',
   'holded_send_document',


### PR DESCRIPTION
## Sprint B del Plan de Lanzamiento V1

Segundo sprint del plan #147. **Base:** `claude/isaak-v1-sprint-a-IMiC1` (no main) porque depende de `feature-flags.ts` creado en #148.

## Cambios entregados

### B1 · Corpus AEAT (verificación)

Ya integrado en el system prompt via la tool `inspector_consult` (RAG sobre corpus AEAT/BOE + citas numeradas). Sin cambios.

### B2 + B3 · Tools Holded

**Nuevas helpers en `lib/holded-api.ts`**: `holdedListTaxes`, `holdedListNumberingSeries`, `holdedGetDocumentPdf` (binary→base64), `holdedCreateInvoiceDraft` (fuerza `approveDoc: false`).

**Catálogo V1 — 20 tools** (era 17):
- ✏️ `holded_create_invoice` → **`holded_create_invoice_draft`** (queda en borrador, usuario aprueba en Holded)
- ➕ `holded_list_taxes`
- ➕ `holded_list_numbering_series` (devuelve nota si vacío)
- ➕ `holded_get_document_pdf` (404 → `error: not_found`)
- 📝 `holded_get_journal` description ampliada a "libro diario / daily book"

Write-tool registry, inspector AEAT bridge, sub-agents prompt y 2 archivos de tests actualizados con el nuevo nombre. **37/37 tests verdes**.

### B5 · `/resumen` minimal

Bajo `isV1Launch()`, return temprano que deja **solo el grid de 4 KPI cards**. Cash forecast, cash flow chart, banking warnings y ResumenChart vuelven en V2+.

### B6 · `/alertas` con contenido propio

Reescrito (era placeholder Sprint A que re-exportaba `/fiscal`). Consume `/api/isaak/fiscal/alerts` y muestra:
1. Próximos vencimientos AEAT (máx 8) con categoría + días hasta vencer
2. Alertas enviadas (máx 10) con estado, body, canal

Sin gráficos, sin pestañas, sin auditoría.

## Lo que NO está aquí (Sprint C)

- **B4** cron `fiscal-alerts` E2E → verificación manual en smoke
- **B7** onboarding Holded copy → junto a landing
- **B8** Stripe products `isaak_pro_monthly` (29€) + `isaak_pro_annual` (290€) → junto a landing
- **B9** Trial 14 días sin tarjeta → junto a Stripe

## Verificación

- ✅ `npx tsc --noEmit`: 0 errores en archivos modificados
- ✅ 37/37 tests verdes (`inspector-aeat-bridge`, `isaak-tools-registry`)
- ✅ Sin cambios en `apps/holded-mcp` ni `apps/app/api/mcp`
- ✅ El identificador del modelo no aparece en commit ni código

## Orden de merge sugerido

1. Mergear #148 Sprint A → main
2. Cambiar base de este PR a main, re-pushear
3. Mergear este PR → main
4. Arrancar Sprint C

## Próximo sprint (C — 3-4 días)

Landing Hub (`verifactu.business` rediseño) + landing producto (`isaak.verifactu.business`) + Stripe products + trial 14d + video 60s + smoke E2E + activar flag en prod.