### PR TITLE
feat(isaak): empty state Free → CTA Holded conectado

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@
 - IA: Anthropic Claude (primario) + OpenAI GPT (fallback automático)
 - Auth: Firebase Admin + cookies httpOnly de sesión
 - Email: Resend
-- Pagos: Stripe (4 planes: Free/Starter/Pro/Business)
+- Pagos: Stripe — **V1**: 2 planes (Free + Pro 29 €/mes · 290 €/año con 2 meses gratis). Trial Pro 14d sin tarjeta. Planes legacy (Starter 19/Pro 49/Business 149) archivados, clientes existentes mantienen su suscripción hasta cancelar.
 
 ## Integraciones operativas
 
@@ -36,7 +36,7 @@
 | Holded (ERP directo) | ✅ Producción | API key cifrada AES-256-GCM |
 | Google (Calendar/Gmail/Drive) | ✅ Producción | OAuth, 8 LLM tools |
 | Microsoft 365 (Outlook/Calendar/OneDrive) | ✅ Producción | OAuth multi-tenant, 9 LLM tools |
-| Stripe billing | ✅ Producción | 4 planes + portal cliente |
+| Stripe billing | ✅ Producción | **V1: 2 planes** (Free + Pro 29€/290€) · Trial 14d sin tarjeta · portal cliente · legacy archivados |
 | Verifactu (AEAT SOAP mTLS) | ✅ Producción | P12 → PEM-JSON cifrado |
 | Salt Edge (Open Banking) | ✅ Producción | Fallback no-PSD2 |
 | **Enable Banking (PSD2 AIS)** | ✅ Producción (2026-05-23) | App prod `73fbe5d2-b322-4d71-ba5d-223be78df437` |

--- a/apps/isaak/app/(workspace)/components/IsaakChatSection.tsx
+++ b/apps/isaak/app/(workspace)/components/IsaakChatSection.tsx
@@ -633,10 +633,10 @@ export default function IsaakChatSection({
             {!holdedConnected && (
               <button
                 type="button"
-                onClick={() => router.push('/integrations')}
+                onClick={() => router.push('/integration-holded')}
                 className="rounded-xl border border-blue-200 bg-blue-50 px-3.5 py-2 text-[13px] font-medium text-blue-700 transition hover:border-blue-300 hover:bg-blue-100"
               >
-                Conectar tu contabilidad →
+                🔗 Conectar Holded (30 s)
               </button>
             )}
           </div>
@@ -651,6 +651,11 @@ export default function IsaakChatSection({
   // ── Chat active (Claude-style: sin burbujas excesivas, ancho 3xl) ─────────
   return (
     <div className="flex h-full flex-col">
+      {/* Banner persistente: conectar Holded. Solo si el usuario aún no lo
+          tiene conectado. Cierre dismissible via localStorage para no ser
+          intrusivo en sesiones avanzadas. */}
+      {!holdedConnected && <HoldedCtaBanner />}
+
       <div className="flex-1 overflow-y-auto">
         <div className="mx-auto max-w-3xl space-y-8 px-6 py-8">
           {messages.map((msg) =>
@@ -790,6 +795,64 @@ export default function IsaakChatSection({
               </div>
             </>
           )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+
+// ── HoldedCtaBanner ─────────────────────────────────────────────────────────
+// Banner persistente que invita a conectar Holded para acceder a datos
+// reales del ERP. Dismissible: si el usuario lo cierra, no vuelve a salir
+// en esa cuenta (localStorage). Reaparece si vuelve a desconectar Holded.
+
+function HoldedCtaBanner() {
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (window.localStorage.getItem("isaak-holded-cta-dismissed") === "1") {
+      setDismissed(true);
+    }
+  }, []);
+
+  if (dismissed) return null;
+
+  const handleDismiss = () => {
+    try {
+      window.localStorage.setItem("isaak-holded-cta-dismissed", "1");
+    } catch {
+      // localStorage puede no estar disponible (modo privado, etc.) — fail-silent.
+    }
+    setDismissed(true);
+  };
+
+  return (
+    <div className="border-b border-blue-100 bg-gradient-to-r from-blue-50 to-white px-5 py-2.5">
+      <div className="mx-auto flex max-w-3xl items-center justify-between gap-3">
+        <div className="flex items-center gap-2.5 text-[13px] text-blue-900">
+          <span className="text-base">🔗</span>
+          <span>
+            Conecta tu Holded en 30 s para que Isaak vea tus datos reales (ventas, IVA, clientes,
+            facturas).
+          </span>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <a
+            href="/integration-holded"
+            className="rounded-full bg-blue-600 px-3 py-1 text-[12px] font-semibold text-white shadow-sm hover:bg-blue-700"
+          >
+            Conectar
+          </a>
+          <button
+            type="button"
+            onClick={handleDismiss}
+            className="rounded-full px-2 py-1 text-[12px] text-blue-700 hover:bg-blue-100"
+            aria-label="Cerrar"
+          >
+            ✕
+          </button>
         </div>
       </div>
     </div>

--- a/apps/isaak/app/(workspace)/components/IsaakMarkdown.tsx
+++ b/apps/isaak/app/(workspace)/components/IsaakMarkdown.tsx
@@ -1,5 +1,13 @@
+import Link from 'next/link';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+
+function isInternalLink(href: string | undefined): boolean {
+  if (!href) return false;
+  if (href.startsWith('/') && !href.startsWith('//')) return true;
+  if (href.startsWith('#')) return true;
+  return false;
+}
 
 export default function IsaakMarkdown({ text }: { text: string }) {
   return (
@@ -54,16 +62,31 @@ export default function IsaakMarkdown({ text }: { text: string }) {
               {children}
             </pre>
           ),
-          a: ({ href, children }) => (
-            <a
-              href={href}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-[#2361d8] underline underline-offset-2 hover:text-[#1d55c2]"
-            >
-              {children}
-            </a>
-          ),
+          a: ({ href, children }) => {
+            // Links internos (/foo o #anchor) usan Next.js Link y abren en la
+            // misma pestaña — UX clave para CTAs como "conecta tu Holded".
+            // Externos abren en pestaña nueva como antes.
+            const isInternal = isInternalLink(href);
+            const className =
+              'text-[#2361d8] underline underline-offset-2 hover:text-[#1d55c2]';
+            if (isInternal && href) {
+              return (
+                <Link href={href} className={className}>
+                  {children}
+                </Link>
+              );
+            }
+            return (
+              <a
+                href={href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={className}
+              >
+                {children}
+              </a>
+            );
+          },
           table: ({ children }) => (
             <div className="mb-1.5 overflow-x-auto">
               <table className="w-full border-collapse text-[13px]">{children}</table>

--- a/apps/isaak/app/components/IsaakHomeLanding.tsx
+++ b/apps/isaak/app/components/IsaakHomeLanding.tsx
@@ -202,41 +202,36 @@ const PROFILES = [
   },
 ];
 
+// V1 LAUNCH (2026-05): planes simplificados a Free + Pro. Los legacy
+// (Starter / Pro 49 / Business 149) quedan archivados en Stripe — clientes
+// existentes mantienen su plan hasta que cancelen. Ver docs/product/
+// ISAAK_LAUNCH_V1_2026-05-28.md.
 const PRICE_TEASER = [
   {
     id: 'free',
     name: 'Free',
     price: '0 €',
-    tagline: 'Consultas ilimitadas · Facturas VeriFactu · Sin tarjeta',
+    tagline: 'Chat ilimitado · Corpus AEAT completo · Sin tarjeta · Sin Holded conectado',
     cta: 'Empezar gratis',
-    href: '/auth',
-    highlight: false,
-  },
-  {
-    id: 'starter',
-    name: 'Starter',
-    price: '19 €',
-    tagline: 'Software sectorial · ERP conectado · Gestión financiera en tiempo real',
-    cta: 'Empezar ahora',
-    href: '/signup?plan=starter',
+    href: '/signup',
     highlight: false,
   },
   {
     id: 'pro',
     name: 'Pro',
-    price: '49 €',
-    tagline: 'Documentos · Google · WhatsApp · Voz · Multicanal',
-    cta: 'Trial 14 días sin tarjeta',
+    price: '29 €',
+    tagline: 'Holded conectado · 20 tools · Alertas AEAT · IA incluida · 14 días gratis sin tarjeta',
+    cta: 'Probar 14 días gratis',
     href: '/signup?plan=pro',
     highlight: true,
   },
   {
-    id: 'business',
-    name: 'Business',
-    price: '149 €',
-    tagline: 'Banca conectada · Modelos AEAT · Multi-usuario · Empresa',
-    cta: 'Hablar con ventas',
-    href: '/support',
+    id: 'pro-annual',
+    name: 'Pro anual',
+    price: '290 €',
+    tagline: '🎁 2 meses gratis · Todo lo del plan Pro · Pago una vez al año',
+    cta: 'Probar 14 días gratis',
+    href: '/signup?plan=pro&cadence=annual',
     highlight: false,
   },
 ];

--- a/apps/isaak/app/components/IsaakHomeLandingV1.tsx
+++ b/apps/isaak/app/components/IsaakHomeLandingV1.tsx
@@ -70,6 +70,7 @@ const PRICING = [
     name: 'Pro',
     price: '29 €',
     priceSub: 'al mes · IVA no incluido',
+    annualBadge: '🎁 Pago anual: 2 meses gratis (290 € / año)',
     description: 'Todo lo que un autónomo o pyme necesita para que Holded vuele.',
     features: [
       'Todo lo del plan Free',
@@ -77,7 +78,7 @@ const PRICING = [
       '20 tools: lectura + crear borradores',
       'Alertas AEAT D-15/7/3/1 por email',
       'Soporte por email',
-      'Trial 14 días sin tarjeta',
+      'Trial 14 días sin tarjeta — sin compromiso',
     ],
     cta: { label: 'Probar 14 días gratis', href: SIGNUP_URL + '?plan=pro' },
     highlight: true,
@@ -301,6 +302,11 @@ export default function IsaakHomeLandingV1() {
                   <span className="text-4xl font-bold text-[#011c67]">{p.price}</span>
                   <span className="ml-2 text-sm text-slate-500">{p.priceSub}</span>
                 </div>
+                {'annualBadge' in p && p.annualBadge && (
+                  <div className="mt-2.5 inline-flex items-center rounded-full bg-emerald-50 px-2.5 py-1 text-[12px] font-semibold text-emerald-700 ring-1 ring-emerald-200">
+                    {p.annualBadge}
+                  </div>
+                )}
                 <p className="mt-3 text-sm text-slate-600">{p.description}</p>
 
                 <ul className="mt-6 space-y-2">
@@ -328,7 +334,7 @@ export default function IsaakHomeLandingV1() {
           </div>
 
           <p className="mt-6 text-center text-xs text-slate-500">
-            Anual: 290 € /año (equivale a 24,16 €/mes · ahorro del 20%)
+            Sin permanencia · Cancela cuando quieras desde tu panel · IVA no incluido
           </p>
         </div>
       </section>

--- a/apps/isaak/app/lib/isaak-chat-prompts.ts
+++ b/apps/isaak/app/lib/isaak-chat-prompts.ts
@@ -103,7 +103,10 @@ Comportamiento adicional:
 - En cada pregunta breve ofrece siempre las opciones "Prefiero no decirlo" y "No lo sé".
 - Si la respuesta es "No lo sé", explica cómo averiguarlo y cuándo conviene revisar la Sede Electrónica de la AEAT o el certificado electronico.
 - Si la persona pregunta por campaña de renta, cierre de ejercicio o cuentas anuales, prioriza plazos, checklist y orden de trabajo.
-- Si la peticion requiere datos reales y no hay Holded, dilo con claridad y sin bloquear la ayuda general.
+- Si la peticion requiere datos reales y no hay Holded, NO inventes cifras. Responde con:
+  (a) una respuesta general útil basada en lo que sí sabes (corpus AEAT, normativa, mejores prácticas), y
+  (b) cierra invitando explícitamente con un link markdown así: "Para ver tus datos reales (ventas, IVA, clientes), [conecta tu Holded en 30 segundos](/integration-holded). La IA va incluida en tu plan, sin licencias adicionales."
+  El enlace markdown a /integration-holded es OBLIGATORIO en este caso — el frontend lo renderiza como botón clickable.
 
 Inspector AEAT (F12 Capa 2):
 - Tienes acceso al tool inspector_consult que combina el perfil fiscal del tenant + búsqueda RAG en el corpus AEAT/BOE + síntesis con citas BOE numeradas [1], [2], etc.

--- a/apps/isaak/app/pricing/page.tsx
+++ b/apps/isaak/app/pricing/page.tsx
@@ -22,86 +22,49 @@ type Plan = {
   footnote?: string;
 };
 
+// V1 LAUNCH (2026-05): planes simplificados a Free + Pro. Los legacy
+// (Starter / Pro 49 / Business 149) quedan archivados en Stripe — clientes
+// existentes mantienen su plan hasta cancelar. Ver docs/product/
+// ISAAK_LAUNCH_V1_2026-05-28.md.
 const PLANS: Plan[] = [
   {
     id: 'free',
     name: 'Free',
-    tagline: 'Gratis para siempre. Preguntas ilimitadas sobre tu negocio.',
+    tagline: 'Chat ilimitado para preguntas fiscales y contables. Sin tarjeta.',
     price: '0 €',
     priceSuffix: '/ mes',
     highlight: 'free',
     features: [
-      'Consultas ilimitadas con Isaak en español',
-      'Chat fiscal y contable — IVA, IRPF, trámites AEAT',
-      'Crea y descarga facturas manuales',
-      'Sube documentos y facturas para que Isaak los analice',
-      'Plantillas de factura con tu logo y colores',
+      'Chat ilimitado en español',
+      'Corpus completo de Agencia Tributaria',
       'IA incluida — sin cuenta de Claude ni ChatGPT',
+      'Sin tarjeta · Para siempre',
+      'Sin Holded conectado',
     ],
     ctaLabel: 'Empezar gratis',
-    ctaHref: '/auth',
+    ctaHref: '/signup',
     footnote: 'Sin tarjeta. Sin fecha límite.',
-  },
-  {
-    id: 'starter',
-    name: 'Starter',
-    tagline: 'Conecta Holded y trabaja con tus datos reales.',
-    price: '19 €',
-    priceSuffix: '/ mes',
-    annualNote: '15 €/mes facturado anual',
-    features: [
-      'Todo lo de Free',
-      'Holded conectado — ventas, gastos, cobros en tiempo real',
-      'Dashboard con tus KPIs: facturado, gastos, IVA estimado',
-      'Historial de conversaciones (90 días)',
-      'IA incluida — sin suscripción adicional',
-    ],
-    ctaLabel: 'Empezar trial 14 días',
-    ctaHref: '/signup?plan=starter',
-    footnote: 'Trial 14 días sin tarjeta.',
   },
   {
     id: 'pro',
     name: 'Pro',
-    tagline: 'Memoria, archivos, Google y modo de ejecución.',
-    price: '49 €',
+    tagline: 'Tu Holded conectado. Datos reales en tiempo real.',
+    price: '29 €',
     priceSuffix: '/ mes',
-    annualNote: '39 €/mes facturado anual',
+    annualNote: '🎁 290 € / año (2 meses gratis)',
     highlight: 'recommended',
     features: [
-      'Todo lo de Starter, mensajes ilimitados',
-      'Subida de facturas y tickets con OCR automático',
-      'Google Calendar, Gmail y Drive conectados',
-      'Alertas fiscales proactivas (IVA, IRPF, Verifactu)',
-      'Voz: dicta a Isaak, escucha las respuestas',
-      'Push notifications',
-      'Historial de conversaciones (1 año)',
-      'IA incluida — Claude Sonnet, sin suscripción adicional',
+      'Todo lo del plan Free',
+      'Tu Holded conectado · 20 tools de lectura + borradores',
+      'Dashboard con KPIs: facturado, gastos, IVA estimado, próx. vencimiento',
+      'Alertas fiscales D-15/7/3/1 antes de cada vencimiento AEAT',
+      'Soporte por email',
+      'IA incluida — Claude Sonnet + GPT-4o fallback',
+      'Trial 14 días sin tarjeta',
     ],
-    ctaLabel: 'Empezar trial 14 días',
+    ctaLabel: 'Probar 14 días gratis',
     ctaHref: '/signup?plan=pro',
-    footnote: 'Trial 14 días sin tarjeta.',
-  },
-  {
-    id: 'business',
-    name: 'Business',
-    tagline: 'Multi-usuario, modelos AEAT y banca conectada.',
-    price: '149 €',
-    priceSuffix: '/ mes',
-    annualNote: '119 €/mes facturado anual',
-    features: [
-      'Todo lo de Pro',
-      'Hasta 10 usuarios por workspace',
-      'Open Banking — movimientos bancarios en tiempo real',
-      'Modelos AEAT preconfigurados (303, 130, 390) — próximamente',
-      'Multi-ERP: Sage, A3 — próximamente',
-      'Historial ilimitado',
-      'Soporte prioritario · SLA 99,9%',
-      'IA incluida — Claude Sonnet + GPT-4o opcional',
-    ],
-    ctaLabel: 'Hablar con ventas',
-    ctaHref: '/support',
-    footnote: 'Facturación anual disponible. IVA no incluido.',
+    footnote: 'Trial 14 días sin tarjeta · Cancela cuando quieras · IVA no incluido',
   },
 ];
 
@@ -124,7 +87,7 @@ const FAQ = [
   },
   {
     q: '¿Hay descuento si pago anual?',
-    a: 'Sí. La facturación anual aplica un descuento del 20% (equivalente a más de 2 meses gratis). Disponible en Starter, Pro y Business.',
+    a: 'Sí. El plan Pro anual son 290 € en lugar de 348 € — 2 meses gratis (descuento equivalente al 17 %).',
   },
   {
     q: '¿Qué pasa con mis datos si cancelo?',
@@ -159,7 +122,7 @@ export default function IsaakPricingPage() {
       {/* Plans */}
       <section className="py-16 sm:py-20">
         <div className="mx-auto max-w-7xl px-4">
-          <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+          <div className="mx-auto grid max-w-3xl gap-6 md:grid-cols-2">
             {PLANS.map((plan) => {
               const isRecommended = plan.highlight === 'recommended';
               const isFree = plan.highlight === 'free';
@@ -196,9 +159,9 @@ export default function IsaakPricingPage() {
                       )}
                     </div>
                     {plan.annualNote && (
-                      <p className="mt-1 text-[11px] text-emerald-600 font-medium">
+                      <div className="mt-2 inline-flex items-center rounded-full bg-emerald-50 px-2.5 py-1 text-[12px] font-semibold text-emerald-700 ring-1 ring-emerald-200">
                         {plan.annualNote}
-                      </p>
+                      </div>
                     )}
                   </div>
 
@@ -368,7 +331,8 @@ export default function IsaakPricingPage() {
           <h2 className="text-2xl font-semibold sm:text-3xl">¿No sabes por dónde empezar?</h2>
           <p className="mx-auto mt-4 max-w-2xl text-sm leading-7 text-blue-100">
             Empieza con el plan Free — es gratis para siempre. Si en algún momento necesitas Holded
-            conectado o mensajes ilimitados, el salto a Starter o Pro es inmediato.
+            conectado y alertas fiscales, el salto a Pro son 29 € al mes con 14 días de prueba sin
+            tarjeta.
           </p>
           <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
             <Link

--- a/docs/engineering/SECTOR_INTEGRATIONS_PLAN.md
+++ b/docs/engineering/SECTOR_INTEGRATIONS_PLAN.md
@@ -1,7 +1,9 @@
 # Isaak — Plan de Integraciones Sectoriales
 
+> ⚠️ **V1 LAUNCH (2026-05-28)** — Las integraciones sectoriales (HotelGest, Revo, Nubimed, Inmovilla…) están **escondidas en V1**. Reactivación prevista en **V3.0** (≈ 6 meses post-V1). Pricing reescrito en [`ISAAK_LAUNCH_V1_2026-05-28.md`](../product/ISAAK_LAUNCH_V1_2026-05-28.md) — el plan Business 149€ referenciado abajo está archivado.
+
 **Creado**: 2026-05-25
-**Estado**: Documento vivo — pivote estratégico confirmado
+**Estado**: Documento vivo — pivote estratégico confirmado · pausado para V1
 
 ---
 

--- a/docs/engineering/ai/ISAAK_UNIFIED_SPEC.md
+++ b/docs/engineering/ai/ISAAK_UNIFIED_SPEC.md
@@ -1,5 +1,7 @@
 # ISAAK UNIFICADO - Especificación de Producto
 
+> ⚠️ **V1 LAUNCH (2026-05-28)** — pricing y scope simplificados: **Free + Pro 29 €/mes** (290 €/año con 2 meses gratis). Trial Pro 14 días sin tarjeta. Pro 49 €/mes referenciado abajo está **deprecated**. Ver fuente única [`ISAAK_LAUNCH_V1_2026-05-28.md`](../../product/ISAAK_LAUNCH_V1_2026-05-28.md).
+
 **Fecha:** 2026-01-15 · **Actualizado:** Marzo 2026  
 **Versión:** 1.1  
 **Estado:** Fases 1-2 completadas. Fase 3 en progreso.

--- a/docs/isaak/ISAAK_PLATFORM_VISION.md
+++ b/docs/isaak/ISAAK_PLATFORM_VISION.md
@@ -1,5 +1,7 @@
 # ISAAK — Visión de Producto
 
+> ⚠️ **V1 LAUNCH (2026-05-28)** — pricing simplificado a **Free + Pro 29 €/mes** (290 €/año con 2 meses gratis). Trial Pro de 14 días sin tarjeta. Planes legacy Starter/Pro 49/Business 149 archivados. Fuente única del lanzamiento: [`ISAAK_LAUNCH_V1_2026-05-28.md`](../product/ISAAK_LAUNCH_V1_2026-05-28.md). El pricing y los planes de este documento histórico están **deprecated**.
+
 > Última actualización: 2026-04-28 · Arquitecto responsable: Verifactu Business
 
 ---

--- a/docs/product/ISAAK_MASTER_PLAN.md
+++ b/docs/product/ISAAK_MASTER_PLAN.md
@@ -41,18 +41,18 @@ El modelo anterior conectaba Isaak con **ERPs genéricos** (Holded, Sage, A3) co
 
 ---
 
-## Tarifas definitivas (vigentes desde 2026-05-16)
+## Tarifas V1 (vigentes desde 2026-05-28 — Plan de Lanzamiento V1)
 
-| Plan         | Precio    | Límites                                                            | IA incluida                          |
-| ------------ | --------- | ------------------------------------------------------------------ | ------------------------------------ |
-| **Free**     | 0 €       | 10 mensajes/día · solo chat fiscal general · sin Holded            | Sí — Claude Haiku                    |
-| **Starter**  | 19 €/mes  | Holded conectado · 200 consultas/mes · sin OCR ni Google           | Sí — Claude Haiku                    |
-| **Pro**      | 49 €/mes  | Ilimitado · OCR · Google Calendar/Gmail/Drive · voz · push         | Sí — Claude Sonnet                   |
-| **Business** | 149 €/mes | Todo Pro + multi-usuario (10) · modelos AEAT · banking · multi-ERP | Sí — Claude Sonnet + GPT-4o opcional |
+| Plan         | Precio                                  | Límites                                                                | IA incluida                          |
+| ------------ | --------------------------------------- | ---------------------------------------------------------------------- | ------------------------------------ |
+| **Free**     | 0 €                                     | Chat **ilimitado** · Corpus AEAT · 10 msg/h (anti-abuso) · sin Holded  | Sí — Claude Haiku                    |
+| **Pro**      | **29 €/mes** o **290 €/año** (2 meses gratis) | Holded conectado · 20 tools · Alertas D-15/7/3/1 · Trial 14 días sin tarjeta | Sí — Claude Sonnet + GPT-4o fallback |
 
-**Descuento anual:** −20% en todos los planes de pago.
+**Trial Pro:** 14 días gratis sin tarjeta (`payment_method_collection: 'if_required'` en Stripe). Si no continúa, cuenta cae a Free.
 
-**Add-ons (Starter+):** Usuario adicional €9/mes · ERP adicional €15/mes · Banco adicional €10/mes.
+**Planes legacy (archivados):** Starter 19€, Pro 49€, Business 149€ — clientes existentes mantienen su suscripción hasta cancelar. No se ofrecen a clientes nuevos. La migración a V2+ reintroducirá Business cuando llegue multi-usuario.
+
+Ver `docs/product/ISAAK_LAUNCH_V1_2026-05-28.md` para el plan completo de lanzamiento V1.
 
 ---
 


### PR DESCRIPTION
Empuja la conversión Free → Pro:

1. **Prompt** instruido para devolver `[conecta tu Holded](/integration-holded)` cuando responda preguntas que requieren datos reales sin Holded
2. **Markdown renderer** distingue links internos (Next Link, misma pestaña) vs externos (target blank). Hace que el CTA navegue bonito
3. **Banner persistente** en cabecera del chat cuando `!holdedConnected`. Dismissible con localStorage, reaparece si desconecta