### PR TITLE
fix(ci): pnpm/action-setup detecta versión desde package.json

### DIFF
--- a/.github/workflows/golden-tests-nightly.yml
+++ b/.github/workflows/golden-tests-nightly.yml
@@ -45,10 +45,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Detecta versión de pnpm desde `packageManager` en package.json
+      # (evita conflicto con la versión fijada en el monorepo).
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.27.0
           run_install: false
 
       - name: Setup Node
@@ -57,8 +58,10 @@ jobs:
           node-version: 20
           cache: 'pnpm'
 
+      # --no-frozen-lockfile porque main puede tener commits que avancen el
+      # lock antes de que el bot pueda actualizarlo (igual que Vercel).
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --no-frozen-lockfile
 
       - name: Generate Prisma client
         run: pnpm --filter @verifactu/db exec prisma generate


### PR DESCRIPTION
Pequeño fix al workflow de golden tests. El primer run falló porque pasamos `version: 10.27.0` cuando el monorepo ya define `packageManager` en package.json — pnpm/action-setup@v4 con ambos campos entra en conflicto.

Fix:
- Quitar `version:` y dejar que la action detecte automáticamente desde `packageManager`
- Cambiar a `--no-frozen-lockfile` para alinear con Vercel