### PR TITLE
fix(isaak): desbloquear build Vercel — sectorConnected required + tipos pdf-parse

### DIFF
--- a/apps/isaak/app/lib/isaak-webhook-emitter.ts
+++ b/apps/isaak/app/lib/isaak-webhook-emitter.ts
@@ -138,7 +138,10 @@ export async function emitWebhookEvent(
           endpointId: ep.id,
           tenantId,
           eventType,
-          payload: payloadBase,
+          // Cast: payloadBase.data tiene tipo `unknown` (input genérico de
+          // la función). Prisma rechaza unknown en columnas JSON aunque en
+          // runtime acepta cualquier JSON-serializable. Safe cast.
+          payload: payloadBase as unknown as Prisma.InputJsonValue,
           status: 'pending',
           attempts: 0,
         },

--- a/apps/isaak/types/pdf-parse.d.ts
+++ b/apps/isaak/types/pdf-parse.d.ts
@@ -1,0 +1,20 @@
+// Minimal type stub for `pdf-parse` (no @types package exists upstream).
+// Used by app/lib/aeat-corpus-extractors.ts to extract text from AEAT manual PDFs.
+// Only the surface we actually call is typed; the rest stays `any`.
+declare module 'pdf-parse' {
+  type PdfParseOutput = {
+    text: string;
+    numpages: number;
+    info: Record<string, unknown>;
+    metadata: unknown;
+    version: string;
+  };
+
+  type PdfParseFn = (
+    data: Buffer | Uint8Array,
+    options?: Record<string, unknown>
+  ) => Promise<PdfParseOutput>;
+
+  const pdfParse: PdfParseFn;
+  export default pdfParse;
+}


### PR DESCRIPTION
## Urgente — Vercel build de apps/isaak falla en `main`

3 errores de typecheck introducidos por commits recientes ya en main hacen que cualquier PR contra apps/isaak (incluyendo Sprint A #148 y Sprint B #149) falle en Vercel.

Descubierto al revisar el deploy de PR #148:
```
Deployment has failed — apps/isaak
./app/lib/isaak-chat-context.ts:108:5
Type error: Property 'sectorConnected' is missing in type ... but required in type 'IsaakToolContext'.
```

## Los 3 errores y sus fixes

| Error | Causa | Fix |
|---|---|---|
| `sectorConnected` missing en `isaak-chat-context.ts:108` | Commit `3f2456c0` (sector LLM tools) hizo el campo required en el type pero no actualizó el loader principal | Añadir `sectorConnected: false` en el `toolContext` construido |
| `sectorConnected` missing en `tests/intelligence/golden/tool-use.test.ts:21` | Mismo commit, no actualizó este fixture | Añadir `sectorConnected: false` |
| `Cannot find declaration file for 'pdf-parse'` | Commit `e6a15abc` (PDF extractor AEAT) importa pdf-parse pero el paquete no publica tipos | Declaration file stub en `apps/isaak/types/pdf-parse.d.ts` |

## Verificación

- ✅ `npx tsc --noEmit`: 0 errores (era ≥ 3)
- ✅ `npx next build`: completa correctamente en local
- ✅ Sin cambios funcionales — solo tipos
- ✅ No toca handlers /api/mcp ni connectors

## Por qué este PR es prerequisito

Mergear este PR primero permite:
1. Que main vuelva a tener build Vercel verde
2. Que PR #148 (Sprint A V1) pueda mergearse sin fallar build
3. Que PR #149 (Sprint B V1) pueda mergearse sin fallar build

## Test plan

- [ ] Vercel deploy verde para isaak
- [ ] Mergear este PR primero
- [ ] Re-disparar checks en #148 y #149 (deberían pasar)