### PR TITLE
feat(isaak V1.1): /ajustes/notificaciones + hub /integrations V1 + popover collapsed

### DIFF
--- a/apps/isaak/app/(workspace)/ajustes/notificaciones/page.tsx
+++ b/apps/isaak/app/(workspace)/ajustes/notificaciones/page.tsx
@@ -1,0 +1,498 @@
+// V1.1 — Panel unificado de notificaciones (4 canales).
+//
+// Una pantalla con 4 tarjetas: Email · Push web · WhatsApp · Telegram.
+// Cada tarjeta muestra estado de conexión + acciones para vincular o
+// configurar. Re-utiliza los endpoints existentes:
+//   - GET  /api/isaak/notifications/status       → estado consolidado
+//   - POST /api/isaak/push/subscribe             → suscribir SW push
+//   - POST /api/isaak/push/unsubscribe           → desuscribir
+//   - GET  /api/isaak/push/preferences           → 3 sub-toggles push
+//   - PATCH /api/isaak/push/preferences          → guardar toggle
+//   - POST /api/isaak/telegram/link              → generar deep-link 24h
+//
+// El layout (workspace) ya valida sesión y aplica `force-dynamic`.
+
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import {
+  AlertCircle,
+  ArrowRight,
+  Bell,
+  CheckCircle2,
+  ExternalLink,
+  Loader2,
+  Mail,
+  MessageCircle,
+  Send,
+  ShieldCheck,
+  Smartphone,
+} from 'lucide-react';
+
+const WHATSAPP_NUMBER =
+  process.env.NEXT_PUBLIC_WHATSAPP_NUMBER ?? '15559835009';
+const WHATSAPP_DEEP_LINK = `https://wa.me/${WHATSAPP_NUMBER}?text=${encodeURIComponent(
+  'Hola Isaak, quiero vincular mi cuenta de WhatsApp.',
+)}`;
+
+type PushPrefs = {
+  alertaFiscal: boolean;
+  documentoSinConciliar: boolean;
+  avisoProactivoIsaak: boolean;
+};
+
+type NotificationsStatus = {
+  email: { address: string | null; enabled: boolean };
+  push: { subscribed: boolean; preferences: PushPrefs };
+  whatsapp: {
+    linked: boolean;
+    phone: string | null;
+    lastActivityAt: string | null;
+    consentAt: string | null;
+  };
+  telegram: {
+    linked: boolean;
+    chatId: number | null;
+    username: string | null;
+    firstName: string | null;
+    lastActivityAt: string | null;
+  };
+};
+
+const PUSH_PREF_LABELS: {
+  key: keyof PushPrefs;
+  label: string;
+  description: string;
+}[] = [
+  {
+    key: 'alertaFiscal',
+    label: 'Alertas AEAT',
+    description: 'D-15, D-7, D-3 y D-1 antes de cada vencimiento (303, 130, 111…).',
+  },
+  {
+    key: 'documentoSinConciliar',
+    label: 'Documentos sin conciliar',
+    description: 'Facturas o movimientos pendientes que necesitan tu atención.',
+  },
+  {
+    key: 'avisoProactivoIsaak',
+    label: 'Avisos proactivos de Isaak',
+    description: 'Cuando Isaak detecta algo relevante (margen, retraso de cobro, anomalía).',
+  },
+];
+
+function formatDate(iso: string | null) {
+  if (!iso) return null;
+  try {
+    return new Date(iso).toLocaleDateString('es-ES', {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+    });
+  } catch {
+    return null;
+  }
+}
+
+export default function NotificationsPage() {
+  const [status, setStatus] = useState<NotificationsStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [pushBusy, setPushBusy] = useState(false);
+  const [pushSupported, setPushSupported] = useState<boolean | null>(null);
+  const [pushPermission, setPushPermission] = useState<NotificationPermission | 'unknown'>(
+    'unknown',
+  );
+  const [savingPref, setSavingPref] = useState<keyof PushPrefs | null>(null);
+  const [tgLoading, setTgLoading] = useState(false);
+  const [tgDeepLink, setTgDeepLink] = useState<string | null>(null);
+
+  const loadStatus = useCallback(async () => {
+    try {
+      const res = await fetch('/api/isaak/notifications/status', {
+        credentials: 'include',
+      });
+      if (!res.ok) return;
+      const data = (await res.json()) as NotificationsStatus;
+      setStatus(data);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const supported = 'serviceWorker' in navigator && 'PushManager' in window;
+    setPushSupported(supported);
+    if (supported && 'Notification' in window) {
+      setPushPermission(Notification.permission);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadStatus();
+  }, [loadStatus]);
+
+  async function handlePushSubscribe() {
+    const vapidPublicKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
+    if (!vapidPublicKey || !('serviceWorker' in navigator)) return;
+    setPushBusy(true);
+    try {
+      const reg = await navigator.serviceWorker.ready;
+      const sub = await reg.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: vapidPublicKey,
+      });
+      const json = sub.toJSON() as {
+        endpoint: string;
+        keys: { p256dh: string; auth: string };
+      };
+      await fetch('/api/isaak/push/subscribe', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(json),
+      });
+      setPushPermission('granted');
+      await loadStatus();
+    } catch {
+      setPushPermission('denied');
+    } finally {
+      setPushBusy(false);
+    }
+  }
+
+  async function handlePushUnsubscribe() {
+    setPushBusy(true);
+    try {
+      const reg = await navigator.serviceWorker.ready;
+      const sub = await reg.pushManager.getSubscription();
+      if (sub) {
+        await fetch('/api/isaak/push/unsubscribe', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ endpoint: sub.endpoint }),
+        });
+        await sub.unsubscribe();
+      }
+      await loadStatus();
+    } finally {
+      setPushBusy(false);
+    }
+  }
+
+  async function togglePref(key: keyof PushPrefs, value: boolean) {
+    if (!status) return;
+    setSavingPref(key);
+    const optimistic = { ...status.push.preferences, [key]: value };
+    setStatus({ ...status, push: { ...status.push, preferences: optimistic } });
+    try {
+      await fetch('/api/isaak/push/preferences', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ [key]: value }),
+      });
+    } finally {
+      setSavingPref(null);
+    }
+  }
+
+  async function handleGenerateTelegramLink() {
+    setTgLoading(true);
+    try {
+      const res = await fetch('/api/isaak/telegram/link', { method: 'POST' });
+      if (!res.ok) return;
+      const data = (await res.json()) as { deepLink: string };
+      setTgDeepLink(data.deepLink);
+      // abre en nueva pestaña automáticamente
+      window.open(data.deepLink, '_blank', 'noopener,noreferrer');
+    } finally {
+      setTgLoading(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <Loader2 className="h-6 w-6 animate-spin text-[#2361d8]" />
+      </div>
+    );
+  }
+
+  if (!status) {
+    return (
+      <div className="mx-auto max-w-3xl px-4 py-8">
+        <p className="text-sm text-slate-500">
+          No se pudo cargar el estado de notificaciones.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6 px-4 py-8">
+      {/* Header */}
+      <div className="flex items-start gap-3">
+        <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-[#2361d8] text-white">
+          <Bell className="h-5 w-5" />
+        </div>
+        <div>
+          <h1 className="text-xl font-bold text-slate-900">Notificaciones</h1>
+          <p className="text-sm text-slate-500">
+            Elige cómo quieres que Isaak te avise: email, push, WhatsApp o Telegram.
+          </p>
+        </div>
+      </div>
+
+      {/* Email */}
+      <Card
+        icon={<Mail className="h-5 w-5 text-slate-700" />}
+        title="Email"
+        subtitle={status.email.address ?? 'Email no disponible'}
+        connected={status.email.enabled}
+        connectedLabel="Activado"
+      >
+        <p className="text-xs leading-5 text-slate-500">
+          Recibirás los emails operativos (alertas AEAT, recordatorios, facturas Stripe)
+          en la dirección con la que iniciaste sesión. Para cambiarla, edita tu perfil.
+        </p>
+      </Card>
+
+      {/* Push web / móvil */}
+      <Card
+        icon={<Smartphone className="h-5 w-5 text-slate-700" />}
+        title="Notificaciones push (web y móvil)"
+        subtitle={
+          status.push.subscribed
+            ? 'Recibirás avisos aunque tengas Isaak cerrado'
+            : 'Activa los avisos en este dispositivo'
+        }
+        connected={status.push.subscribed}
+        connectedLabel="Activadas"
+      >
+        {pushSupported === false ? (
+          <div className="rounded-lg bg-amber-50 px-3 py-2 text-xs text-amber-800">
+            Tu navegador no soporta notificaciones push. Prueba con Chrome, Edge o
+            Safari (16.4+).
+          </div>
+        ) : pushPermission === 'denied' && !status.push.subscribed ? (
+          <div className="rounded-lg bg-rose-50 px-3 py-2 text-xs text-rose-800">
+            Has bloqueado las notificaciones en este navegador. Cámbialo en los
+            ajustes del sitio y vuelve a probar.
+          </div>
+        ) : !status.push.subscribed ? (
+          <button
+            onClick={handlePushSubscribe}
+            disabled={pushBusy}
+            className="inline-flex items-center gap-2 rounded-lg bg-[#2361d8] px-3 py-2 text-xs font-semibold text-white transition hover:bg-[#1f55c0] disabled:opacity-50"
+          >
+            {pushBusy ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Bell className="h-3.5 w-3.5" />
+            )}
+            Activar notificaciones
+          </button>
+        ) : (
+          <div className="space-y-2">
+            <p className="text-xs font-medium text-slate-600">¿Qué quieres recibir?</p>
+            <div className="space-y-1.5 rounded-xl border border-slate-100 bg-slate-50/50 p-3">
+              {PUSH_PREF_LABELS.map(({ key, label, description }) => {
+                const checked = status.push.preferences[key];
+                const saving = savingPref === key;
+                return (
+                  <label
+                    key={key}
+                    className="flex cursor-pointer items-start gap-3 rounded-lg p-2 transition hover:bg-white"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      disabled={saving}
+                      onChange={(e) => void togglePref(key, e.target.checked)}
+                      className="mt-1 h-4 w-4 rounded border-slate-300 text-[#2361d8] focus:ring-[#2361d8]"
+                    />
+                    <div className="min-w-0 flex-1">
+                      <div className="text-xs font-semibold text-slate-800">
+                        {label}
+                        {saving && (
+                          <Loader2 className="ml-1.5 inline h-3 w-3 animate-spin text-slate-400" />
+                        )}
+                      </div>
+                      <div className="mt-0.5 text-[11px] leading-4 text-slate-500">
+                        {description}
+                      </div>
+                    </div>
+                  </label>
+                );
+              })}
+            </div>
+            <button
+              onClick={handlePushUnsubscribe}
+              disabled={pushBusy}
+              className="text-[11px] font-medium text-rose-600 hover:text-rose-700 disabled:opacity-50"
+            >
+              {pushBusy ? 'Procesando…' : 'Desactivar en este dispositivo'}
+            </button>
+          </div>
+        )}
+      </Card>
+
+      {/* WhatsApp */}
+      <Card
+        icon={<MessageCircle className="h-5 w-5 text-[#25D366]" />}
+        title="WhatsApp"
+        subtitle={
+          status.whatsapp.linked
+            ? `Vinculado · ${status.whatsapp.phone ?? 'número oculto'}`
+            : 'Habla con Isaak desde WhatsApp 24/7'
+        }
+        connected={status.whatsapp.linked}
+        connectedLabel="Vinculado"
+      >
+        {status.whatsapp.linked ? (
+          <div className="space-y-2">
+            <div className="rounded-lg border border-emerald-100 bg-emerald-50/50 px-3 py-2 text-xs text-emerald-800">
+              <CheckCircle2 className="mr-1 inline h-3.5 w-3.5" />
+              Tu cuenta está vinculada. Última actividad:{' '}
+              {formatDate(status.whatsapp.lastActivityAt) ?? 'sin actividad reciente'}.
+            </div>
+            <a
+              href={WHATSAPP_DEEP_LINK}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 text-[11px] font-medium text-slate-600 hover:text-slate-800"
+            >
+              Abrir conversación
+              <ExternalLink className="h-3 w-3" />
+            </a>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            <p className="text-xs leading-5 text-slate-500">
+              Pulsa el botón para abrir WhatsApp y enviar un mensaje. Tu número quedará
+              vinculado automáticamente cuando contestemos.
+            </p>
+            <a
+              href={WHATSAPP_DEEP_LINK}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-lg bg-[#25D366] px-3 py-2 text-xs font-semibold text-white transition hover:bg-[#1da851]"
+            >
+              <MessageCircle className="h-3.5 w-3.5" />
+              Abrir WhatsApp
+              <ArrowRight className="h-3.5 w-3.5" />
+            </a>
+          </div>
+        )}
+      </Card>
+
+      {/* Telegram */}
+      <Card
+        icon={<Send className="h-5 w-5 text-[#229ED9]" />}
+        title="Telegram"
+        subtitle={
+          status.telegram.linked
+            ? `Vinculado · ${status.telegram.username ? '@' + status.telegram.username : status.telegram.firstName ?? 'chat anónimo'}`
+            : 'Bot @IsaakFiscalBot · /start para empezar'
+        }
+        connected={status.telegram.linked}
+        connectedLabel="Vinculado"
+      >
+        {status.telegram.linked ? (
+          <div className="rounded-lg border border-emerald-100 bg-emerald-50/50 px-3 py-2 text-xs text-emerald-800">
+            <CheckCircle2 className="mr-1 inline h-3.5 w-3.5" />
+            Bot vinculado. Última actividad:{' '}
+            {formatDate(status.telegram.lastActivityAt) ?? 'sin actividad reciente'}.
+          </div>
+        ) : (
+          <div className="space-y-2">
+            <p className="text-xs leading-5 text-slate-500">
+              Generamos un enlace único de 24h. Al pulsarlo, Telegram abrirá el chat con
+              Isaak y tu cuenta quedará vinculada al instante.
+            </p>
+            <button
+              onClick={handleGenerateTelegramLink}
+              disabled={tgLoading}
+              className="inline-flex items-center gap-2 rounded-lg bg-[#229ED9] px-3 py-2 text-xs font-semibold text-white transition hover:bg-[#1d8ec3] disabled:opacity-50"
+            >
+              {tgLoading ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Send className="h-3.5 w-3.5" />
+              )}
+              Vincular Telegram
+              <ArrowRight className="h-3.5 w-3.5" />
+            </button>
+            {tgDeepLink && (
+              <p className="text-[11px] text-slate-500">
+                Si Telegram no se abre,{' '}
+                <a
+                  href={tgDeepLink}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-medium text-[#229ED9] hover:underline"
+                >
+                  haz click aquí
+                </a>
+                .
+              </p>
+            )}
+          </div>
+        )}
+      </Card>
+
+      {/* Footer privacidad */}
+      <div className="rounded-xl border border-slate-100 bg-slate-50 p-4 text-xs text-slate-500">
+        <ShieldCheck className="mr-1 inline h-3.5 w-3.5 text-slate-400" />
+        Solo te enviamos lo que has activado. Puedes pausar cada canal cuando quieras
+        desde esta misma pantalla.
+      </div>
+    </div>
+  );
+}
+
+function Card({
+  icon,
+  title,
+  subtitle,
+  connected,
+  connectedLabel,
+  children,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  subtitle: string;
+  connected: boolean;
+  connectedLabel: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+      <div className="flex items-start gap-3">
+        <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl bg-slate-50">
+          {icon}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <h2 className="text-sm font-semibold text-slate-900">{title}</h2>
+            <span
+              className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold ${
+                connected
+                  ? 'bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200'
+                  : 'bg-slate-100 text-slate-500'
+              }`}
+            >
+              {connected ? (
+                <CheckCircle2 className="h-3 w-3" />
+              ) : (
+                <AlertCircle className="h-3 w-3" />
+              )}
+              {connected ? connectedLabel : 'No activo'}
+            </span>
+          </div>
+          <p className="mt-0.5 truncate text-xs text-slate-500">{subtitle}</p>
+        </div>
+      </div>
+      <div className="mt-4">{children}</div>
+    </div>
+  );
+}

--- a/apps/isaak/app/(workspace)/components/IsaakChatSection.tsx
+++ b/apps/isaak/app/(workspace)/components/IsaakChatSection.tsx
@@ -23,6 +23,9 @@ import Link from 'next/link';
 import IsaakMarkdown from './IsaakMarkdown';
 import { ARTIFACT_ICON, type IsaakArtifact } from '@/app/lib/isaak-artifact';
 import IsaakArtifactPanel from './IsaakArtifactPanel';
+import SlashCommandPicker, {
+  shouldShowSlashPicker,
+} from './SlashCommandPicker';
 
 // ── Speech API minimal types ──────────────────────────────────────────────────
 interface ISpeechRecognitionResult {
@@ -221,9 +224,12 @@ function ChatInput({
   placeholder?: string;
 }) {
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const [caret, setCaret] = useState(0);
+  const slashKeyHandlerRef = useRef<(e: React.KeyboardEvent) => boolean>(() => false);
+  const showSlashPicker = shouldShowSlashPicker(input, caret);
 
   return (
-    <div className="space-y-2">
+    <div className="relative space-y-2">
       {selectedFile && (
         <div className="flex items-center gap-2 rounded-xl border border-blue-200 bg-blue-50 px-3 py-2">
           <FileText size={13} className="shrink-0 text-[#2361d8]" />
@@ -290,8 +296,16 @@ function ChatInput({
         <textarea
           ref={inputRef}
           value={input}
-          onChange={(e) => onChange(e.target.value)}
-          onKeyDown={onKeyDown}
+          onChange={(e) => {
+            onChange(e.target.value);
+            setCaret(e.target.selectionStart ?? 0);
+          }}
+          onSelect={(e) => setCaret(e.currentTarget.selectionStart ?? 0)}
+          onKeyDown={(e) => {
+            // El picker tiene prioridad si está visible.
+            if (showSlashPicker && slashKeyHandlerRef.current(e)) return;
+            onKeyDown(e);
+          }}
           placeholder={
             isListening
               ? 'Escuchando...'
@@ -311,6 +325,27 @@ function ChatInput({
           {loading ? <Loader2 size={14} className="animate-spin" /> : <SendHorizonal size={14} />}
         </button>
       </form>
+      {showSlashPicker && (
+        <SlashCommandPicker
+          input={input}
+          caret={caret}
+          onPick={({ value, cursorPos }) => {
+            onChange(value);
+            requestAnimationFrame(() => {
+              const el = inputRef.current;
+              if (el) {
+                el.focus();
+                el.setSelectionRange(cursorPos, cursorPos);
+                setCaret(cursorPos);
+              }
+            });
+          }}
+          onClose={() => onChange('')}
+          registerKeyHandler={(handler) => {
+            slashKeyHandlerRef.current = handler;
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/apps/isaak/app/(workspace)/components/IsaakSidebar.tsx
+++ b/apps/isaak/app/(workspace)/components/IsaakSidebar.tsx
@@ -151,7 +151,8 @@ const PROFILE_MENU_V1 = [
   { href: '/settings?section=profile', label: 'Perfil', icon: UserCircle2 },
   { href: '/settings?section=company', label: 'Empresa', icon: Building2 },
   { href: '/settings?section=billing', label: 'Plan y facturación', icon: CreditCard },
-  { href: '/integration-holded', label: 'Integración Holded', icon: Plug },
+  { href: '/ajustes/notificaciones', label: 'Notificaciones', icon: Bell },
+  { href: '/integrations', label: 'Integraciones', icon: Plug },
   { href: '/ayuda', label: 'Centro de ayuda', icon: LifeBuoy },
 ] as const;
 
@@ -533,9 +534,16 @@ export default function IsaakSidebar({
         className={`relative border-t border-white/5 p-2 ${collapsed ? 'px-1.5' : ''}`}
         ref={profileRef}
       >
-        {/* Profile popover */}
-        {profileOpen && !collapsed && (
-          <div className="absolute bottom-full left-2 right-2 mb-2 overflow-hidden rounded-2xl border border-white/10 bg-[#0d1e4a] shadow-2xl">
+        {/* Profile popover — flota a la derecha cuando el sidebar está colapsado
+            (modo Chat / preferencia de usuario) para no quedar oculto. */}
+        {profileOpen && (
+          <div
+            className={
+              collapsed
+                ? 'absolute bottom-2 left-full ml-2 w-[260px] overflow-hidden rounded-2xl border border-white/10 bg-[#0d1e4a] shadow-2xl z-50'
+                : 'absolute bottom-full left-2 right-2 mb-2 overflow-hidden rounded-2xl border border-white/10 bg-[#0d1e4a] shadow-2xl'
+            }
+          >
             {/* User header */}
             <div className="flex items-center gap-3 border-b border-white/5 px-4 py-3">
               <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[var(--brand-color)] text-[13px] font-bold text-white">
@@ -631,9 +639,7 @@ export default function IsaakSidebar({
         {/* Profile trigger button */}
         <button
           type="button"
-          onClick={() => {
-            if (!collapsed) setProfileOpen((v) => !v);
-          }}
+          onClick={() => setProfileOpen((v) => !v)}
           title={collapsed ? `${user.name} · Cuenta` : undefined}
           className={`flex w-full items-center rounded-xl p-2 transition hover:bg-white/5 ${
             collapsed ? 'justify-center' : 'gap-2.5'

--- a/apps/isaak/app/(workspace)/components/SlashCommandPicker.tsx
+++ b/apps/isaak/app/(workspace)/components/SlashCommandPicker.tsx
@@ -1,0 +1,322 @@
+'use client';
+
+// V1.2 — Slash command picker para el composer del chat.
+//
+// Cuando el usuario empieza el mensaje con "/", aparece un popover sobre
+// el textarea con los comandos disponibles filtrados por lo que sigue.
+// Selección con ↑/↓ + Enter, Tab o click. Esc cierra. Click fuera cierra.
+//
+// Cada comando expande a un texto prefijado en el textarea (no envía
+// automáticamente — el usuario completa y pulsa enviar). Algunos terminan
+// con un placeholder entre comillas para que el usuario rellene.
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Bell,
+  Bot,
+  Briefcase,
+  FileSpreadsheet,
+  FileText,
+  HelpCircle,
+  Landmark,
+  Receipt,
+  Scale,
+  Search,
+  Sparkles,
+  Users,
+  type LucideIcon,
+} from 'lucide-react';
+
+export type SlashCommand = {
+  trigger: string; // sin "/", lo añade el picker
+  label: string;
+  description: string;
+  icon: LucideIcon;
+  /**
+   * Texto que se inserta en el input al elegir el comando. Si contiene
+   * `{cursor}`, el cursor del textarea se posiciona ahí tras el reemplazo.
+   */
+  expansion: string;
+};
+
+export const SLASH_COMMANDS: SlashCommand[] = [
+  {
+    trigger: 'factura',
+    label: '/factura',
+    description: 'Crear borrador de factura emitida',
+    icon: Receipt,
+    expansion: 'Crea un borrador de factura para {cursor}',
+  },
+  {
+    trigger: 'iva',
+    label: '/iva',
+    description: '¿Cuánto IVA tengo a pagar este trimestre?',
+    icon: Landmark,
+    expansion: '¿Cuánto IVA tengo a pagar este trimestre?',
+  },
+  {
+    trigger: '303',
+    label: '/303',
+    description: 'Calcular borrador del modelo 303',
+    icon: FileSpreadsheet,
+    expansion: 'Calcula el borrador del modelo 303 del trimestre actual',
+  },
+  {
+    trigger: 'informe',
+    label: '/informe',
+    description: 'Generar resumen ejecutivo del mes en PDF',
+    icon: FileText,
+    expansion: 'Genera el resumen ejecutivo del mes en PDF',
+  },
+  {
+    trigger: 'libro-iva',
+    label: '/libro-iva',
+    description: 'Exportar libro IVA emitidas a Excel',
+    icon: FileSpreadsheet,
+    expansion: 'Exporta el libro IVA emitidas del trimestre actual a Excel',
+  },
+  {
+    trigger: 'cliente',
+    label: '/cliente',
+    description: 'Buscar un cliente por nombre o NIF',
+    icon: Users,
+    expansion: 'Búscame el cliente {cursor}',
+  },
+  {
+    trigger: 'conciliar',
+    label: '/conciliar',
+    description: 'Movimientos bancarios sin conciliar',
+    icon: Landmark,
+    expansion: '¿Qué movimientos bancarios tengo sin conciliar este mes?',
+  },
+  {
+    trigger: 'gastos',
+    label: '/gastos',
+    description: 'Top categorías de gasto del periodo',
+    icon: Receipt,
+    expansion: '¿Cuáles son mis 10 mayores categorías de gasto este trimestre?',
+  },
+  {
+    trigger: 'alertas',
+    label: '/alertas',
+    description: 'Próximos vencimientos AEAT',
+    icon: Bell,
+    expansion: '¿Qué vencimientos AEAT tengo en los próximos 30 días?',
+  },
+  {
+    trigger: 'legal',
+    label: '/legal',
+    description: 'Asesor Legal — revisar contrato',
+    icon: Scale,
+    expansion: 'Revísame este contrato:\n\n{cursor}',
+  },
+  {
+    trigger: 'carta-aeat',
+    label: '/carta-aeat',
+    description: 'Redactar carta para la AEAT (Word)',
+    icon: FileText,
+    expansion: 'Redacta una carta para la AEAT sobre {cursor}',
+  },
+  {
+    trigger: 'propuesta',
+    label: '/propuesta',
+    description: 'Propuesta comercial a cliente (Word)',
+    icon: Briefcase,
+    expansion: 'Redacta una propuesta comercial para el cliente {cursor}',
+  },
+  {
+    trigger: 'buscar',
+    label: '/buscar',
+    description: 'Buscar en el corpus AEAT (Inspector)',
+    icon: Search,
+    expansion: 'Inspector AEAT: {cursor}',
+  },
+  {
+    trigger: 'ayuda',
+    label: '/ayuda',
+    description: '¿Qué puede hacer Isaak por mí?',
+    icon: HelpCircle,
+    expansion: '¿Qué cosas puedes hacer por mí? Dame 5 ejemplos concretos.',
+  },
+];
+
+function matchesQuery(cmd: SlashCommand, query: string): boolean {
+  if (!query) return true;
+  const q = query.toLowerCase();
+  return (
+    cmd.trigger.toLowerCase().includes(q) ||
+    cmd.label.toLowerCase().includes(q) ||
+    cmd.description.toLowerCase().includes(q)
+  );
+}
+
+export function shouldShowSlashPicker(input: string, caret: number): boolean {
+  // Solo cuando el "/" está al principio del input y el cursor está dentro
+  // del primer token (sin espacios). Evita disparar el picker en medio de
+  // un mensaje largo.
+  if (!input.startsWith('/')) return false;
+  const firstSpace = input.indexOf(' ');
+  const firstNewline = input.indexOf('\n');
+  const tokenEnd = Math.min(
+    firstSpace === -1 ? input.length : firstSpace,
+    firstNewline === -1 ? input.length : firstNewline,
+  );
+  return caret <= tokenEnd;
+}
+
+export function applyExpansion(
+  cmd: SlashCommand,
+): { value: string; cursorPos: number } {
+  const exp = cmd.expansion;
+  const cursorMarker = '{cursor}';
+  const idx = exp.indexOf(cursorMarker);
+  if (idx === -1) {
+    return { value: exp, cursorPos: exp.length };
+  }
+  const value = exp.replace(cursorMarker, '');
+  return { value, cursorPos: idx };
+}
+
+type Props = {
+  input: string;
+  caret: number;
+  onPick: (expansion: { value: string; cursorPos: number }) => void;
+  onClose: () => void;
+  /** Para registrar el handler de teclado externo del textarea. */
+  registerKeyHandler?: (handler: (e: React.KeyboardEvent) => boolean) => void;
+};
+
+export default function SlashCommandPicker({
+  input,
+  caret,
+  onPick,
+  onClose,
+  registerKeyHandler,
+}: Props) {
+  const query = input.startsWith('/') ? input.slice(1).split(/[\s\n]/)[0] : '';
+  const filtered = useMemo(
+    () => SLASH_COMMANDS.filter((c) => matchesQuery(c, query)),
+    [query],
+  );
+  const [activeIndex, setActiveIndex] = useState(0);
+  const listRef = useRef<HTMLUListElement>(null);
+
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [query]);
+
+  // Scroll del item activo a la vista.
+  useEffect(() => {
+    const list = listRef.current;
+    if (!list) return;
+    const item = list.children[activeIndex] as HTMLElement | undefined;
+    if (item) item.scrollIntoView({ block: 'nearest' });
+  }, [activeIndex]);
+
+  // Registro del handler de teclas que el composer delega al picker.
+  useEffect(() => {
+    if (!registerKeyHandler) return;
+    const handler = (e: React.KeyboardEvent): boolean => {
+      if (filtered.length === 0) {
+        if (e.key === 'Escape') {
+          onClose();
+          return true;
+        }
+        return false;
+      }
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setActiveIndex((i) => (i + 1) % filtered.length);
+        return true;
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setActiveIndex((i) => (i - 1 + filtered.length) % filtered.length);
+        return true;
+      }
+      if (e.key === 'Enter' || e.key === 'Tab') {
+        e.preventDefault();
+        onPick(applyExpansion(filtered[activeIndex]));
+        return true;
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+        return true;
+      }
+      return false;
+    };
+    registerKeyHandler(handler);
+    return () => registerKeyHandler(() => false);
+  }, [registerKeyHandler, filtered, activeIndex, onPick, onClose]);
+
+  if (filtered.length === 0) {
+    return (
+      <div className="absolute bottom-full left-0 right-0 mb-2 overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-[0_12px_40px_-12px_rgba(15,23,42,0.18)]">
+        <div className="px-4 py-3 text-[12px] text-slate-500">
+          No hay comandos que coincidan con
+          <code className="ml-1 rounded bg-slate-100 px-1.5 py-0.5 text-[11px] font-medium text-slate-700">
+            /{query}
+          </code>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="absolute bottom-full left-0 right-0 mb-2 overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-[0_12px_40px_-12px_rgba(15,23,42,0.18)]">
+      <div className="flex items-center justify-between border-b border-slate-100 bg-slate-50/60 px-3 py-1.5">
+        <div className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider text-slate-500">
+          <Sparkles size={11} className="text-[#2361d8]" />
+          Comandos rápidos
+        </div>
+        <span className="text-[10px] text-slate-400">↑↓ navegar · ↵ usar · esc cerrar</span>
+      </div>
+      <ul ref={listRef} className="max-h-[280px] overflow-y-auto py-1">
+        {filtered.map((cmd, i) => {
+          const Icon = cmd.icon;
+          const active = i === activeIndex;
+          return (
+            <li key={cmd.trigger}>
+              <button
+                type="button"
+                onMouseEnter={() => setActiveIndex(i)}
+                onMouseDown={(e) => {
+                  // mousedown (no click) para no perder foco del textarea
+                  e.preventDefault();
+                  onPick(applyExpansion(cmd));
+                }}
+                className={`flex w-full items-center gap-3 px-3 py-2 text-left transition ${
+                  active ? 'bg-[#2361d8]/8' : 'hover:bg-slate-50'
+                }`}
+              >
+                <span
+                  className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg ${
+                    active ? 'bg-[#2361d8] text-white' : 'bg-slate-100 text-slate-600'
+                  }`}
+                >
+                  <Icon size={13} />
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="flex items-baseline gap-2">
+                    <span
+                      className={`font-mono text-[12px] font-semibold ${
+                        active ? 'text-[#2361d8]' : 'text-slate-800'
+                      }`}
+                    >
+                      {cmd.label}
+                    </span>
+                  </span>
+                  <span className="block truncate text-[11px] text-slate-500">
+                    {cmd.description}
+                  </span>
+                </span>
+                {active && <Bot size={11} className="flex-shrink-0 text-[#2361d8]" />}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/apps/isaak/app/(workspace)/integrations/IntegrationsV1Client.tsx
+++ b/apps/isaak/app/(workspace)/integrations/IntegrationsV1Client.tsx
@@ -1,0 +1,385 @@
+// V1.1 — Hub minimal de integraciones (4 cards).
+//
+// Reemplaza al catálogo enorme (50+ apps) bajo el flag ISAAK_V1_LAUNCH.
+// Expone solo lo que está soportado y validado en producción:
+//   - Holded            → /integration-holded
+//   - Google Workspace  → /api/isaak/google/auth (Calendar + Gmail + Drive)
+//   - Microsoft 365     → /microsoft
+//   - Calendario fiscal → derivado de Google/Microsoft (sync automático)
+//
+// El catálogo completo vive en IntegrationsClient y se reactivará en V2+
+// quitando el flag.
+
+'use client';
+
+import Link from 'next/link';
+import { useCallback, useEffect, useState } from 'react';
+import {
+  AlertCircle,
+  ArrowRight,
+  Calendar,
+  CheckCircle2,
+  Cloud,
+  ExternalLink,
+  FileSpreadsheet,
+  HardDrive,
+  Loader2,
+  Mail,
+  Plug,
+  ShieldCheck,
+} from 'lucide-react';
+
+type GoogleStatus = {
+  connected: boolean;
+  email: string | null;
+  hasGmailScope: boolean;
+  hasDriveScope: boolean;
+  googleConfigured: boolean;
+};
+
+type MicrosoftStatus = {
+  connected: boolean;
+  email: string | null;
+  displayName: string | null;
+  hasCalendarScope: boolean;
+  hasMailScope: boolean;
+  hasOneDriveScope: boolean;
+  microsoftConfigured: boolean;
+};
+
+type HoldedStatus = {
+  connected: boolean;
+  status: string;
+  keyMasked: string | null;
+  connectedAt: string | null;
+};
+
+export default function IntegrationsV1Client() {
+  const [google, setGoogle] = useState<GoogleStatus | null>(null);
+  const [microsoft, setMicrosoft] = useState<MicrosoftStatus | null>(null);
+  const [holded, setHolded] = useState<HoldedStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const loadAll = useCallback(async () => {
+    try {
+      const [gRes, mRes, hRes] = await Promise.all([
+        fetch('/api/isaak/google/status', { credentials: 'include' }),
+        fetch('/api/isaak/microsoft/status', { credentials: 'include' }),
+        fetch('/api/holded/status', { credentials: 'include' }),
+      ]);
+      if (gRes.ok) setGoogle((await gRes.json()) as GoogleStatus);
+      if (mRes.ok) setMicrosoft((await mRes.json()) as MicrosoftStatus);
+      if (hRes.ok) setHolded((await hRes.json()) as HoldedStatus);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadAll();
+  }, [loadAll]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <Loader2 className="h-6 w-6 animate-spin text-[#2361d8]" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6 px-4 py-8">
+      {/* Header */}
+      <div className="flex items-start gap-3">
+        <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-[#2361d8] text-white">
+          <Plug className="h-5 w-5" />
+        </div>
+        <div>
+          <h1 className="text-xl font-bold text-slate-900">Integraciones</h1>
+          <p className="text-sm text-slate-500">
+            Conecta tu ERP, tus calendarios y tus emails para que Isaak trabaje con
+            datos reales.
+          </p>
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        {/* Holded */}
+        <IntegrationCard
+          icon={
+            <span className="text-base font-bold tracking-tight text-[#1a1f36]">H</span>
+          }
+          iconBg="bg-[#fff8e1]"
+          title="Holded"
+          subtitle="Tu ERP — facturas, clientes, contabilidad"
+          connected={holded?.connected ?? false}
+          configured
+          status={
+            holded?.connected
+              ? `Vinculado · ${holded.keyMasked ?? ''}`
+              : 'Pega tu API key en 30 segundos'
+          }
+          primaryHref="/integration-holded"
+          primaryLabel={holded?.connected ? 'Gestionar' : 'Conectar Holded'}
+          features={[
+            'Lectura: facturas, clientes, productos, contabilidad',
+            'Crear borradores (apruebas tú antes de emitir)',
+            'API key cifrada con AES-256-GCM',
+          ]}
+        />
+
+        {/* Google Workspace */}
+        <IntegrationCard
+          icon={<GoogleLogo />}
+          iconBg="bg-white border border-slate-200"
+          title="Google Workspace"
+          subtitle="Calendar · Gmail · Drive"
+          connected={google?.connected ?? false}
+          configured={google?.googleConfigured ?? false}
+          status={
+            google?.connected
+              ? `Vinculado · ${google.email ?? ''}`
+              : 'Sincroniza vencimientos AEAT y archiva facturas en Drive'
+          }
+          primaryHref={
+            google?.connected ? '/api/isaak/google/auth' : '/api/isaak/google/auth'
+          }
+          primaryLabel={
+            google?.connected ? 'Ampliar permisos' : 'Conectar Google'
+          }
+          primaryExternal
+          features={[
+            { icon: Calendar, text: 'Calendar: vencimientos AEAT automáticos' },
+            { icon: Mail, text: 'Gmail: detecta facturas de proveedores' },
+            { icon: HardDrive, text: 'Drive: archivado en carpeta "Isaak — Facturas"' },
+          ]}
+        />
+
+        {/* Microsoft 365 */}
+        <IntegrationCard
+          icon={<Cloud className="h-5 w-5 text-blue-600" />}
+          iconBg="bg-blue-50"
+          title="Microsoft 365"
+          subtitle="Outlook · Calendar · OneDrive"
+          connected={microsoft?.connected ?? false}
+          configured={microsoft?.microsoftConfigured ?? false}
+          status={
+            microsoft?.connected
+              ? `Vinculado · ${microsoft.displayName ?? microsoft.email ?? ''}`
+              : 'Misma funcionalidad que Google, en el ecosistema Microsoft'
+          }
+          primaryHref="/microsoft"
+          primaryLabel={microsoft?.connected ? 'Gestionar' : 'Conectar Microsoft'}
+          features={[
+            { icon: Calendar, text: 'Outlook Calendar: vencimientos AEAT' },
+            { icon: Mail, text: 'Outlook Mail: detecta facturas' },
+            { icon: HardDrive, text: 'OneDrive: archivado de facturas PDF' },
+          ]}
+        />
+
+        {/* Calendario fiscal */}
+        <IntegrationCard
+          icon={<Calendar className="h-5 w-5 text-emerald-600" />}
+          iconBg="bg-emerald-50"
+          title="Calendario fiscal"
+          subtitle="Vencimientos AEAT en tu calendario"
+          connected={
+            (google?.connected ?? false) || (microsoft?.connected ?? false)
+          }
+          configured
+          status={
+            google?.connected || microsoft?.connected
+              ? 'Sincronización disponible — entra en la integración para crear eventos.'
+              : 'Conecta Google o Microsoft primero para sincronizar plazos.'
+          }
+          primaryHref={
+            google?.connected
+              ? '/integrations'
+              : microsoft?.connected
+                ? '/microsoft'
+                : '/integrations'
+          }
+          primaryLabel={
+            google?.connected || microsoft?.connected
+              ? 'Sincronizar'
+              : 'Conectar calendario'
+          }
+          features={[
+            { icon: FileSpreadsheet, text: 'Modelos 303, 130, 111, 115, 349, 347' },
+            { icon: Calendar, text: 'Recordatorios D-15 / D-7 / D-3 / D-1' },
+            { icon: ShieldCheck, text: 'Eventos privados, solo en tu calendario' },
+          ]}
+        />
+      </div>
+
+      {/* Footer — qué más viene */}
+      <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50/50 p-5">
+        <div className="flex items-start gap-3">
+          <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-white shadow-sm">
+            <ShieldCheck className="h-4 w-4 text-slate-500" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <h3 className="text-sm font-semibold text-slate-900">
+              Próximas integraciones
+            </h3>
+            <p className="mt-1 text-xs text-slate-500">
+              Estamos integrando bancos (Enable Banking), CRMs, plataformas de cobro
+              y ERPs sectoriales (Revo, Hotelgest…). Si quieres priorizar alguna,{' '}
+              <Link
+                href="/ayuda"
+                className="font-medium text-[#2361d8] hover:underline"
+              >
+                escríbenos
+              </Link>
+              .
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+type FeatureLine = { icon: React.ComponentType<{ className?: string }>; text: string };
+
+function IntegrationCard({
+  icon,
+  iconBg,
+  title,
+  subtitle,
+  connected,
+  configured,
+  status,
+  primaryHref,
+  primaryLabel,
+  primaryExternal,
+  features,
+}: {
+  icon: React.ReactNode;
+  iconBg: string;
+  title: string;
+  subtitle: string;
+  connected: boolean;
+  configured: boolean;
+  status: string;
+  primaryHref: string;
+  primaryLabel: string;
+  primaryExternal?: boolean;
+  features: (string | FeatureLine)[];
+}) {
+  const disabled = !configured;
+  return (
+    <div className="flex flex-col rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+      <div className="flex items-start gap-3">
+        <div
+          className={`flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl ${iconBg}`}
+        >
+          {icon}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <h2 className="text-sm font-semibold text-slate-900">{title}</h2>
+            <span
+              className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold ${
+                connected
+                  ? 'bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200'
+                  : 'bg-slate-100 text-slate-500'
+              }`}
+            >
+              {connected ? (
+                <CheckCircle2 className="h-3 w-3" />
+              ) : (
+                <AlertCircle className="h-3 w-3" />
+              )}
+              {connected ? 'Conectado' : 'No conectado'}
+            </span>
+          </div>
+          <p className="mt-0.5 text-xs text-slate-500">{subtitle}</p>
+        </div>
+      </div>
+
+      <p className="mt-3 text-xs leading-5 text-slate-600">{status}</p>
+
+      <ul className="mt-3 space-y-1.5">
+        {features.map((f, i) => {
+          if (typeof f === 'string') {
+            return (
+              <li key={i} className="flex items-start gap-2 text-[11px] text-slate-600">
+                <CheckCircle2 className="mt-0.5 h-3 w-3 flex-shrink-0 text-emerald-500" />
+                {f}
+              </li>
+            );
+          }
+          const Icon = f.icon;
+          return (
+            <li key={i} className="flex items-start gap-2 text-[11px] text-slate-600">
+              <Icon className="mt-0.5 h-3 w-3 flex-shrink-0 text-slate-400" />
+              {f.text}
+            </li>
+          );
+        })}
+      </ul>
+
+      <div className="mt-4 flex flex-1 items-end">
+        {disabled ? (
+          <span className="inline-flex w-full items-center justify-center gap-1.5 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs font-medium text-amber-800">
+            <AlertCircle className="h-3.5 w-3.5" />
+            Próximamente
+          </span>
+        ) : primaryExternal ? (
+          <a
+            href={primaryHref}
+            className={`inline-flex w-full items-center justify-center gap-2 rounded-lg px-3 py-2 text-xs font-semibold transition ${
+              connected
+                ? 'border border-slate-200 bg-white text-slate-700 hover:bg-slate-50'
+                : 'bg-[#2361d8] text-white hover:bg-[#1f55c0]'
+            }`}
+          >
+            {primaryLabel}
+            {connected ? (
+              <ExternalLink className="h-3.5 w-3.5" />
+            ) : (
+              <ArrowRight className="h-3.5 w-3.5" />
+            )}
+          </a>
+        ) : (
+          <Link
+            href={primaryHref}
+            className={`inline-flex w-full items-center justify-center gap-2 rounded-lg px-3 py-2 text-xs font-semibold transition ${
+              connected
+                ? 'border border-slate-200 bg-white text-slate-700 hover:bg-slate-50'
+                : 'bg-[#2361d8] text-white hover:bg-[#1f55c0]'
+            }`}
+          >
+            {primaryLabel}
+            <ArrowRight className="h-3.5 w-3.5" />
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// Google "G" logo (inline SVG, sin dependencia externa).
+function GoogleLogo() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-5 w-5" aria-hidden="true">
+      <path
+        fill="#4285F4"
+        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+      />
+      <path
+        fill="#34A853"
+        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.99.66-2.25 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+      />
+      <path
+        fill="#FBBC05"
+        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18A10.97 10.97 0 0 0 1 12c0 1.77.42 3.44 1.18 4.93l2.85-2.22.81-.62z"
+      />
+      <path
+        fill="#EA4335"
+        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84C6.71 7.31 9.14 5.38 12 5.38z"
+      />
+    </svg>
+  );
+}

--- a/apps/isaak/app/(workspace)/integrations/page.tsx
+++ b/apps/isaak/app/(workspace)/integrations/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next';
+import { ISAAK_V1_LAUNCH } from '@/app/lib/feature-flags';
 import IntegrationsClient from './IntegrationsClient';
+import IntegrationsV1Client from './IntegrationsV1Client';
 
 export const metadata: Metadata = {
   title: 'Integraciones — Isaak',
@@ -7,5 +9,7 @@ export const metadata: Metadata = {
 };
 
 export default function IntegrationsPage() {
+  // V1: hub minimal (4 cards). V2+: catálogo completo (50+ apps).
+  if (ISAAK_V1_LAUNCH) return <IntegrationsV1Client />;
   return <IntegrationsClient />;
 }

--- a/apps/isaak/app/api/cron/aeat-auto-submit-303/route.ts
+++ b/apps/isaak/app/api/cron/aeat-auto-submit-303/route.ts
@@ -149,7 +149,7 @@ function buildVetoEmailHtml(input: {
         </td></tr>
         <tr><td style="background:#f8faff;padding:16px 32px;border-top:1px solid #e2e8f0;">
           <p style="margin:0;font-size:12px;color:#94a3b8;">
-            Isaak · Copiloto fiscal IA · <a href="https://isaak.verifactu.business" style="color:#3b82f6;">isaak.verifactu.business</a>
+            Isaak · Copiloto fiscal IA · <a href="https://isaak.chat" style="color:#3b82f6;">isaak.chat</a>
           </p>
         </td></tr>
       </table>
@@ -197,7 +197,7 @@ export async function GET(req: NextRequest) {
     summary.passA.scanned = profiles.length;
 
     const appUrl =
-      process.env.NEXT_PUBLIC_APP_URL?.replace(/\/$/, '') || 'https://isaak.verifactu.business';
+      process.env.NEXT_PUBLIC_APP_URL?.replace(/\/$/, '') || 'https://isaak.chat';
     const resendApiKey = process.env.RESEND_API_KEY?.trim();
     const fromEmail =
       process.env.RESEND_FROM_ISAAK?.trim() ||

--- a/apps/isaak/app/api/cron/connector-health/route.ts
+++ b/apps/isaak/app/api/cron/connector-health/route.ts
@@ -151,7 +151,7 @@ async function checkHoldedConnections(): Promise<{
             connectorName: 'Holded',
             reason:
               'La API key de Holded ya no responde correctamente. Es posible que haya caducado o sido revocada desde el panel de Holded.',
-            actionUrl: 'https://isaak.verifactu.business/settings?section=integraciones',
+            actionUrl: 'https://isaak.chat/settings?section=integraciones',
             actionLabel: 'Reconectar Holded',
           }).catch(() => null);
         }
@@ -225,7 +225,7 @@ async function checkSaltEdgeConnections(): Promise<{
           connector: 'banking',
           connectorName: conn.providerName,
           reason,
-          actionUrl: 'https://isaak.verifactu.business/workspace?tab=banca',
+          actionUrl: 'https://isaak.chat/workspace?tab=banca',
           actionLabel: 'Revisar conexión bancaria',
         }).catch(() => null);
       }

--- a/apps/isaak/app/api/invoices/[id]/pdf/route.ts
+++ b/apps/isaak/app/api/invoices/[id]/pdf/route.ts
@@ -167,7 +167,7 @@ async function buildInvoicePdf(invoice: {
 
     // Footer
     '0.6 0.6 0.6 rg',
-    'BT /F1 8 Tf 45 30 Td (Generado por Isaak ' + esc('— isaak.verifactu.business') + ') Tj ET',
+    'BT /F1 8 Tf 45 30 Td (Generado por Isaak ' + esc('— isaak.chat') + ') Tj ET',
     '0 0 0 rg',
   ]
     .filter(Boolean)

--- a/apps/isaak/app/api/isaak/modelos/303/veto/route.ts
+++ b/apps/isaak/app/api/isaak/modelos/303/veto/route.ts
@@ -35,7 +35,7 @@ function htmlPage(title: string, heading: string, body: string, color: string): 
     <div class="header"><h1>${heading}</h1></div>
     <div class="body">
       ${body}
-      <a class="link" href="https://isaak.verifactu.business">Ir a Isaak</a>
+      <a class="link" href="https://isaak.chat">Ir a Isaak</a>
       <p class="note">Isaak · Copiloto fiscal IA · verifactu.business</p>
     </div>
   </div>

--- a/apps/isaak/app/api/isaak/notifications/status/route.ts
+++ b/apps/isaak/app/api/isaak/notifications/status/route.ts
@@ -1,0 +1,68 @@
+// Estado consolidado de los 4 canales de notificación (email / push / WhatsApp /
+// Telegram) para el panel /ajustes/notificaciones.
+
+import { NextResponse } from 'next/server';
+import { getHoldedSession } from '@/app/lib/holded-session';
+import { prisma } from '@/app/lib/prisma';
+
+export const runtime = 'nodejs';
+
+export async function GET() {
+  const session = await getHoldedSession().catch(() => null);
+  if (!session?.tenantId || !session.userId) {
+    return NextResponse.json({ error: 'Sesión requerida.' }, { status: 401 });
+  }
+
+  const tenantId = session.tenantId;
+  const userId = session.userId;
+
+  const [pushSubCount, pushPrefs, waThread, tgChat] = await Promise.all([
+    prisma.isaakPushSubscription.count({ where: { tenantId, userId } }),
+    prisma.isaakPushPreferences.findUnique({
+      where: { tenantId_userId: { tenantId, userId } },
+      select: {
+        alertaFiscal: true,
+        documentoSinConciliar: true,
+        avisoProactivoIsaak: true,
+      },
+    }),
+    prisma.whatsAppThread.findFirst({
+      where: { tenantId, consentAt: { not: null } },
+      orderBy: { lastMessageAt: 'desc' },
+      select: { phoneNumber: true, lastMessageAt: true, consentAt: true },
+    }),
+    prisma.telegramChat.findFirst({
+      where: { tenantId },
+      orderBy: { lastMessageAt: 'desc' },
+      select: { chatId: true, username: true, firstName: true, lastMessageAt: true },
+    }),
+  ]);
+
+  return NextResponse.json({
+    email: {
+      address: session.email ?? null,
+      enabled: true,
+    },
+    push: {
+      subscribed: pushSubCount > 0,
+      preferences: {
+        alertaFiscal: pushPrefs?.alertaFiscal ?? true,
+        documentoSinConciliar: pushPrefs?.documentoSinConciliar ?? true,
+        avisoProactivoIsaak: pushPrefs?.avisoProactivoIsaak ?? true,
+      },
+    },
+    whatsapp: {
+      linked: !!waThread,
+      phone: waThread?.phoneNumber ?? null,
+      lastActivityAt: waThread?.lastMessageAt?.toISOString() ?? null,
+      consentAt: waThread?.consentAt?.toISOString() ?? null,
+    },
+    telegram: {
+      linked: !!tgChat,
+      chatId: tgChat ? Number(tgChat.chatId) : null,
+      username: tgChat?.username ?? null,
+      firstName: tgChat?.firstName ?? null,
+      lastActivityAt: tgChat?.lastMessageAt?.toISOString() ?? null,
+    },
+  });
+}

--- a/apps/isaak/app/api/telegram/setup/route.ts
+++ b/apps/isaak/app/api/telegram/setup/route.ts
@@ -22,7 +22,7 @@ export async function GET(req: NextRequest) {
   }
 
   const appUrl =
-    process.env.NEXT_PUBLIC_APP_URL?.replace(/\/$/, '') || 'https://isaak.verifactu.business';
+    process.env.NEXT_PUBLIC_APP_URL?.replace(/\/$/, '') || 'https://isaak.chat';
   const webhookUrl = `${appUrl}/api/telegram/webhook`;
 
   if (!process.env.TELEGRAM_BOT_TOKEN?.trim()) {

--- a/apps/isaak/app/api/telegram/webhook/route.ts
+++ b/apps/isaak/app/api/telegram/webhook/route.ts
@@ -254,7 +254,7 @@ async function processUpdate(rawBody: string): Promise<void> {
 
     if (data === 'menu_vincular') {
       const appUrl =
-        process.env.NEXT_PUBLIC_APP_URL?.replace(/\/$/, '') || 'https://isaak.verifactu.business';
+        process.env.NEXT_PUBLIC_APP_URL?.replace(/\/$/, '') || 'https://isaak.chat';
       await sendTelegramText(
         tgChatId,
         `🔗 Para vincular tu cuenta de Isaak, ve a:\n\n<b>${appUrl}/settings/telegram</b>\n\nGenerarás un enlace de vinculación que abrirás aquí en Telegram.`
@@ -373,7 +373,7 @@ async function handleHelp(
     '',
     tenantId
       ? '✅ Tu cuenta de Isaak está vinculada.'
-      : `🔗 Vincula tu cuenta en <b>isaak.verifactu.business</b> → Ajustes → Telegram para acceder a tus datos.`,
+      : `🔗 Vincula tu cuenta en <b>isaak.chat</b> → Ajustes → Telegram para acceder a tus datos.`,
   ].join('\n');
   await sendTelegramText(tgChatId, reply);
   await saveOutbound(chatDbId, tenantId, reply);
@@ -451,7 +451,7 @@ async function handlePlanSelect(
   if (!tenantId) {
     await sendTelegramText(
       tgChatId,
-      `⚠️ Vincula tu cuenta de Isaak antes del pago para activar el plan automáticamente.\n\nVe a <b>isaak.verifactu.business → Ajustes → Telegram</b> y genera el enlace de vinculación.`
+      `⚠️ Vincula tu cuenta de Isaak antes del pago para activar el plan automáticamente.\n\nVe a <b>isaak.chat → Ajustes → Telegram</b> y genera el enlace de vinculación.`
     );
   }
 

--- a/apps/isaak/app/components/IsaakPublicSupportWidget.tsx
+++ b/apps/isaak/app/components/IsaakPublicSupportWidget.tsx
@@ -170,7 +170,7 @@ export default function IsaakPublicSupportWidget() {
           {/* CTA to register */}
           <div className="border-t border-white/5 bg-white/3 px-4 py-2.5">
             <a
-              href={`${process.env.NEXT_PUBLIC_ISAAK_SITE_URL || 'https://isaak.verifactu.business'}/auth`}
+              href={`${process.env.NEXT_PUBLIC_ISAAK_SITE_URL || 'https://isaak.chat'}/auth`}
               className="flex items-center justify-center gap-2 rounded-full bg-[#2361d8] px-4 py-2 text-[12px] font-semibold text-white transition hover:bg-[#1f55c0]"
             >
               Empezar gratis — sin tarjeta

--- a/apps/isaak/app/components/PricingSectionV1.tsx
+++ b/apps/isaak/app/components/PricingSectionV1.tsx
@@ -72,7 +72,7 @@ const PLANS: Plan[] = [
       { icon: MessageSquare, text: 'Chat ilimitado (10 mensajes/h)' },
       { icon: MessageCircle, text: 'Acceso desde WhatsApp + Telegram' },
       { icon: Brain, text: 'Corpus completo de Agencia Tributaria' },
-      { icon: Scale, text: 'Asesor legal de contratos', soon: true },
+      { icon: Scale, text: 'Asesor legal de contratos' },
       { icon: Sparkles, text: 'IA incluida — Claude Haiku' },
     ],
     notIncluded: ['Holded conectado', 'Alertas AEAT proactivas', 'Excel de libros y modelos'],

--- a/apps/isaak/app/layout.tsx
+++ b/apps/isaak/app/layout.tsx
@@ -8,7 +8,7 @@ import { isV1Launch } from './lib/feature-flags';
 import './globals.css';
 
 const manrope = Manrope({ subsets: ['latin'], weight: ['400', '500', '600', '700', '800'] });
-const siteUrl = process.env.NEXT_PUBLIC_ISAAK_SITE_URL || 'https://isaak.verifactu.business';
+const siteUrl = process.env.NEXT_PUBLIC_ISAAK_SITE_URL || 'https://isaak.chat';
 const avatarPath = '/Personalidad/isaak-avatar-verifactu.png';
 
 export const viewport: Viewport = {

--- a/apps/isaak/app/lib/communications/connector-health-email.ts
+++ b/apps/isaak/app/lib/communications/connector-health-email.ts
@@ -58,8 +58,8 @@ function buildHtml(input: ConnectorHealthAlertInput): string {
         <tr><td style="background:#f8faff;padding:16px 32px;border-top:1px solid #e2e8f0;">
           <p style="margin:0;font-size:12px;color:#94a3b8;">
             © 2026 Verifactu Business ·
-            <a href="https://isaak.verifactu.business/settings?section=integraciones" style="color:#94a3b8;">Gestionar integraciones</a> ·
-            <a href="https://isaak.verifactu.business" style="color:#94a3b8;">isaak.verifactu.business</a>
+            <a href="https://isaak.chat/settings?section=integraciones" style="color:#94a3b8;">Gestionar integraciones</a> ·
+            <a href="https://isaak.chat" style="color:#94a3b8;">isaak.chat</a>
           </p>
         </td></tr>
       </table>

--- a/apps/isaak/app/lib/fiscal-knowledge.ts
+++ b/apps/isaak/app/lib/fiscal-knowledge.ts
@@ -181,7 +181,7 @@ TIPOS DE IVA (vigentes hasta nueva modificación):
 // ── URLs de producto Isaak ─────────────────────────────────────────────────────
 
 const _base =
-  process.env.NEXT_PUBLIC_ISAAK_SITE_URL?.replace(/\/$/, '') || 'https://isaak.verifactu.business';
+  process.env.NEXT_PUBLIC_ISAAK_SITE_URL?.replace(/\/$/, '') || 'https://isaak.chat';
 
 export const ISAAK_URLS = {
   register: _base,

--- a/apps/isaak/app/lib/isaak-legal-advisor.ts
+++ b/apps/isaak/app/lib/isaak-legal-advisor.ts
@@ -1,0 +1,246 @@
+// V1.2 — Sub-agente "Asesor legal de contratos".
+//
+// Recibe el texto de un contrato (en español, derecho civil/mercantil
+// español por defecto) y devuelve una revisión estructurada:
+//   - resumen, partes, objeto, duración
+//   - riesgos clasificados por severidad (alta/media/baja) con
+//     cita literal de la cláusula + sugerencia de redacción
+//   - cláusulas favorables y recomendaciones generales
+//
+// NO sustituye al asesoramiento de un abogado colegiado — es revisión
+// orientativa para que el usuario sepa qué preguntar y dónde mirar.
+//
+// Bajo capó usa callLLM con responseFormat: 'json_object' (Claude
+// Sonnet primario, GPT-4o fallback). System prompt en `legal-prompt`.
+
+import { callLLM } from '@verifactu/utils';
+
+export const CONTRACT_TYPES = [
+  'nda',
+  'servicios',
+  'arrendamiento',
+  'compraventa',
+  'laboral',
+  'licencia',
+  'distribucion',
+  'otro',
+] as const;
+export type ContractType = (typeof CONTRACT_TYPES)[number];
+
+export type ContractParty = {
+  rol: string;
+  identificacion: string;
+};
+
+export type ContractRisk = {
+  severidad: 'alta' | 'media' | 'baja';
+  clausula: string;
+  riesgo: string;
+  sugerencia: string;
+  referenciaLegal?: string | null;
+};
+
+export type ContractReview = {
+  ok: true;
+  tipoDetectado: ContractType;
+  resumen: string;
+  partes: ContractParty[];
+  objetoPrincipal: string;
+  duracion: string;
+  riesgos: ContractRisk[];
+  clausulasFavorables: string[];
+  recomendaciones: string[];
+  proximosPasos: string[];
+  disclaimer: string;
+  model: string;
+  latencyMs: number;
+};
+
+export type ContractReviewError = {
+  ok: false;
+  error: string;
+  message: string;
+};
+
+const SYSTEM_PROMPT = `Eres "Asesor Legal" — un sub-agente de Isaak especializado en revisión de contratos bajo derecho español (Código Civil, Código de Comercio, Ley General para la Defensa de Consumidores y Usuarios).
+
+Tu trabajo es revisar el contrato que el usuario te pase y devolver una valoración estructurada en JSON. La revisión debe ser práctica: el lector es un autónomo o pyme, no un letrado.
+
+Reglas:
+1. SIEMPRE devuelves JSON válido con el shape indicado abajo. Nada de markdown ni texto fuera del JSON.
+2. NUNCA digas que "consulte a un abogado" en cada riesgo — eso ya va en el disclaimer global. Para cada riesgo, da una sugerencia concreta de redacción alternativa.
+3. Cita la cláusula LITERAL cuando puedas (entrecomillada). Si es muy larga, resume manteniendo el sentido.
+4. Riesgos a buscar por defecto (no exclusivo):
+   - Renovación automática sin opt-out claro
+   - Penalizaciones desproporcionadas (>10% del valor contractual)
+   - Cláusula de exclusividad o no-competencia abusiva
+   - Jurisdicción / fuero que perjudica al usuario (especialmente si vive lejos)
+   - Modificación unilateral del precio o servicio
+   - Limitación de responsabilidad excesiva del proveedor
+   - Confidencialidad asimétrica (solo obliga a una parte)
+   - Cesión del contrato sin consentimiento
+   - Duración indefinida sin causa de desistimiento
+   - Cláusulas suelo, gastos hipotecarios, intereses moratorios (B2C bancario)
+   - Falta de protección de datos (LOPD/GDPR) cuando aplica
+   - Plazos de pago superiores a los legales (Ley 15/2010 — 60 días B2B)
+5. Severidad:
+   - alta = riesgo económico significativo o nulidad probable
+   - media = desequilibrio relevante pero negociable
+   - baja = recomendación de mejora, no bloqueo
+6. tipoDetectado: si el usuario lo pasa, respétalo. Si no, dedúcelo del contenido.
+7. referenciaLegal cuando proceda: cita artículo (ej. "art. 1255 CC", "art. 80 TRLGDCU").
+
+Shape JSON obligatorio:
+{
+  "tipoDetectado": "nda" | "servicios" | "arrendamiento" | "compraventa" | "laboral" | "licencia" | "distribucion" | "otro",
+  "resumen": string,             // 2-4 frases en lenguaje natural
+  "partes": [{ "rol": string, "identificacion": string }],
+  "objetoPrincipal": string,     // 1-2 frases
+  "duracion": string,            // texto libre con plazo, prórroga, etc.
+  "riesgos": [
+    {
+      "severidad": "alta" | "media" | "baja",
+      "clausula": string,        // literal o resumen de la cláusula problemática
+      "riesgo": string,          // por qué es problemático
+      "sugerencia": string,      // texto alternativo concreto
+      "referenciaLegal": string | null
+    }
+  ],
+  "clausulasFavorables": [string],
+  "recomendaciones": [string],   // máximo 5 — generales, no específicas de una cláusula
+  "proximosPasos": [string]      // qué hacer ahora (ej. "negociar la cláusula 5", "validar con abogado", "firmar — sin riesgos altos")
+}
+
+Si el texto que te pasan NO parece un contrato, devuelve:
+{ "error": "not_a_contract", "message": "El texto no parece un contrato — necesito el documento completo o una sección con cláusulas." }
+`;
+
+const DISCLAIMER =
+  'Esta revisión es orientativa y se ha generado con IA. No sustituye al consejo de un abogado colegiado. Antes de firmar o de iniciar acciones legales, contrasta con un profesional.';
+
+export type ReviewContractInput = {
+  contractText: string;
+  contractType?: ContractType | null;
+  tenantContext?: {
+    name?: string;
+    activity?: string;
+  };
+};
+
+const MIN_CONTRACT_LENGTH = 200; // caracteres
+const MAX_CONTRACT_LENGTH = 30_000;
+
+export async function reviewContract(
+  input: ReviewContractInput,
+): Promise<ContractReview | ContractReviewError> {
+  const text = (input.contractText ?? '').trim();
+  if (text.length < MIN_CONTRACT_LENGTH) {
+    return {
+      ok: false,
+      error: 'text_too_short',
+      message: `El texto del contrato es demasiado corto (mínimo ${MIN_CONTRACT_LENGTH} caracteres). Pega el documento completo o una sección sustancial.`,
+    };
+  }
+  if (text.length > MAX_CONTRACT_LENGTH) {
+    return {
+      ok: false,
+      error: 'text_too_long',
+      message: `El texto excede ${MAX_CONTRACT_LENGTH} caracteres. Recórtalo a las secciones más relevantes (objeto, contraprestación, duración, resolución, jurisdicción).`,
+    };
+  }
+
+  const userContextLines: string[] = [];
+  if (input.contractType && input.contractType !== 'otro') {
+    userContextLines.push(`Tipo de contrato indicado por el usuario: ${input.contractType}.`);
+  }
+  if (input.tenantContext?.name) {
+    userContextLines.push(`Empresa/usuario: ${input.tenantContext.name}.`);
+  }
+  if (input.tenantContext?.activity) {
+    userContextLines.push(`Actividad: ${input.tenantContext.activity}.`);
+  }
+
+  const userMsg = [
+    userContextLines.join(' '),
+    '',
+    'Texto del contrato a revisar:',
+    '"""',
+    text,
+    '"""',
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  try {
+    const response = await callLLM({
+      feature: 'legal_review',
+      instructions: SYSTEM_PROMPT,
+      messages: [{ role: 'user', content: userMsg }],
+      responseFormat: 'json_object',
+      temperature: 0.2,
+      maxOutputTokens: 4096,
+    });
+
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(response.text) as Record<string, unknown>;
+    } catch {
+      return {
+        ok: false,
+        error: 'invalid_llm_response',
+        message: 'El modelo no devolvió un JSON parseable. Reintenta o reduce el tamaño del contrato.',
+      };
+    }
+
+    if (typeof parsed.error === 'string') {
+      return {
+        ok: false,
+        error: parsed.error,
+        message: typeof parsed.message === 'string' ? parsed.message : 'El texto no parece un contrato.',
+      };
+    }
+
+    const tipoDetectado = (parsed.tipoDetectado as ContractType) ?? 'otro';
+    if (!CONTRACT_TYPES.includes(tipoDetectado)) {
+      return {
+        ok: false,
+        error: 'invalid_contract_type',
+        message: `Tipo detectado inválido: ${tipoDetectado}.`,
+      };
+    }
+
+    return {
+      ok: true,
+      tipoDetectado,
+      resumen: String(parsed.resumen ?? ''),
+      partes: Array.isArray(parsed.partes) ? (parsed.partes as ContractParty[]) : [],
+      objetoPrincipal: String(parsed.objetoPrincipal ?? ''),
+      duracion: String(parsed.duracion ?? ''),
+      riesgos: Array.isArray(parsed.riesgos)
+        ? (parsed.riesgos as ContractRisk[]).filter(
+            (r) => r && typeof r === 'object' && typeof r.clausula === 'string',
+          )
+        : [],
+      clausulasFavorables: Array.isArray(parsed.clausulasFavorables)
+        ? (parsed.clausulasFavorables as string[]).filter((s) => typeof s === 'string')
+        : [],
+      recomendaciones: Array.isArray(parsed.recomendaciones)
+        ? (parsed.recomendaciones as string[])
+            .filter((s) => typeof s === 'string')
+            .slice(0, 8)
+        : [],
+      proximosPasos: Array.isArray(parsed.proximosPasos)
+        ? (parsed.proximosPasos as string[]).filter((s) => typeof s === 'string')
+        : [],
+      disclaimer: DISCLAIMER,
+      model: response.model,
+      latencyMs: response.latencyMs ?? 0,
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      error: 'llm_call_failed',
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/apps/isaak/app/lib/isaak-legal-tools.ts
+++ b/apps/isaak/app/lib/isaak-legal-tools.ts
@@ -1,0 +1,95 @@
+// V1.2 — LLM tools del sub-agente Asesor Legal.
+//
+// Patrón paralelo al de isaak-report-tools.ts: una lista de tools con
+// JSON Schema, un dispatcher executeLegalTool, y un predicate
+// isLegalToolName. Se registra en isaak-tools-registry.ts.
+//
+// Disponible siempre (read-only, no requiere conector externo). La tool
+// invoca un sub-LLM con system prompt especializado en derecho español.
+
+import {
+  reviewContract,
+  CONTRACT_TYPES,
+  type ContractType,
+} from './isaak-legal-advisor';
+
+export const LEGAL_CHAT_TOOLS = [
+  {
+    name: 'isaak_review_contract',
+    description:
+      'Sub-agente Asesor Legal: revisa un contrato y devuelve resumen, partes, objeto, duración, riesgos clasificados por severidad (alta/media/baja) con sugerencia de redacción alternativa, cláusulas favorables, recomendaciones y próximos pasos. Derecho español por defecto. NO sustituye a un abogado — incluye disclaimer al final. Usa esta tool cuando el usuario pegue un contrato o pida revisión de un texto contractual.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        contractText: {
+          type: 'string',
+          description:
+            'Texto completo o sección sustancial del contrato a revisar. Entre 200 y 30000 caracteres.',
+        },
+        contractType: {
+          type: ['string', 'null'],
+          enum: [...CONTRACT_TYPES, null],
+          description:
+            'Tipo de contrato si el usuario lo indica. Si no, déjalo null y el sub-agente lo detectará.',
+        },
+      },
+      required: ['contractText'],
+    },
+  },
+] as const;
+
+export type LegalToolName = (typeof LEGAL_CHAT_TOOLS)[number]['name'];
+
+const LEGAL_TOOL_NAMES = new Set<string>(LEGAL_CHAT_TOOLS.map((t) => t.name));
+
+export function isLegalToolName(name: string): name is LegalToolName {
+  return LEGAL_TOOL_NAMES.has(name);
+}
+
+export type LegalToolContext = {
+  tenantId: string;
+  userId: string;
+  tenantName?: string | null;
+  tenantActivity?: string | null;
+};
+
+export async function executeLegalTool(
+  ctx: LegalToolContext,
+  name: LegalToolName,
+  input: unknown,
+): Promise<unknown> {
+  const args = (input ?? {}) as Record<string, unknown>;
+
+  if (name === 'isaak_review_contract') {
+    const contractText = String(args.contractText ?? '');
+    const rawType = args.contractType;
+    const contractType =
+      typeof rawType === 'string' && (CONTRACT_TYPES as readonly string[]).includes(rawType)
+        ? (rawType as ContractType)
+        : null;
+
+    const result = await reviewContract({
+      contractText,
+      contractType,
+      tenantContext: {
+        name: ctx.tenantName ?? undefined,
+        activity: ctx.tenantActivity ?? undefined,
+      },
+    });
+
+    if (!result.ok) return result;
+
+    const riesgosAltos = result.riesgos.filter((r) => r.severidad === 'alta').length;
+    const riesgosMedios = result.riesgos.filter((r) => r.severidad === 'media').length;
+    return {
+      ...result,
+      message: `Revisión legal completada. Tipo: ${result.tipoDetectado}. Riesgos detectados: ${riesgosAltos} alto(s), ${riesgosMedios} medio(s), ${result.riesgos.length - riesgosAltos - riesgosMedios} bajo(s). Modelo: ${result.model}. Recuerda que es revisión orientativa — el disclaimer va al final.`,
+    };
+  }
+
+  return {
+    ok: false,
+    error: 'unknown_tool',
+    message: `Legal tool desconocida: ${name}.`,
+  };
+}

--- a/apps/isaak/app/lib/isaak-navigation.ts
+++ b/apps/isaak/app/lib/isaak-navigation.ts
@@ -9,7 +9,7 @@ function getOrigin(value: string | undefined, fallback: string) {
 
 export const ISAAK_PUBLIC_URL = getOrigin(
   process.env.NEXT_PUBLIC_ISAAK_SITE_URL,
-  'https://isaak.verifactu.business'
+  'https://isaak.chat'
 );
 
 export const APP_URL = getOrigin(process.env.NEXT_PUBLIC_APP_URL, ISAAK_PUBLIC_URL);
@@ -26,7 +26,7 @@ export const HOLDed_AUTH_URL = `${HOLDed_URL}/auth/holded`;
 export const HOLDed_PROFILE_ONBOARDING_URL = `${HOLDed_URL}/onboarding/profile`;
 
 export const SUPPORT_EMAIL = (
-  process.env.NEXT_PUBLIC_SUPPORT_EMAIL || 'soporte@isaak.verifactu.business'
+  process.env.NEXT_PUBLIC_SUPPORT_EMAIL || 'soporte@verifactu.business'
 ).trim();
 
 export const buildHoldedAuthUrl = (source: string, next?: string) => {

--- a/apps/isaak/app/lib/isaak-tools-registry.ts
+++ b/apps/isaak/app/lib/isaak-tools-registry.ts
@@ -15,6 +15,12 @@ import {
   isSectorToolName,
   type SectorToolName,
 } from './sector-tools';
+import {
+  LEGAL_CHAT_TOOLS,
+  executeLegalTool,
+  isLegalToolName,
+  type LegalToolName,
+} from './isaak-legal-tools';
 import { emitWebhookEvent, type IsaakWebhookEventType } from './isaak-webhook-emitter';
 
 // Mapping: write tool name → webhook event type emitted on success.
@@ -132,6 +138,8 @@ const READ_ONLY_NAMES = new Set<string>([
   'sector_list_invoices',
   'sector_list_contacts',
   'sector_list_products',
+  // V1.2 — Legal (sub-agente revisión de contratos, read-only)
+  'isaak_review_contract',
 ]);
 
 type AnthropicToolDef = {
@@ -161,7 +169,8 @@ export type ToolCategoryFilter =
   | 'google'
   | 'microsoft'
   | 'ledger'
-  | 'sector';
+  | 'sector'
+  | 'legal';
 
 export function buildReadOnlyToolsForContext(
   ctx: IsaakToolContext,
@@ -207,6 +216,12 @@ export function buildReadOnlyToolsForContext(
       if (isAllowed(t.name)) out.push(toAITool(t));
     }
   }
+  // V1.2: Sub-agente Asesor Legal — siempre disponible (incl. Free).
+  if (include('legal')) {
+    for (const t of LEGAL_CHAT_TOOLS) {
+      if (isAllowed(t.name)) out.push(toAITool(t));
+    }
+  }
 
   return out;
 }
@@ -246,7 +261,13 @@ export async function executeIsaakTool(
 
   try {
     let result: unknown;
-    if (isSectorToolName(name)) {
+    if (isLegalToolName(name)) {
+      result = await executeLegalTool(
+        { tenantId: ctx.tenantId, userId: ctx.userId },
+        name as LegalToolName,
+        toolUse.input,
+      );
+    } else if (isSectorToolName(name)) {
       result = await executeSectorTool(ctx.tenantId, name as SectorToolName, toolUse.input);
     } else if (isLedgerToolName(name)) {
       result = await executeLedgerTool(

--- a/apps/isaak/app/sitemap.ts
+++ b/apps/isaak/app/sitemap.ts
@@ -1,6 +1,6 @@
 import type { MetadataRoute } from 'next';
 
-const siteUrl = process.env.NEXT_PUBLIC_ISAAK_SITE_URL || 'https://isaak.verifactu.business';
+const siteUrl = process.env.NEXT_PUBLIC_ISAAK_SITE_URL || 'https://isaak.chat';
 
 const routes = ['/', '/modos/excel', '/conectores', '/asesorias'];
 

--- a/apps/isaak/middleware.ts
+++ b/apps/isaak/middleware.ts
@@ -18,6 +18,8 @@ import { NextRequest, NextResponse } from 'next/server';
 // Hosts permitidos por defecto. Se pueden extender via env
 // ISAAK_ALLOWED_ORIGINS (lista separada por comas).
 const DEFAULT_ALLOWED_HOSTS = [
+  'isaak.chat',
+  'www.isaak.chat',
   'isaak.app',
   'isaak.verifactu.business',
   'app.verifactu.business',


### PR DESCRIPTION
## Fase 1 del plan V1.1 — pulir el workspace logueado

Tres entregables que activan, en UI, capacidades que ya teníamos construidas en backend pero invisibles para el usuario.

### 1.1 · Panel `/ajustes/notificaciones` (4 canales)
- Nueva pantalla unificada con 4 tarjetas: Email · Push web · WhatsApp · Telegram.
- Cada tarjeta: estado vivo (conectado/no) + acciones.
- Push: subscribe via Service Worker + 3 toggles granulares (`alertaFiscal` / `documentoSinConciliar` / `avisoProactivoIsaak`) reutilizando `IsaakPushPreferences`.
- WhatsApp: deep link a `wa.me/...` + estado basado en `WhatsAppThread.consentAt`.
- Telegram: POST a `/api/isaak/telegram/link` para generar deep-link 24h + estado basado en `TelegramChat`.
- Nuevo endpoint `GET /api/isaak/notifications/status` consolida los 4 estados (reutiliza `IsaakPushSubscription`, `IsaakPushPreferences`, `WhatsAppThread`, `TelegramChat`).
- **Sin migración DB** — todo reutilización de modelos existentes.

### 1.2 · Popover del avatar con sidebar colapsado
- Antes: en `/chat/*` el sidebar se auto-colapsa y el botón solo mostraba tooltip.
- Ahora: el popover se abre también en modo colapsado, flotando a la derecha (`left-full ml-2`).
- Nueva entrada "Notificaciones" en `PROFILE_MENU_V1`.

### 1.3 · Hub `/integrations` V1 (4 cards)
- Nuevo `IntegrationsV1Client.tsx`: Holded · Google Workspace · Microsoft 365 · Calendario fiscal.
- Cada card lee status real (`/api/isaak/google/status`, `/api/isaak/microsoft/status`, `/api/holded/status`) y muestra estado, features y CTA al detalle.
- `page.tsx` enruta bajo `ISAAK_V1_LAUNCH`: el catálogo completo de 50+ apps (2.185 líneas) queda intacto para V2+.
- En sidebar V1, "Integración Holded" pasa a "Integraciones" (un único punto de entrada).

### 1.4 · `/microsoft` — ya existía completo (no se toca)

## Test plan
- [ ] `/ajustes/notificaciones` carga las 4 cards con estado correcto
- [ ] Push: "Activar" pide permiso → suscribe → revela los 3 toggles
- [ ] Toggle sub-pref guarda con PATCH (optimistic + spinner)
- [ ] WhatsApp: botón abre `wa.me` con texto pre-rellenado
- [ ] Telegram: botón genera deep-link y abre la app
- [ ] Sidebar colapsado en `/chat/*`: click en avatar abre popover a la derecha
- [ ] `/integrations` con `ISAAK_V1_LAUNCH=true` → 4 cards V1
- [ ] Sin flag → catálogo completo

Typecheck pasa limpio (`tsc --noEmit` exit 0).