### PR TITLE
ci(isaak): setup golden tests — nightly + script local + docs

### DIFF
--- a/.github/workflows/golden-tests-nightly.yml
+++ b/.github/workflows/golden-tests-nightly.yml
@@ -1,0 +1,132 @@
+name: Golden Tests — Nightly
+
+# Corre la suite "golden" de Isaak (~41 tests E2E contra Anthropic Claude)
+# cada noche a las 03:00 UTC. Si algo regresa, abre un issue automáticamente.
+#
+# También se puede disparar manualmente desde la pestaña Actions del repo.
+#
+# Required secrets (Settings → Secrets and variables → Actions):
+#   ANTHROPIC_API_KEY_TESTS   — API key de Anthropic, separada de la de prod
+#                               (~$1.50/run, sugerencia: poner budget cap mensual)
+#
+# Optional secrets:
+#   OPENAI_API_KEY_TESTS      — para el LLM judge (gpt-4o-mini)
+#   ISAAK_GOLDEN_MODEL        — override modelo Anthropic (default: claude-sonnet-4-6)
+
+on:
+  schedule:
+    # 03:00 UTC = 04:00 / 05:00 hora peninsular según horario verano/invierno
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+    inputs:
+      category:
+        description: 'Categoría a correr (vacío = todas)'
+        type: choice
+        required: false
+        default: ''
+        options:
+          - ''
+          - 'tool-use'
+          - 'clarify'
+          - 'no-hallucination'
+          - 'multi-turn'
+          - 'sub-agent'
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  golden:
+    name: Run golden suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.27.0
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm --filter @verifactu/db exec prisma generate
+
+      - name: Run golden tests
+        id: tests
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY_TESTS }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY_TESTS }}
+          ISAAK_GOLDEN_LIVE: '1'
+          ISAAK_GOLDEN_MODEL: ${{ vars.ISAAK_GOLDEN_MODEL || '' }}
+          CATEGORY: ${{ inputs.category || '' }}
+        run: |
+          cd apps/isaak
+          if [ -n "$CATEGORY" ]; then
+            echo "Running category: $CATEGORY"
+            npx jest --config jest.config.mjs "tests/intelligence/golden/${CATEGORY}.test.ts" \
+              2>&1 | tee /tmp/golden-output.log
+          else
+            echo "Running full suite"
+            npx jest --config jest.config.mjs tests/intelligence/golden/ \
+              2>&1 | tee /tmp/golden-output.log
+          fi
+
+      - name: Upload test log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: golden-output-${{ github.run_id }}
+          path: /tmp/golden-output.log
+          retention-days: 14
+
+      - name: Open issue if tests failed
+        if: failure() && github.event_name == 'schedule'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            let log = '';
+            try {
+              log = fs.readFileSync('/tmp/golden-output.log', 'utf8');
+              // Capture failure summary — last ~80 lines should include the Jest summary
+              log = log.split('\n').slice(-80).join('\n');
+            } catch (e) {
+              log = `(no log file)`;
+            }
+            const date = new Date().toISOString().slice(0, 10);
+            const title = `Golden tests regressed — ${date}`;
+            const body = [
+              `Nightly golden tests fallaron en \`${context.sha.slice(0, 8)}\`.`,
+              ``,
+              `**Workflow run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              ``,
+              `<details><summary>Últimas líneas del log</summary>`,
+              ``,
+              '```',
+              log,
+              '```',
+              ``,
+              `</details>`,
+              ``,
+              `Investigar antes del próximo release V1.x / V2.0.`,
+            ].join('\n');
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: ['golden-tests', 'regression'],
+            });

--- a/apps/isaak/tests/intelligence/README.md
+++ b/apps/isaak/tests/intelligence/README.md
@@ -3,6 +3,20 @@
 Reference set of fixtures and tests that pin Isaak's chat behaviour as it
 evolves through F1 → F8 (see `docs/engineering/ISAAK_INTELLIGENCE.md`).
 
+Tests reales contra Anthropic Claude — **no mocks**. Skipped por defecto.
+
+## Qué cubren
+
+| Test                | Fixtures                | Qué valida                                                                          |
+| ------------------- | ----------------------- | ----------------------------------------------------------------------------------- |
+| `tool-use`          | `fixtures/tool-use/`    | Que Isaak elige las tools correctas según la pregunta                               |
+| `clarify`           | `clarify/`, `no-clarify/` | Pide aclaración cuando es ambiguo · NO la pide cuando es claro                    |
+| `no-hallucination`  | `no-hallucination/`     | NO inventa cifras cuando no tiene datos reales                                      |
+| `multi-turn`        | `multi-turn/`           | Mantiene contexto coherente entre turnos                                            |
+| `sub-agent`         | `sub-agent/`            | Delega correctamente a sub-agentes (inspector AEAT, ledger, etc.)                   |
+
+Total: **~41 fixtures · 5 test files**.
+
 ## Layout
 
 ```
@@ -12,6 +26,8 @@ tests/intelligence/
     no-clarify/          # precise queries → should answer
     no-hallucination/    # no grounding → should NOT invent
     multi-turn/          # context across turns
+    sub-agent/           # delegation to specialized sub-agents
+    tool-use/            # correct tool selection
   helpers/
     types.ts             # GoldenFixture schema
     load-fixtures.ts     # loads .json files by category
@@ -19,25 +35,108 @@ tests/intelligence/
     run-isaak.ts         # invokes callLLM with the prod system prompt
   golden/
     clarify.test.ts
-    no-hallucination.test.ts
     multi-turn.test.ts
+    no-hallucination.test.ts
+    sub-agent.test.ts
+    tool-use.test.ts
 ```
 
-## Running
+## Cómo correrlos
 
-Most assertions hit the real LLM and cost tokens. They're SKIPPED by
-default. The wiring tests always run (they verify fixtures exist).
+Por defecto están SKIPPED — los wiring tests siempre corren (verifican que
+los fixtures existen y son JSON válidos).
+
+### Setup
 
 ```bash
-# CI / fast: only wiring + lib unit tests
-npm test -- intelligence
+# 1. Setea la API key de Anthropic (primario)
+export ANTHROPIC_API_KEY="sk-ant-xxx"
 
-# Live: actually run fixtures against the LLM
-ISAAK_GOLDEN_LIVE=1 npm test -- intelligence
+# 2. Activa el modo live
+export ISAAK_GOLDEN_LIVE=1
+
+# 3. (Opcional) API key OpenAI para el LLM judge
+export OPENAI_API_KEY="sk-proj-xxx"
 ```
 
-Required env for live mode: `ANTHROPIC_API_KEY` (or `ISAAK_ANTHROPIC_API_KEY`)
-and `OPENAI_API_KEY` (for the judge).
+Aceptamos también `ISAAK_ANTHROPIC_API_KEY` o `ANTHROPIC_API_KEY_DEV`
+como alias (en este orden de prioridad).
+
+### Correr toda la suite
+
+```bash
+cd apps/isaak
+npx jest --config jest.config.mjs tests/intelligence/golden/
+```
+
+### Correr una sola categoría
+
+```bash
+# Solo tool-use
+npx jest --config jest.config.mjs tests/intelligence/golden/tool-use.test.ts
+
+# Solo clarify + no-hallucination
+npx jest --config jest.config.mjs --testPathPatterns="clarify|no-hallucination"
+```
+
+### Correr una sola fixture
+
+```bash
+npx jest --config jest.config.mjs --testNamePattern="ventas_top_clientes"
+```
+
+### Script helper (todo de una)
+
+Desde la raíz del monorepo:
+
+```bash
+ANTHROPIC_API_KEY=sk-ant-xxx node scripts/run-golden-tests.mjs
+```
+
+Setea `ISAAK_GOLDEN_LIVE=1` automáticamente e imprime un resumen al final
+con tasa de éxito por categoría.
+
+## Coste estimado
+
+- Modelo: `claude-sonnet-4-6` por defecto (override con `ISAAK_GOLDEN_MODEL`)
+- `max_tokens: 600`, `temperature: 0.45`
+- ~2-3 llamadas por test × ~41 tests × ~1.5k tokens cada
+- **≈ $1.50 USD por run completo** a precios Anthropic actuales
+
+Para reducir coste, corre solo la categoría que estés cambiando.
+
+## Cuándo correrlos
+
+- ✅ **Antes de cualquier cambio en system prompts** o sub-agent prompts
+- ✅ **Antes de cualquier cambio en `holded-tools.ts`** o `isaak-tools-registry.ts`
+- ✅ **Antes de un release V1.x o V2.0**
+- ✅ **Nightly automático** via `.github/workflows/golden-nightly.yml`
+- ❌ NO en cada commit (caro y lento)
+
+## Qué hacer si fallan
+
+Cada test imprime el output completo del LLM y el veredicto del judge.
+Razones más comunes:
+
+| Síntoma                                          | Probable causa                                                | Cómo investigar                                                                     |
+| ------------------------------------------------ | ------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| Tool incorrecta seleccionada                     | Cambio en descripciones de tools                              | Diff de `holded-tools.ts` reciente. Reformular descripción si es ambigua             |
+| Pide aclaración cuando no debería                | Sub-agent prompt nuevo muy estricto                           | Diff de `isaak-sub-agents.ts` o `isaak-chat-prompts.ts`                              |
+| Inventa cifras sin datos                         | Prompt deja de enfatizar "no inventes"                        | Asegurar que el system prompt incluye `NO HALLUCINATION` cláusula                    |
+| Pierde contexto multi-turn                       | Cambio en cómo se serializan los messages anteriores          | Diff de `isaak-chat-context.ts` o helper de mensajes                                 |
+| Sub-agent no se invoca                           | Cambio en la lógica de routing                                | Diff de `isaak-sub-agents.ts` (selector + descriptions)                              |
+
+Si una regresión es legítima (el comportamiento NUEVO es mejor que el
+viejo), actualiza el fixture con la respuesta esperada nueva.
+
+## CI nightly
+
+Workflow `.github/workflows/golden-nightly.yml` corre la suite completa
+todas las noches a las 03:00 UTC. Notifica si algo regresa.
+
+Requiere el secret `ANTHROPIC_API_KEY_TESTS` en Settings → Secrets →
+Actions del repo. Se recomienda una API key separada de la de producción
+para poder rotarla independientemente y poner un budget cap más bajo.
 
 ## Adding fixtures
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "video:outro": "node scripts/generate-outro-sora.mjs",
     "video:outro:tutorial": "node scripts/generate-outro-tutorial-sora.mjs",
     "video:build-demo": "node scripts/build-demo-video.mjs",
-    "video:youtube": "node scripts/build-youtube-videos.mjs"
+    "video:youtube": "node scripts/build-youtube-videos.mjs",
+    "test:golden": "node scripts/run-golden-tests.mjs"
   },
   "devDependencies": {
     "@next/env": "^16.1.1",

--- a/scripts/run-golden-tests.mjs
+++ b/scripts/run-golden-tests.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+//
+// run-golden-tests.mjs
+//
+// Helper para correr la suite "golden" de Isaak desde la raíz del monorepo
+// con una sola línea. Setea ISAAK_GOLDEN_LIVE=1 e imprime un resumen final
+// con la tasa de éxito por categoría.
+//
+// Uso:
+//   ANTHROPIC_API_KEY=sk-ant-xxx node scripts/run-golden-tests.mjs
+//
+//   # Solo una categoría:
+//   ANTHROPIC_API_KEY=... node scripts/run-golden-tests.mjs tool-use
+//
+//   # Override modelo:
+//   ANTHROPIC_API_KEY=... ISAAK_GOLDEN_MODEL=claude-haiku-4-5 \
+//     node scripts/run-golden-tests.mjs
+//
+// Coste estimado: ~$1.50 USD por suite completa. Ver
+// apps/isaak/tests/intelligence/README.md para detalle.
+
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..');
+
+const VALID_CATEGORIES = ['tool-use', 'clarify', 'no-hallucination', 'multi-turn', 'sub-agent'];
+
+function usage() {
+  console.log('Usage: ANTHROPIC_API_KEY=sk-ant-... node scripts/run-golden-tests.mjs [category]');
+  console.log('');
+  console.log(`Valid categories: ${VALID_CATEGORIES.join(', ')}`);
+  console.log('Omit category to run all.');
+}
+
+function preflight() {
+  const apiKey =
+    process.env.ANTHROPIC_API_KEY ||
+    process.env.ISAAK_ANTHROPIC_API_KEY ||
+    process.env.ANTHROPIC_API_KEY_DEV;
+  if (!apiKey) {
+    console.error('✗ Missing ANTHROPIC_API_KEY (or ISAAK_ANTHROPIC_API_KEY / ANTHROPIC_API_KEY_DEV).');
+    console.error('');
+    usage();
+    process.exit(2);
+  }
+  return apiKey;
+}
+
+const category = process.argv[2]?.trim() || '';
+if (category === '-h' || category === '--help') {
+  usage();
+  process.exit(0);
+}
+if (category && !VALID_CATEGORIES.includes(category)) {
+  console.error(`✗ Unknown category: "${category}".`);
+  console.error('');
+  usage();
+  process.exit(2);
+}
+
+const apiKey = preflight();
+
+const testPath = category
+  ? `tests/intelligence/golden/${category}.test.ts`
+  : 'tests/intelligence/golden/';
+
+console.log('━'.repeat(60));
+console.log(`Isaak golden tests — ${category || 'all categories'}`);
+console.log(`Model: ${process.env.ISAAK_GOLDEN_MODEL || 'claude-sonnet-4-6 (default)'}`);
+console.log('━'.repeat(60));
+console.log('');
+
+const args = [
+  'jest',
+  '--config',
+  'jest.config.mjs',
+  testPath,
+  '--verbose',
+];
+
+const startTs = Date.now();
+
+const child = spawn('npx', args, {
+  cwd: join(ROOT, 'apps/isaak'),
+  env: {
+    ...process.env,
+    ANTHROPIC_API_KEY: apiKey,
+    ISAAK_ANTHROPIC_API_KEY: apiKey,
+    ISAAK_GOLDEN_LIVE: '1',
+  },
+  stdio: 'inherit',
+});
+
+child.on('exit', (code) => {
+  const elapsedSec = ((Date.now() - startTs) / 1000).toFixed(1);
+  console.log('');
+  console.log('━'.repeat(60));
+  console.log(`Done in ${elapsedSec}s · exit code ${code}`);
+  if (code !== 0) {
+    console.log('');
+    console.log('Algunos tests fallaron. Investiga:');
+    console.log('  1. Cambios recientes en system prompts o tool descriptions');
+    console.log('  2. Diff vs último commit que pasaba la suite');
+    console.log('  3. Si el comportamiento NUEVO es correcto, actualiza el fixture');
+    console.log('');
+    console.log('Ver apps/isaak/tests/intelligence/README.md');
+  }
+  console.log('━'.repeat(60));
+  process.exit(code ?? 1);
+});


### PR DESCRIPTION
## Setup completo de golden tests

Cierra el ciclo de los **~41 tests de inteligencia** que validan el comportamiento real de Isaak contra Anthropic Claude. Hasta ahora skipped por defecto y sin documentar para uso operativo.

## Cambios

### 1. `.github/workflows/golden-tests-nightly.yml`

Corre la suite completa cada noche a las **03:00 UTC**. Si algo regresa, abre issue automático con label `golden-tests` + `regression` y las últimas 80 líneas del log.

También dispatchable manual con dropdown de categoría (tool-use / clarify / no-hallucination / multi-turn / sub-agent).

### 2. `scripts/run-golden-tests.mjs`

Helper local para correrlos con una sola línea:

```bash
ANTHROPIC_API_KEY=sk-ant-xxx node scripts/run-golden-tests.mjs
ANTHROPIC_API_KEY=sk-ant-xxx node scripts/run-golden-tests.mjs tool-use
```

Alias en package.json: `pnpm test:golden` o `pnpm test:golden tool-use`.

### 3. README expandido: `apps/isaak/tests/intelligence/README.md`

De 49 líneas básicas a documentación operativa completa:
- Tabla de las 5 categorías
- Setup paso a paso
- Comandos suite completa / categoría / fixture individual
- Coste: ~$1.50 USD/run completo
- Cuándo correrlos
- Troubleshooting por síntoma → causa → cómo investigar

## Coste estimado

- Modelo: `claude-sonnet-4-6` (override con `ISAAK_GOLDEN_MODEL`)
- ~$1.50 USD por run completo
- Nightly = ~$45/mes

**Recomendación**: poner budget cap mensual en la cuenta Anthropic asociada al `ANTHROPIC_API_KEY_TESTS` para evitar sustos.

## Verificación

- ✅ `node scripts/run-golden-tests.mjs --help` funciona
- ✅ Workflow YAML válido (GitHub Actions estándar)
- ✅ `npx tsc --noEmit` en apps/isaak: 0 errores
- ✅ Sin tocar `/api/mcp` ni connectors

## Setup en GitHub (post-merge)

1. Settings → Secrets and variables → Actions → New repository secret:
   - Name: `ANTHROPIC_API_KEY_TESTS`
   - Value: una API key Anthropic dedicada (no la de producción)
   - Recomendable: budget cap $50/mes en la cuenta Anthropic

2. (Opcional) `OPENAI_API_KEY_TESTS` para el LLM judge gpt-4o-mini

3. (Opcional) Variable `ISAAK_GOLDEN_MODEL` para override del modelo

4. Disparar el workflow manualmente desde la pestaña Actions para sanity check

## Test plan

- [ ] Vercel deploy verde
- [ ] Setear `ANTHROPIC_API_KEY_TESTS` en GitHub Secrets
- [ ] Trigger manual del workflow desde Actions tab
- [ ] Confirmar que las 41 tests pasan (o investigar las que fallen)
- [ ] Confirmar que el nightly arranca a las 03:00 UTC del día siguiente